### PR TITLE
Fixed a hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains a version of *The Swift Programming Language*
 that you can build using Swift-DocC.
 
-The version of *The Swift Programming Language* published on docs.swift.org
+The version of *The Swift Programming Language* published on https://docs.swift.org
 is currently built using a legacy toolchain,
 not from this repository or its content.
 The goal is to replace that version with a version built from this repository,

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains a version of *The Swift Programming Language*
 that you can build using Swift-DocC.
 
-The version of *The Swift Programming Language* published on https://docs.swift.org
+The version of *The Swift Programming Language* published on [docs.swift.org](https://docs.swift.org/swift-book/)
 is currently built using a legacy toolchain,
 not from this repository or its content.
 The goal is to replace that version with a version built from this repository,


### PR DESCRIPTION
Replaced link text in the Readme file with a working link for direct access to the swift docs website.