### PR TITLE
Split Statement Grammar and Item Grammar Apart

### DIFF
--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Declarations.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Declarations.md
@@ -70,26 +70,35 @@ or a file that contains top-level executable code.
 ```
 Grammar of a top-level declaration
 
-top-level-declaration --> statements-OPT
+top-level-declaration --> items-OPT
 ```
 
 
 ## Code Blocks
 
 A *code block* is used by a variety of declarations and control structures
-to group statements together.
+to group items together.
 It has the following form:
 
 ```
 {
-   <#statements#>
+   <#items#>
 }
 ```
 
 
-The *statements* inside a code block include declarations,
+The *items* inside a code block include declarations,
 expressions, and other kinds of statements and are executed in order
 of their appearance in source code.
+
+```
+Grammar of an item
+
+item --> expression ``;``-OPT
+item --> declaration ``;``-OPT
+item --> statement ``;``-OPT
+items --> item items-OPT
+```
 
 @Comment {
   TR: What exactly are the scope rules for Swift?
@@ -102,7 +111,7 @@ of their appearance in source code.
 ```
 Grammar of a code block
 
-code-block --> ``{`` statements-OPT ``}``
+code-block --> ``{`` items-OPT ``}``
 ```
 
 

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Expressions.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Expressions.md
@@ -1302,7 +1302,7 @@ see <doc:AutomaticReferenceCounting#Resolving-Strong-Reference-Cycles-for-Closur
 ```
 Grammar of a closure expression
 
-closure-expression --> ``{`` attributes-OPT closure-signature-OPT statements-OPT ``}``
+closure-expression --> ``{`` attributes-OPT closure-signature-OPT items-OPT ``}``
 
 closure-signature --> capture-list-OPT closure-parameter-clause ``async``-OPT ``throws``-OPT function-result-OPT ``in``
 closure-signature --> capture-list ``in``

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Statements.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Statements.md
@@ -25,8 +25,6 @@ and is used to separate multiple statements if they appear on the same line.
 ```
 Grammar of a statement
 
-statement --> expression ``;``-OPT
-statement --> declaration ``;``-OPT
 statement --> loop-statement ``;``-OPT
 statement --> branch-statement ``;``-OPT
 statement --> labeled-statement ``;``-OPT
@@ -1216,10 +1214,10 @@ Grammar of a conditional compilation block
 
 conditional-compilation-block --> if-directive-clause elseif-directive-clauses-OPT else-directive-clause-OPT endif-directive
 
-if-directive-clause --> if-directive compilation-condition statements-OPT
+if-directive-clause --> if-directive compilation-condition items-OPT
 elseif-directive-clauses --> elseif-directive-clause elseif-directive-clauses-OPT
-elseif-directive-clause --> elseif-directive compilation-condition statements-OPT
-else-directive-clause --> else-directive statements-OPT
+elseif-directive-clause --> elseif-directive compilation-condition items-OPT
+else-directive-clause --> else-directive items-OPT
 if-directive --> ``#if``
 elseif-directive --> ``#elseif``
 else-directive --> ``#else``


### PR DESCRIPTION
TSPL has referred to declarations and expressions as "statements", while
the Swift Compiler refers to this general class of syntax
as "items". Split the statement and item productions apart.