### PR TITLE
Omit trailing "dot zero" in version number

### DIFF
--- a/Sources/TSPL/TSPL.docc/GuidedTour/Compatibility.md
+++ b/Sources/TSPL/TSPL.docc/GuidedTour/Compatibility.md
@@ -39,7 +39,7 @@ Concurrency requires Swift 5.7 or later,
 and a version of the Swift standard library
 that provides the corresponding concurrency types.
 On Apple platforms, set a deployment target
-of at least iOS 13, macOS 10.15, tvOS 13, or watchOS 6.0.
+of at least iOS 13, macOS 10.15, tvOS 13, or watchOS 6.
 
 A target written in Swift 5.7 can depend on
 a target that's written in Swift 4.2 or Swift 4,


### PR DESCRIPTION
Per Apple Style Guide [entry](https://support.apple.com/guide/applestyleguide/v-apsg51b3c806/web) for "version number":

> When referring to a major release number (such as macOS 10.14 or iOS 12), omit any trailing .0 unless it’s needed for clarity.
