### PR TITLE
Remove claim on possible optional bindings in repeat-while conditions

### DIFF
--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Statements.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Statements.md
@@ -174,8 +174,6 @@ the *statements* in a `repeat`-`while` statement are executed at least once.
 
 The value of the *condition*
 must be of type `Bool` or a type bridged to `Bool`.
-The condition can also be an optional binding declaration,
-as discussed in <doc:TheBasics#Optional-Binding>.
 
 ```
 Grammar of a repeat-while statement


### PR DESCRIPTION
The claim is immediatly disproved on the grammer rule description below that states that the `while` condition is an expression. An expression in turn does not comprise an optional binding. The grammar rule seems to be correct since it matches with the bahavior of the Swift compiler and the SwiftSyntax library.
