### PR TITLE
Mark "syntax outline" code listings as Swift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .swiftpm
 /.build
 /Package.resolved
+.docc-build

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Closures.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Closures.md
@@ -134,7 +134,7 @@ using closure expression syntax.
 
 Closure expression syntax has the following general form:
 
-```
+```swift
 { (<#parameters#>) -> <#return type#> in
    <#statements#>
 }

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/CollectionTypes.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/CollectionTypes.md
@@ -192,7 +192,7 @@ which is a shorthand way to write one or more values as an array collection.
 An array literal is written as a list of values, separated by commas,
 surrounded by a pair of square brackets:
 
-```
+```swift
 [<#value 1#>, <#value 2#>, <#value 3#>]
 ```
 
@@ -1142,7 +1142,7 @@ the key and value in each key-value pair are separated by a colon.
 The key-value pairs are written as a list, separated by commas,
 surrounded by a pair of square brackets:
 
-```
+```swift
 [<#key 1#>: <#value 1#>, <#key 2#>: <#value 2#>, <#key 3#>: <#value 3#>]
 ```
 

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/ControlFlow.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/ControlFlow.md
@@ -306,7 +306,7 @@ a set of statements is repeated until the condition becomes `false`.
 
 Here's the general form of a `while` loop:
 
-```
+```swift
 while <#condition#> {
    <#statements#>
 }
@@ -508,7 +508,7 @@ It then continues to repeat the loop until the condition is `false`.
 
 Here's the general form of a `repeat`-`while` loop:
 
-```
+```swift
 repeat {
    <#statements#>
 } while <#condition#>
@@ -794,7 +794,7 @@ for responding to multiple potential states.
 In its simplest form, a `switch` statement compares a value against
 one or more values of the same type.
 
-```
+```swift
 switch <#some value to consider#> {
    case <#value 1#>:
       <#respond to value 1#>
@@ -1602,7 +1602,7 @@ a label on the same line as the statement's introducer keyword, followed by a co
 Here's an example of this syntax for a `while` loop,
 although the principle is the same for all loops and `switch` statements:
 
-```
+```swift
 <#label name#>: while <#condition#> {
    <#statements#>
 }
@@ -1922,7 +1922,7 @@ for the full list, see <doc:Attributes#Declaration-Attributes>.
 In addition to specifying major version numbers like iOS 8 or macOS 10.10,
 you can specify minor versions numbers like iOS 11.2.6 and macOS 10.13.3.
 
-```
+```swift
 if #available(<#platform name#> <#version#>, <#...#>, *) {
     <#statements to execute if the APIs are available#>
 } else {

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/ErrorHandling.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/ErrorHandling.md
@@ -395,7 +395,7 @@ to determine which one of them can handle the error.
 
 Here is the general form of a `do`-`catch` statement:
 
-```
+```swift
 do {
     try <#expression#>
     <#statements#>

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Initialization.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Initialization.md
@@ -922,7 +922,7 @@ will save time or make initialization of the class clearer in intent.
 Designated initializers for classes are written in the same way as
 simple initializers for value types:
 
-```
+```swift
 init(<#parameters#>) {
    <#statements#>
 }
@@ -933,7 +933,7 @@ Convenience initializers are written in the same style,
 but with the `convenience` modifier placed before the `init` keyword,
 separated by a space:
 
-```
+```swift
 convenience init(<#parameters#>) {
    <#statements#>
 }

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/TheBasics.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/TheBasics.md
@@ -1411,7 +1411,7 @@ as part of a single action.
 
 Write an optional binding for an `if` statement as follows:
 
-```
+```swift
 if let <#constantName#> = <#someOptional#> {
    <#statements#>
 }

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Attributes.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Attributes.md
@@ -13,7 +13,7 @@ the compiler shouldn't generate a warning if the return value is unused.
 You specify an attribute by writing the `@` symbol followed by the attribute's name
 and any arguments that the attribute accepts:
 
-```
+```swift
 @<#attribute name#>
 @<#attribute name#>(<#attribute arguments#>)
 ```
@@ -77,7 +77,7 @@ including important milestones.
   of the specified platform or language in which the declaration was introduced.
   It has the following form:
   
-  ```
+  ```swift
   introduced: <#version number#>
   ```
   The *version number* consists of one to three positive integers,
@@ -86,7 +86,7 @@ including important milestones.
   of the specified platform or language in which the declaration was deprecated.
   It has the following form:
   
-  ```
+  ```swift
   deprecated: <#version number#>
   ```
   The optional *version number* consists of one to three positive integers,
@@ -100,7 +100,7 @@ including important milestones.
   it's removed from the specified platform or language and can no longer be used.
   It has the following form:
   
-  ```
+  ```swift
   obsoleted: <#version number#>
   ```
   The *version number* consists of one to three positive integers, separated by periods.
@@ -108,7 +108,7 @@ including important milestones.
   when emitting a warning or error about the use of a deprecated or obsoleted declaration.
   It has the following form:
   
-  ```
+  ```swift
   message: <#message#>
   ```
   The *message* consists of a string literal.
@@ -118,7 +118,7 @@ including important milestones.
   when emitting an error about the use of a renamed declaration.
   It has the following form:
   
-  ```
+  ```swift
   renamed: <#new name#>
   ```
   The *new name* consists of a string literal.You can apply the `available` attribute
@@ -198,7 +198,7 @@ If an `available` attribute only specifies an `introduced` argument
 in addition to a platform or language name argument,
 you can use the following shorthand syntax instead:
 
-```
+```swift
 @available(<#platform name#> <#version number#>, *)
 @available(swift <#version number#>)
 ```

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Declarations.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Declarations.md
@@ -80,7 +80,7 @@ A *code block* is used by a variety of declarations and control structures
 to group statements together.
 It has the following form:
 
-```
+```swift
 {
    <#statements#>
 }
@@ -113,7 +113,7 @@ that are declared outside the current file.
 The basic form imports the entire module;
 it consists of the `import` keyword followed by a module name:
 
-```
+```swift
 import <#module#>
 ```
 
@@ -126,7 +126,7 @@ only the imported symbol
 (and not the module that declares it)
 is made available in the current scope.
 
-```
+```swift
 import <#import kind#> <#module#>.<#symbol name#>
 import <#module#>.<#submodule#>
 ```
@@ -151,7 +151,7 @@ import-path --> identifier | identifier ``.`` import-path
 A *constant declaration* introduces a constant named value into your program.
 Constant declarations are declared using the `let` keyword and have the following form:
 
-```
+```swift
 let <#constant name#>: <#type#> = <#expression#>
 ```
 
@@ -280,7 +280,7 @@ with the `override` declaration modifier, as described in <doc:Inheritance#Overr
 
 The following form declares a stored variable or stored variable property:
 
-```
+```swift
 var <#variable name#>: <#type#> = <#expression#>
 ```
 
@@ -309,7 +309,7 @@ is stored in memory.
 
 The following form declares a computed variable or computed property:
 
-```
+```swift
 var <#variable name#>: <#type#> {
    get {
       <#statements#>
@@ -353,7 +353,7 @@ see <doc:Properties#Computed-Properties>.
 You can also declare a stored variable or property with `willSet` and `didSet` observers.
 A stored variable or property declared with observers has the following form:
 
-```
+```swift
 var <#variable name#>: <#type#> = <#expression#> {
    willSet(<#setter name#>) {
       <#statements#>
@@ -585,7 +585,7 @@ didSet-clause --> attributes-OPT ``didSet`` setter-name-OPT code-block
 A *type alias declaration* introduces a named alias of an existing type into your program.
 Type alias declarations are declared using the `typealias` keyword and have the following form:
 
-```
+```swift
 typealias <#name#> = <#existing type#>
 ```
 
@@ -738,7 +738,7 @@ A function declared in the context of class, structure, enumeration, or protocol
 is referred to as a *method*.
 Function declarations are declared using the `func` keyword and have the following form:
 
-```
+```swift
 func <#function name#>(<#parameters#>) -> <#return type#> {
    <#statements#>
 }
@@ -748,7 +748,7 @@ func <#function name#>(<#parameters#>) -> <#return type#> {
 If the function has a return type of `Void`,
 the return type can be omitted as follows:
 
-```
+```swift
 func <#function name#>(<#parameters#>) {
    <#statements#>
 }
@@ -803,7 +803,7 @@ The order of arguments in a function call
 must match the order of parameters in the function's declaration.
 The simplest entry in a parameter list has the following form:
 
-```
+```swift
 <#parameter name#>: <#parameter type#>
 ```
 
@@ -841,7 +841,7 @@ f(x: 1, y: 2) // both x and y are labeled
 You can override the default behavior for argument labels
 with one of the following forms:
 
-```
+```swift
 <#argument label#> <#parameter name#>: <#parameter type#>
 _ <#parameter name#>: <#parameter type#>
 ```
@@ -1030,7 +1030,7 @@ take a variable number of values,
 and provide default values
 using the following forms:
 
-```
+```swift
 _ : <#parameter type#>
 <#parameter name#>: <#parameter type#>...
 <#parameter name#>: <#parameter type#> = <#default argument value#>
@@ -1282,7 +1282,7 @@ These functions and methods are known as *throwing functions*
 and *throwing methods*.
 They have the following form:
 
-```
+```swift
 func <#function name#>(<#parameters#>) throws -> <#return type#> {
    <#statements#>
 }
@@ -1415,7 +1415,7 @@ These functions and methods are known as *asynchronous functions*
 and *asynchronous methods*.
 They have the following form:
 
-```
+```swift
 func <#function name#>(<#parameters#>) async -> <#return type#> {
    <#statements#>
 }
@@ -1547,7 +1547,7 @@ as discussed in <doc:Declarations#Extension-Declaration>.
 The following form declares an enumeration type that contains
 enumeration cases of any type:
 
-```
+```swift
 enum <#enumeration name#>: <#adopted protocols#> {
     case <#enumeration case 1#>
     case <#enumeration case 2#>(<#associated value types#>)
@@ -1697,7 +1697,7 @@ it can't contain any cases that are also marked with the `indirect` modifier.
 The following form declares an enumeration type that contains
 enumeration cases of the same basic type:
 
-```
+```swift
 enum <#enumeration name#>: <#raw-value type#>, <#adopted protocols#> {
     case <#enumeration case 1#> = <#raw value 1#>
     case <#enumeration case 2#> = <#raw value 2#>
@@ -1888,7 +1888,7 @@ raw-value-literal --> numeric-literal | static-string-literal | boolean-literal
 A *structure declaration* introduces a named structure type into your program.
 Structure declarations are declared using the `struct` keyword and have the following form:
 
-```
+```swift
 struct <#structure name#>: <#adopted protocols#> {
    <#declarations#>
 }
@@ -1950,7 +1950,7 @@ struct-member --> declaration | compiler-control-statement
 A *class declaration* introduces a named class type into your program.
 Class declarations are declared using the `class` keyword and have the following form:
 
-```
+```swift
 class <#class name#>: <#superclass#>, <#adopted protocols#> {
    <#declarations#>
 }
@@ -2045,7 +2045,7 @@ class-member --> declaration | compiler-control-statement
 An *actor declaration* introduces a named actor type into your program.
 Actor declarations are declared using the `actor` keyword and have the following form:
 
-```
+```swift
 actor <#actor name#>: <#adopted protocols#> {
     <#declarations#>
 }
@@ -2137,7 +2137,7 @@ A *protocol declaration* introduces a named protocol type into your program.
 Protocol declarations are declared at global scope
 using the `protocol` keyword and have the following form:
 
-```
+```swift
 protocol <#protocol name#>: <#inherited protocols#> {
    <#protocol member declarations#>
 }
@@ -2300,7 +2300,7 @@ in the body of the protocol declaration.
 Protocol property declarations have a special form of a variable
 declaration:
 
-```
+```swift
 var <#property name#>: <#type#> { get set }
 ```
 
@@ -2441,7 +2441,7 @@ Protocols declare that conforming types must implement a subscript
 by including a protocol subscript declaration in the body of the protocol declaration.
 Protocol subscript declarations have a special form of a subscript declaration:
 
-```
+```swift
 subscript (<#parameters#>) -> <#return type#> { get set }
 ```
 
@@ -2624,7 +2624,7 @@ as described in <doc:Initialization>.
 The following form declares initializers for structures, enumerations,
 and designated initializers of classes:
 
-```
+```swift
 init(<#parameters#>) {
    <#statements#>
 }
@@ -2648,7 +2648,7 @@ to delegate part or all of the initialization process.
 To declare convenience initializers for a class,
 mark the initializer declaration with the `convenience` declaration modifier.
 
-```
+```swift
 convenience init(<#parameters#>) {
    <#statements#>
 }
@@ -2804,7 +2804,7 @@ initializer-body --> code-block
 A *deinitializer declaration* declares a deinitializer for a class type.
 Deinitializers take no parameters and have the following form:
 
-```
+```swift
 deinit {
    <#statements#>
 }
@@ -2841,7 +2841,7 @@ the behavior of existing types.
 Extension declarations are declared using the `extension` keyword
 and have the following form:
 
-```
+```swift
 extension <#type name#> where <#requirements#> {
    <#declarations#>
 }
@@ -2882,7 +2882,7 @@ can't be overridden in an extension of that type.
 Extension declarations can add protocol conformance to an existing
 class, structure, or enumeration type by specifying *adopted protocols*:
 
-```
+```swift
 extension <#type name#>: <#adopted protocols#> where <#requirements#> {
    <#declarations#>
 }
@@ -3346,7 +3346,7 @@ for accessing the elements in a collection, list, or sequence.
 Subscript declarations are declared using the `subscript` keyword
 and have the following form:
 
-```
+```swift
 subscript (<#parameters#>) -> <#return type#> {
    get {
       <#statements#>
@@ -3459,7 +3459,7 @@ defined in <doc:LexicalStructure#Operators>.
 
 The following form declares a new infix operator:
 
-```
+```swift
 infix operator <#operator name#>: <#precedence group#>
 ```
 
@@ -3475,7 +3475,7 @@ For more information, see <doc:Declarations#Precedence-Group-Declaration>.
 
 The following form declares a new prefix operator:
 
-```
+```swift
 prefix operator <#operator name#>
 ```
 
@@ -3488,7 +3488,7 @@ Prefix operators are nonassociative.
 
 The following form declares a new postfix operator:
 
-```
+```swift
 postfix operator <#operator name#>
 ```
 
@@ -3533,7 +3533,7 @@ binds to its operands, in the absence of grouping parentheses.
 
 A precedence group declaration has the following form:
 
-```
+```swift
 precedencegroup <#precedence group name#> {
     higherThan: <#lower group names#>
     lowerThan: <#higher group names#>

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Expressions.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Expressions.md
@@ -53,7 +53,7 @@ An *in-out expression* marks a variable
 that's being passed
 as an in-out argument to a function call expression.
 
-```
+```swift
 &<#expression#>
 ```
 
@@ -79,7 +79,7 @@ A *try expression* consists of the `try` operator
 followed by an expression that can throw an error.
 It has the following form:
 
-```
+```swift
 try <#expression#>
 ```
 
@@ -90,7 +90,7 @@ An *optional-try expression* consists of the `try?` operator
 followed by an expression that can throw an error.
 It has the following form:
 
-```
+```swift
 try? <#expression#>
 ```
 
@@ -104,7 +104,7 @@ A *forced-try expression* consists of the `try!` operator
 followed by an expression that can throw an error.
 It has the following form:
 
-```
+```swift
 try! <#expression#>
 ```
 
@@ -205,7 +205,7 @@ An *await expression* consists of the `await` operator
 followed by an expression that uses the result of an asynchronous operation.
 It has the following form:
 
-```
+```swift
 await <#expression#>
 ```
 
@@ -316,7 +316,7 @@ an infix binary operator with the expression that it takes
 as its left- and right-hand arguments.
 It has the following form:
 
-```
+```swift
 <#left-hand argument#> <#operator#> <#right-hand argument#>
 ```
 
@@ -364,7 +364,7 @@ The *assignment operator* sets a new value
 for a given expression.
 It has the following form:
 
-```
+```swift
 <#expression#> = <#value#>
 ```
 
@@ -411,7 +411,7 @@ The *ternary conditional operator* evaluates to one of two given values
 based on the value of a condition.
 It has the following form:
 
-```
+```swift
 <#condition#> ? <#expression used if true#> : <#expression used if false#>
 ```
 
@@ -443,7 +443,7 @@ and the `as!` operator.
 
 They have the following form:
 
-```
+```swift
 <#expression#> is <#type#>
 <#expression#> as <#type#>
 <#expression#> as? <#type#>
@@ -719,7 +719,7 @@ An *array literal* is
 an ordered collection of values.
 It has the following form:
 
-```
+```swift
 [<#value 1#>, <#value 2#>, <#...#>]
 ```
 
@@ -749,7 +749,7 @@ A *dictionary literal* is
 an unordered collection of key-value pairs.
 It has the following form:
 
-```
+```swift
 [<#key 1#>: <#value 1#>, <#key 2#>: <#value 2#>, <#...#>]
 ```
 
@@ -818,7 +818,7 @@ The `self` expression is an explicit reference to the current type
 or instance of the type in which it occurs.
 It has the following forms:
 
-```
+```swift
 self
 self.<#member name#>
 self[<#subscript index#>]
@@ -916,7 +916,7 @@ A *superclass expression* lets a class
 interact with its superclass.
 It has one of the following forms:
 
-```
+```swift
 super.<#member name#>
 super[<#subscript index#>]
 super.init(<#initializer arguments#>)
@@ -952,7 +952,7 @@ a closure contains statements,
 and it captures constants and variables from its enclosing scope.
 It has the following form:
 
-```
+```swift
 { (<#parameters#>) -> <#return type#> in
    <#statements#>
 }
@@ -966,7 +966,7 @@ as described in <doc:Declarations#Function-Declaration>.
 Writing `throws` or `async` in a closure expression
 explicitly marks a closure as throwing or asynchronous.
 
-```
+```swift
 { (<#parameters#>) async throws -> <#return type#> in
    <#statements#>
 }
@@ -1331,7 +1331,7 @@ in a context where type inference
 can determine the implied type.
 It has the following form:
 
-```
+```swift
 .<#member name#>
 ```
 
@@ -1503,7 +1503,7 @@ Each expression can have an optional identifier before it,
 separated by a colon (`:`).
 It has the following form:
 
-```
+```swift
 (<#identifier 1#>: <#expression 1#>, <#identifier 2#>: <#expression 2#>, <#...#>)
 ```
 
@@ -1590,7 +1590,7 @@ in dynamic programming tasks,
 such as key-value observing.
 They have the following form:
 
-```
+```swift
 \<#type name#>.<#path#>
 ```
 
@@ -2043,7 +2043,7 @@ used to refer to a method or to a property's
 getter or setter in Objective-C.
 It has the following form:
 
-```
+```swift
 #selector(<#method name#>)
 #selector(getter: <#property name#>)
 #selector(setter: <#property name#>)
@@ -2165,7 +2165,7 @@ used to refer to a property in Objective-C,
 for use in key-value coding and key-value observing APIs.
 It has the following form:
 
-```
+```swift
 #keyPath(<#property name#>)
 ```
 
@@ -2303,7 +2303,7 @@ A *function call expression* consists of a function name
 followed by a comma-separated list of the function's arguments in parentheses.
 Function call expressions have the following form:
 
-```
+```swift
 <#function name#>(<#argument value 1#>, <#argument value 2#>)
 ```
 
@@ -2315,7 +2315,7 @@ the function call must include names before its argument values,
 separated by a colon (`:`).
 This kind of function call expression has the following form:
 
-```
+```swift
 <#function name#>(<#argument name 1#>: <#argument value 1#>, <#argument name 2#>: <#argument value 2#>)
 ```
 
@@ -2678,7 +2678,7 @@ An *initializer expression* provides access
 to a type's initializer.
 It has the following form:
 
-```
+```swift
 <#expression#>.init(<#initializer arguments#>)
 ```
 
@@ -2784,7 +2784,7 @@ to the members of a named type, a tuple, or a module.
 It consists of a period (`.`) between the item
 and the identifier of its member.
 
-```
+```swift
 <#expression#>.<#member name#>
 ```
 
@@ -3075,7 +3075,7 @@ argument-name --> identifier ``:``
 A postfix `self` expression consists of an expression or the name of a type,
 immediately followed by `.self`. It has the following forms:
 
-```
+```swift
 <#expression#>.self
 <#type#>.self
 ```
@@ -3103,7 +3103,7 @@ using the getter and setter
 of the corresponding subscript declaration.
 It has the following form:
 
-```
+```swift
 <#expression#>[<#index expressions#>]
 ```
 
@@ -3160,7 +3160,7 @@ A *forced-value expression* unwraps an optional value
 that you are certain isn't `nil`.
 It has the following form:
 
-```
+```swift
 <#expression#>!
 ```
 
@@ -3215,7 +3215,7 @@ An *optional-chaining expression* provides a simplified syntax
 for using optional values in postfix expressions.
 It has the following form:
 
-```
+```swift
 <#expression#>?
 ```
 

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/GenericParametersAndArguments.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/GenericParametersAndArguments.md
@@ -23,7 +23,7 @@ type or function, along with any associated constraints and requirements on thos
 A generic parameter clause is enclosed in angle brackets (<>)
 and has the following form:
 
-```
+```swift
 <<#generic parameter list#>>
 ```
 
@@ -31,7 +31,7 @@ and has the following form:
 The *generic parameter list* is a comma-separated list of generic parameters,
 each of which has the following form:
 
-```
+```swift
 <#type parameter#>: <#constraint#>
 ```
 
@@ -111,7 +111,7 @@ of a type or function's body.
 A generic `where` clause consists of the `where` keyword,
 followed by a comma-separated list of one or more *requirements*.
 
-```
+```swift
 where <#requirements#>
 ```
 
@@ -242,7 +242,7 @@ type.
 A generic argument clause is enclosed in angle brackets (<>)
 and has the following form:
 
-```
+```swift
 <<#generic argument list#>>
 ```
 

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/LexicalStructure.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/LexicalStructure.md
@@ -622,7 +622,7 @@ A string literal is a sequence of characters surrounded by quotation marks.
 A single-line string literal is surrounded by double quotation marks
 and has the following form:
 
-```
+```swift
 "<#characters#>"
 ```
 
@@ -635,7 +635,7 @@ a carriage return, or a line feed.
 A multiline string literal is surrounded by three double quotation marks
 and has the following form:
 
-```
+```swift
 """
 <#characters#>
 """
@@ -755,7 +755,7 @@ A string delimited by extended delimiters is a sequence of characters
 surrounded by quotation marks and a balanced set of one or more number signs (`#`).
 A string delimited by extended delimiters has the following forms:
 
-```
+```swift
 #"<#characters#>"#
 
 #"""
@@ -928,7 +928,7 @@ escaped-newline -->  escape-sequence inline-spaces-OPT line-break
 A regular expression literal is a sequence of characters
 surrounded by slashes (`/`) with the following form:
 
-```
+```swift
 /<#regular expression#>/
 ```
 
@@ -980,7 +980,7 @@ and a balanced set of one or more number signs (`#`).
 A regular expression literal
 delimited by extended delimiters has the following forms:
 
-```
+```swift
 #/<#regular expression#>/#
 
 #/

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Patterns.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Patterns.md
@@ -406,7 +406,7 @@ There are two type-casting patterns, the `is` pattern and the `as` pattern.
 The `is` pattern appears only in `switch` statement
 case labels. The `is` and `as` patterns have the following form:
 
-```
+```swift
 is <#type#>
 <#pattern#> as <#type#>
 ```

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Statements.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Statements.md
@@ -1429,7 +1429,7 @@ based on specified platforms arguments.
 
 An availability condition has the following form:
 
-```
+```swift
 if #available(<#platform name#> <#version#>, <#...#>, *) {
     <#statements to execute if the APIs are available#>
 } else {
@@ -1455,7 +1455,7 @@ logical operators like `&&` and `||`.
 Instead of using `!` to negate an availability condition,
 use an unavailability condition, which has the following form:
 
-```
+```swift
 if #unavailable(<#platform name#> <#version#>, <#...#>) {
     <#fallback statements to execute if the APIs are unavailable#>
 } else {

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Statements.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Statements.md
@@ -80,7 +80,7 @@ that conforms to the
 
 A `for`-`in` statement has the following form:
 
-```
+```swift
 for <#item#> in <#collection#> {
    <#statements#>
 }
@@ -114,7 +114,7 @@ as long as a condition remains true.
 
 A `while` statement has the following form:
 
-```
+```swift
 while <#condition#> {
    <#statements#>
 }
@@ -155,7 +155,7 @@ as long as a condition remains true.
 
 A `repeat`-`while` statement has the following form:
 
-```
+```swift
 repeat {
    <#statements#>
 } while <#condition#>
@@ -214,7 +214,7 @@ In each form, the opening and closing braces are required.
 The first form allows code to be executed only when a condition is true
 and has the following form:
 
-```
+```swift
 if <#condition#> {
    <#statements#>
 }
@@ -227,7 +227,7 @@ and is used for executing one part of code when the condition is true
 and another part of code when the same condition is false.
 When a single else clause is present, an `if` statement has the following form:
 
-```
+```swift
 if <#condition#> {
    <#statements to execute if condition is true#>
 } else {
@@ -240,7 +240,7 @@ The else clause of an `if` statement can contain another `if` statement
 to test more than one condition.
 An `if` statement chained together in this way has the following form:
 
-```
+```swift
 if <#condition 1#> {
    <#statements to execute if condition 1 is true#>
 } else if <#condition 2#> {
@@ -271,7 +271,7 @@ if one or more conditions aren't met.
 
 A `guard` statement has the following form:
 
-```
+```swift
 guard <#condition#> else {
    <#statements#>
 }
@@ -315,7 +315,7 @@ depending on the value of a control expression.
 
 A `switch` statement has the following form:
 
-```
+```swift
 switch <#control expression#> {
    case <#pattern 1#>:
       <#statements#>
@@ -627,7 +627,7 @@ A `break` statement can consist of only the `break` keyword,
 or it can consist of the `break` keyword followed by the name of a statement label,
 as shown below.
 
-```
+```swift
 break
 break <#label name#>
 ```
@@ -664,7 +664,7 @@ A `continue` statement can consist of only the `continue` keyword,
 or it can consist of the `continue` keyword followed by the name of a statement label,
 as shown below.
 
-```
+```swift
 continue
 continue <#label name#>
 ```
@@ -732,7 +732,7 @@ Program execution continues at the point immediately following the function or m
 A `return` statement can consist of only the `return` keyword,
 or it can consist of the `return` keyword followed by an expression, as shown below.
 
-```
+```swift
 return
 return <#expression#>
 ```
@@ -777,7 +777,7 @@ of a `do` statement.
 A `throw` statement consists of the `throw` keyword
 followed by an expression, as shown below.
 
-```
+```swift
 throw <#expression#>
 ```
 
@@ -804,7 +804,7 @@ that the `defer` statement appears in.
 
 A `defer` statement has the following form:
 
-```
+```swift
 defer {
     <#statements#>
 }
@@ -922,7 +922,7 @@ and doesn't incur a performance cost at runtime.
 
 A `do` statement has the following form:
 
-```
+```swift
 do {
     try <#expression#>
     <#statements#>
@@ -1014,7 +1014,7 @@ Every conditional compilation block begins with the `#if` compilation directive
 and ends with the `#endif` compilation directive.
 A simple conditional compilation block has the following form:
 
-```
+```swift
 #if <#compilation condition#>
     <#statements#>
 #endif
@@ -1232,7 +1232,7 @@ You can also add a final additional branch using an `#else` clause.
 Conditional compilation blocks that contain multiple branches
 have the following form:
 
-```
+```swift
 #if <#compilation condition 1#>
     <#statements to compile if compilation condition 1 is true#>
 #elseif <#compilation condition 2#>
@@ -1317,7 +1317,7 @@ used by Swift for diagnostic and debugging purposes.
 
 A line control statement has the following forms:
 
-```
+```swift
 #sourceLocation(file: <#file path#>, line: <#line number#>)
 #sourceLocation()
 ```
@@ -1354,7 +1354,7 @@ A compile-time diagnostic statement causes the compiler
 to emit an error or a warning during compilation.
 A compile-time diagnostic statement has the following forms:
 
-```
+```swift
 #error("<#error message#>")
 #warning("<#warning message#>")
 ```

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Types.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Types.md
@@ -202,7 +202,7 @@ element-name --> identifier
 A *function type* represents the type of a function, method, or closure
 and consists of a parameter and return type separated by an arrow (`->`):
 
-```
+```swift
 (<#parameter type#>) -> <#return type#>
 ```
 
@@ -528,7 +528,7 @@ argument-label --> identifier
 The Swift language provides the following syntactic sugar for the Swift standard library
 `Array<Element>` type:
 
-```
+```swift
 [<#type#>]
 ```
 
@@ -597,7 +597,7 @@ array-type --> ``[`` type ``]``
 The Swift language provides the following syntactic sugar for the Swift standard library
 `Dictionary<Key, Value>` type:
 
-```
+```swift
 [<#key type#>: <#value type#>]
 ```
 
@@ -813,7 +813,7 @@ and in generic `where` clauses.
 
 Protocol composition types have the following form:
 
-```
+```swift
 <#Protocol 1#> & <#Protocol 2#>
 ```
 
@@ -884,7 +884,7 @@ such as the element type of an array or the wrapped type of an optional.
 
 Opaque types have the following form:
 
-```
+```swift
 some <#constraint#>
 ```
 


### PR DESCRIPTION
- Update code snippet to Swift
Fix some Swift code snippet does not use `swift` metadata

> Actually there are other cases for this situation. Since they are incomplete Swift Code, should we mark the `swift` metadata to add syntax highlighting support?

Before (Without Swift Syntax highlighting)
<img width="798" alt="image" src="https://user-images.githubusercontent.com/43724855/194920960-c683c186-406a-4e93-a2da-2e7f61159088.png">

After
<img width="809" alt="image" src="https://user-images.githubusercontent.com/43724855/194920850-75b4fc9d-eeb0-4822-9718-12465370cec2.png">


- Update gitignore
Ignore the .docc-build folder after `docc preview TSPL.docc`