### PR TITLE
Fix swift syntax in concurrency page

### DIFF
--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Concurrency.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Concurrency.md
@@ -273,8 +273,8 @@ you can refactor that code into a synchronous function:
 
 ```swift
 func move(_ photoName: String, from source: String, to destination: String) {
-    add(photoName, to: destination)
-    remove(photoName, from: source)
+    add(photoName, toGallery: destination)
+    remove(photoName, fromGallery: source)
 }
 // ...
 let firstPhoto = await listPhotos(inGallery: "Summer Vacation")[0]

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Concurrency.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Concurrency.md
@@ -255,7 +255,7 @@ Code in between possible suspension points runs sequentially,
 without the possibility of interruption from other concurrent code.
 For example, the code below moves a picture from one gallery to another.
 
-```
+```swift
 let firstPhoto = await listPhotos(inGallery: "Summer Vacation")[0]
 add(firstPhoto, toGallery: "Road Trip")
 // At this point, firstPhoto is temporarily in both galleries.
@@ -271,7 +271,7 @@ To make it even clearer that this chunk of code
 must not have `await` added to it in the future,
 you can refactor that code into a synchronous function:
 
-```
+```swift
 func move(_ photoName: String, from source: String, to destination: String) {
     add(photoName, to: destination)
     remove(photoName, from: source)

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Concurrency.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Concurrency.md
@@ -257,9 +257,9 @@ For example, the code below moves a picture from one gallery to another.
 
 ```
 let firstPhoto = await listPhotos(inGallery: "Summer Vacation")[0]
-add(firstPhoto toGallery: "Road Trip")
+add(firstPhoto, toGallery: "Road Trip")
 // At this point, firstPhoto is temporarily in both galleries.
-remove(firstPhoto fromGallery: "Summer Vacation")
+remove(firstPhoto, fromGallery: "Summer Vacation")
 ```
 
 


### PR DESCRIPTION
### Motivation: 

Hello 👋🏻, while reading the [Defining and Calling Asynchronous Functions page](https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html#ID639), I noticed the syntax of `add` and `remove` method was wrong, because there was no comma. 

### Modifications: 
- Fix swift syntax by adding comma.
- Update code snippet to swift

### Result:

Screenshot of content after changes:

![스크린샷 2022-10-11 오전 4 27 44](https://user-images.githubusercontent.com/56102421/194939327-11b97a42-1ee4-4560-af37-a13e80982994.png)

