### PR TITLE
Add a makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,10 @@
 .SUFFIXES:
 
 .DEFAULT: preview
+.IGNORE: preview
 .PHONY: preview
 preview:
-	-swift package --disable-sandbox preview-documentation --target TSPL
+	swift package --disable-sandbox preview-documentation --target TSPL
 
 .PHONY: archive
 archive: .build/plugins/Swift-DocC/outputs/TSPL.doccarchive

--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,5 @@ preview:
 archive: .build/plugins/Swift-DocC/outputs/TSPL.doccarchive
 
 .build/plugins/Swift-DocC/outputs/TSPL.doccarchive: Sources/TSPL/TSPL.docc/*/*.md
+.build/plugins/Swift-DocC/outputs/TSPL.doccarchive: Sources/TSPL/TSPL.docc/Assets/*.png
 	xcrun swift package plugin generate-documentation --target TSPL --transform-for-static-hosting

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,11 @@
 .IGNORE: preview
 .PHONY: preview
 preview:
-	swift package --disable-sandbox preview-documentation --target TSPL
+	swift package --disable-sandbox preview-documentation
 
 .PHONY: archive
 archive: .build/plugins/Swift-DocC/outputs/TSPL.doccarchive
 
 .build/plugins/Swift-DocC/outputs/TSPL.doccarchive: Sources/TSPL/TSPL.docc/*/*.md
 .build/plugins/Swift-DocC/outputs/TSPL.doccarchive: Sources/TSPL/TSPL.docc/Assets/*.png
-	xcrun swift package plugin generate-documentation --target TSPL --transform-for-static-hosting
+	swift package generate-documentation

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+# This makefile uses only POSIX 'make' features, except for the
+# following widely implemented extensions -- the .PHONY target, which
+# marks targets that don't generate a file whose name is the same as the
+# target, and prerequisites that depend on glob expansion.
+
+.POSIX:
+.SUFFIXES:
+
+.DEFAULT: preview
+.PHONY: preview
+preview:
+	-swift package --disable-sandbox preview-documentation --target TSPL
+
+.PHONY: archive
+archive: .build/plugins/Swift-DocC/outputs/TSPL.doccarchive
+
+.build/plugins/Swift-DocC/outputs/TSPL.doccarchive: Sources/TSPL/TSPL.docc/*/*.md
+	xcrun swift package plugin generate-documentation --target TSPL --transform-for-static-hosting


### PR DESCRIPTION
I found myself using ZSH history search to remember the specific `docc` commands needed to start a preview server and to build a documentation archive (`.doccarchive` bundle).  Another possible approach would be to create a build script, although a build script wouldn't be able to skip rebuilding when source files haven't changed.

Creating this PR a draft, to give us something to discuss.