### PR TITLE
Changed concurrency version back to 5.5 from 5.7.

### DIFF
--- a/Sources/TSPL/TSPL.docc/GuidedTour/Compatibility.md
+++ b/Sources/TSPL/TSPL.docc/GuidedTour/Compatibility.md
@@ -35,11 +35,11 @@ the following changes are available only to code that uses Swift 5.7 or later:
   For example, `UInt64(0xffff_ffff_ffff_ffff)` evaluates to the correct value
   rather than overflowing.
 
-Concurrency requires Swift 5.7 or later,
+Concurrency requires Swift 5.5 or later,
 and a version of the Swift standard library
 that provides the corresponding concurrency types.
 On Apple platforms, set a deployment target
-of at least iOS 15, macOS 12, tvOS 15, or watchOS 8.0.
+of at least iOS 13, macOS 10.15, tvOS 13, or watchOS 6.0.
 
 A target written in Swift 5.7 can depend on
 a target that's written in Swift 4.2 or Swift 4,

--- a/Sources/TSPL/TSPL.docc/GuidedTour/Compatibility.md
+++ b/Sources/TSPL/TSPL.docc/GuidedTour/Compatibility.md
@@ -35,7 +35,7 @@ the following changes are available only to code that uses Swift 5.7 or later:
   For example, `UInt64(0xffff_ffff_ffff_ffff)` evaluates to the correct value
   rather than overflowing.
 
-Concurrency requires Swift 5.5 or later,
+Concurrency requires Swift 5.7 or later,
 and a version of the Swift standard library
 that provides the corresponding concurrency types.
 On Apple platforms, set a deployment target


### PR DESCRIPTION
Updated concurrency deployment target to reflect Xcode 13.2's support for concurrency back to the two earlier versions of the OSes.

Fixes #21.

To keep changes minimal, and keep the paragraph clean and concise, this purposefully doesn't add wording about Xcode 13 and 13.1 only supporting macOS 12 and up, and Xcode 13.2 adding the backwards compatibility, nor any of the history of how that support was added. If someone wants to add wording to that effect that should probably be discussed separately and elsewhere.