### PR TITLE
Add templates for PRs and issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -1,0 +1,31 @@
+name: Bug Report
+description: Something is missing or incorrect
+labels: [Bug]
+body:
+- type: markdown
+  attributes:
+    value: |
+      Thank you for contributing to "The Swift Programming Language"!
+
+      Before you submit your issue, please provide the relevant details in the text areas below.
+- type: textarea
+  attributes:
+    label: Location
+    description: |
+      The URL of the content that has a bug.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Description
+    description: |
+      A short description of what's wrong.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Correction
+    description: |
+      What should the documentation say instead?
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -1,6 +1,6 @@
-name: Bug Report
+name: Content Issue
 description: Something is missing or incorrect
-labels: [Bug]
+labels: ["Content Issue"]
 body:
 - type: markdown
   attributes:
@@ -12,7 +12,7 @@ body:
   attributes:
     label: Location
     description: |
-      The URL of the content that has a bug.
+      The URL of the content that has a problem.
   validations:
     required: false
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
@@ -12,7 +12,7 @@ body:
   attributes:
     label: Location
     description: |
-      The URL of the chapter or section where the new content would go
+      The URL of the chapter or section where the new content would go.
   validations:
     required: false
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
@@ -1,0 +1,36 @@
+name: Enhancement
+description: A suggestion for new content
+labels: [Enhancement]
+body:
+- type: markdown
+  attributes:
+    value: |
+      Thank you for contributing to "The Swift Programming Language"!
+
+      Before you submit your issue, please provide the relevant details in the text areas below.
+- type: textarea
+  attributes:
+    label: Location
+    description: |
+      The URL of the chapter or section where the new content would go
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Description
+    description: |
+      A short description of your proposed addition.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Motivation
+    description: A description of the use-case this proposed documentation will serve.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Alternatives Considered
+    description: If you considered alternative approaches, please include them here.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,9 +1,12 @@
 blank_issues_enabled: yes
 
 contact_links:
-  - name: Discussion Forum
-    url: https://forums.swift.org/c/development/swift-docc
-    about: Ask and answer questions about Swift-DocC and authoring documentation
+  - name: Documentation Forums Category
+    url: https://forums.swift.org/c/92
+    about: Ask and answer questions about writing documentation
+  - name: DocC Forums Category
+    url: https://forums.swift.org/c/80
+    about: Ask and answer questions about using Swift-DocC
   - name: Swift-DocC Documentation
     url: https://www.swift.org/documentation/docc/
     about: Learn about how to use Swift-DocC for authoring documentation

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,7 @@ contact_links:
   - name: Documentation Forums Category
     url: https://forums.swift.org/c/92
     about: Ask and answer questions about writing documentation
-  - name: DocC Forums Category
+  - name: Swift-DocC Forums Category
     url: https://forums.swift.org/c/80
     about: Ask and answer questions about using Swift-DocC
   - name: Swift-DocC Documentation

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: yes
+
+contact_links:
+  - name: Discussion Forum
+    url: https://forums.swift.org/c/development/swift-docc
+    about: Ask and answer questions about Swift-DocC and authoring documentation
+  - name: Swift-DocC Documentation
+    url: https://www.swift.org/documentation/docc/
+    about: Learn about how to use Swift-DocC for authoring documentation

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+<!-- What's in this pull request? -->
+Replace this paragraph with your rationale and a brief summary of what changed.
+
+<!-- If this pull request fixes a bug tracked in GitHub issues, provide the link. -->
+Fixes https://github.com/apple/swift-book/issues/####
+
+
+<!--
+Before merging this pull request, you must run the continuous integration (CI) tests.
+When you're ready to start a CI build,
+write the following in a comment on the pull request:
+
+    @swift-ci Please test.
+
+For more information about triggering CI builds via @swift-ci, see:
+
+    https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci
+
+Thank you for your contribution!
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ and [this book’s style guide][tspl-style].
 Use the following steps when creating a new pull request:
 
 1. Create a local fork of this repository with your changes.
-2. Test that your changes build locally by running `swift package plugin generate-documentation --target TSPL --transform-for-static-hosting`.
+2. Test that your changes build locally by running `make preview`.
 3. Create a pull request in this repository.
 
 Within a few days,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,5 +36,4 @@ Use the following steps when creating a new pull request:
 1. Create a local fork of this repository with your changes.
 2. Test that your changes build locally by running `swift package plugin generate-documentation --target TSPL --transform-for-static-hosting`.
 3. Create a pull request in this repository.
-4. Add @amartini51 and @krilnon as reviewers.
-5. Confirm that your changes build in CI by commenting `@swift-ci please test` on your pull request.
+4. Confirm that your changes build in CI by commenting `@swift-ci please test` on your pull request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,4 +36,6 @@ Use the following steps when creating a new pull request:
 1. Create a local fork of this repository with your changes.
 2. Test that your changes build locally by running `swift package plugin generate-documentation --target TSPL --transform-for-static-hosting`.
 3. Create a pull request in this repository.
-4. Confirm that your changes build in CI by commenting `@swift-ci please test` on your pull request.
+
+Within a few days,
+someone will assign reviewers and start a build in CI.


### PR DESCRIPTION
I based these templates of of what Swift and Swift-DocC use.

In the pull request template, I linked to the full docs for the Swift CI bot — but this repository only has some of its features enabled.  (For example, it doesn't support "test and merge".)  I'm not sure it's worth getting into that level of detail there.

Under the issues template, are there other links we should add?

For now, I'm leaving blank issues enabled to cover things that don't fall under either template, like adopting new features added to DocC or blockers for publication to Swift.org from this repository.

In the future, when we publish from this version, I'd expect us to add a specific template for updating the docs after a Swift Evolution proposal is accepted.

Instead of just reviewing the YAML version of in the issues template, I've temporarily turned on GitHub Issues in my fork, so you can preview the templates before we merge:

https://github.com/amartini51/swift-book/issues/new/choose