### PR TITLE
Include example of defer lexical scoping

### DIFF
--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Statements.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Statements.md
@@ -820,7 +820,7 @@ to perform manual resource management such as closing file descriptors,
 and to perform actions that need to happen even if an error is thrown.
 
 The *statements* in the `defer` statement
-are executed at the end of the scope enclosing the `defer`.
+are executed at the end of the scope that encloses the `defer` statement.
 
 ```swift
 func f(x: Int) {
@@ -861,7 +861,8 @@ f(x: 5)
   ```
 }
 
-The `defer` in the `if` statement
+In the code above,
+the `defer` in the `if` statement
 executes before the `defer` declared in the function `f`
 because the scope of the `if` statement ends
 before the scope of the function.

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Statements.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Statements.md
@@ -819,6 +819,52 @@ This means that a `defer` statement can be used, for example,
 to perform manual resource management such as closing file descriptors,
 and to perform actions that need to happen even if an error is thrown.
 
+The *statements* in the `defer` statement are executed at the end of the scope
+enclosing the `defer`.
+
+```swift
+func f(x: Int) {
+  defer { print("First defer") }
+
+  if x < 10 {
+    defer { print("Second defer") }
+    print("End of if")
+  }
+
+  print("End of function")
+}
+f(x: 5)
+// Prints "End of if"
+// Prints "Second defer"
+// Prints "End of function"
+// Prints "First defer"
+```
+
+
+@Comment {
+  ```swifttest
+  -> func f(x: Int) {
+    defer { print("First defer") }
+
+    if x < 10 {
+      defer { print("Second defer") }
+      print("End of if")
+    }
+
+    print("End of function")
+  }
+  f(x: 5)
+  <- End of if
+  <- Second defer
+  <- End of function
+  <- First defer
+  ```
+}
+
+The `defer` in the `if` statement executes before the `defer` declared in the
+function `f` because the scope of the `if` statement ends before the scope of
+the function.
+
 If multiple `defer` statements appear in the same scope,
 the order they appear is the reverse of the order they're executed.
 Executing the last `defer` statement in a given scope first

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Statements.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Statements.md
@@ -819,8 +819,8 @@ This means that a `defer` statement can be used, for example,
 to perform manual resource management such as closing file descriptors,
 and to perform actions that need to happen even if an error is thrown.
 
-The *statements* in the `defer` statement are executed at the end of the scope
-enclosing the `defer`.
+The *statements* in the `defer` statement
+are executed at the end of the scope enclosing the `defer`.
 
 ```swift
 func f(x: Int) {
@@ -861,9 +861,10 @@ f(x: 5)
   ```
 }
 
-The `defer` in the `if` statement executes before the `defer` declared in the
-function `f` because the scope of the `if` statement ends before the scope of
-the function.
+The `defer` in the `if` statement
+executes before the `defer` declared in the function `f`
+because the scope of the `if` statement ends
+before the scope of the function.
 
 If multiple `defer` statements appear in the same scope,
 the order they appear is the reverse of the order they're executed.


### PR DESCRIPTION
This patch adds an example of how the defer statement is lexically scoped and will execute at the end of the scope, not the end of a function.