### PR TITLE
Replace @Comment blocks with HTML comments

### DIFF
--- a/Sources/TSPL/TSPL.docc/GuidedTour/AboutSwift.md
+++ b/Sources/TSPL/TSPL.docc/GuidedTour/AboutSwift.md
@@ -49,7 +49,7 @@ Our goals for Swift are ambitious.
 We can’t wait to see what you create with it.
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -57,4 +57,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/GuidedTour/Compatibility.md
+++ b/Sources/TSPL/TSPL.docc/GuidedTour/Compatibility.md
@@ -7,7 +7,7 @@ the default version of Swift that's included in Xcode 14.
 You can use Xcode 14 to build targets
 that are written in either Swift 5.7, Swift 4.2, or Swift 4.
 
-@Comment {
+<!--
   - test: `swift-version`
   
   ```swifttest
@@ -20,7 +20,7 @@ that are written in either Swift 5.7, Swift 4.2, or Swift 4.
   >> #endif
   << Just right
   ```
-}
+-->
 
 When you use Xcode 14 to build Swift 4 and Swift 4.2 code,
 most Swift 5.7 functionality is available.
@@ -50,7 +50,7 @@ you can migrate your code from Swift 4 to Swift 5.7
 one framework at a time.
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -58,4 +58,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/GuidedTour/GuidedTour.md
+++ b/Sources/TSPL/TSPL.docc/GuidedTour/GuidedTour.md
@@ -8,10 +8,10 @@ Tradition suggests that the first program in a new language
 should print the words “Hello, world!” on the screen.
 In Swift, this can be done in a single line:
 
-@Comment {
+<!--
   K&R uses “hello, world”.
   It seems worth breaking with tradition to use proper casing.
-}
+-->
 
 ```swift
 print("Hello, world!")
@@ -19,14 +19,14 @@ print("Hello, world!")
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
   -> print("Hello, world!")
   <- Hello, world!
   ```
-}
+-->
 
 If you have written code in C or Objective-C,
 this syntax looks familiar to you ---
@@ -62,7 +62,7 @@ let myConstant = 42
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -70,7 +70,7 @@ let myConstant = 42
   -> myVariable = 50
   -> let myConstant = 42
   ```
-}
+-->
 
 A constant or variable must have the same type
 as the value you want to assign to it.
@@ -93,7 +93,7 @@ let explicitDouble: Double = 70
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -101,7 +101,7 @@ let explicitDouble: Double = 70
   -> let implicitDouble = 70.0
   -> let explicitDouble: Double = 70
   ```
-}
+-->
 
 > Experiment: Create a constant with
 > an explicit type of `Float` and a value of `4`.
@@ -117,7 +117,7 @@ let widthLabel = label + String(width)
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -127,16 +127,16 @@ let widthLabel = label + String(width)
   >> print(widthLabel)
   << The width is 94
   ```
-}
+-->
 
 > Experiment: Try removing the conversion to `String` from the last line.
 > What error do you get?
 
-@Comment {
+<!--
   TODO: Discuss with Core Writers ---
   are these experiments that make you familiar with errors
   helping you learn something?
-}
+-->
 
 There's an even simpler way to include values in strings:
 Write the value in parentheses,
@@ -151,7 +151,7 @@ let fruitSummary = "I have \(apples + oranges) pieces of fruit."
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -164,7 +164,7 @@ let fruitSummary = "I have \(apples + oranges) pieces of fruit."
   >> print(fruitSummary)
   << I have 8 pieces of fruit.
   ```
-}
+-->
 
 > Experiment: Use `\()` to
 > include a floating-point calculation in a string
@@ -184,7 +184,7 @@ And then I said "I have \(apples + oranges) pieces of fruit."
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -193,19 +193,19 @@ And then I said "I have \(apples + oranges) pieces of fruit."
      And then I said "I have \(apples + oranges) pieces of fruit."
      """
   ```
-}
+-->
 
-@Comment {
+<!--
   Can't show an example of indentation in the triple-quoted string above.
   <rdar://problem/49129068> Swift code formatting damages indentation
-}
+-->
 
 Create arrays and dictionaries using brackets (`[]`),
 and access their elements by writing
 the index or key in brackets.
 A comma is allowed after the last element.
 
-@Comment {
+<!--
   REFERENCE
   The list of fruits comes from the colors that the original iMac came in,
   following the initial launch of the iMac in Bondi Blue, ordered by SKU --
@@ -222,9 +222,9 @@ A comma is allowed after the last element.
        M7443LL/A (333 MHz Tangerine)
        M7442LL/A (333 MHz Grape)
        M7440LL/A (333 MHz Blueberry)
-}
+-->
 
-@Comment {
+<!--
   REFERENCE
   Occupations is a reference to Firefly,
   specifically to Mal's joke about Jayne's job on the ship.
@@ -243,7 +243,7 @@ A comma is allowed after the last element.
   Mal: What?
   Simon: I was just wondering what his job is - on the ship.
   Mal: Public relations.
-}
+-->
 
 ```swift
 var fruits = ["strawberries", "limes", "tangerines"]
@@ -257,7 +257,7 @@ occupations["Jayne"] = "Public Relations"
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -270,7 +270,7 @@ occupations["Jayne"] = "Public Relations"
       ]
   -> occupations["Jayne"] = "Public Relations"
   ```
-}
+-->
 
 Arrays automatically grow as you add elements.
 
@@ -280,7 +280,7 @@ print(fruits)
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -288,7 +288,7 @@ print(fruits)
   -> print(fruits)
   << ["strawberries", "grapes", "tangerines", "blueberries"]
   ```
-}
+-->
 
 To create an empty array or dictionary,
 use the initializer syntax.
@@ -299,14 +299,14 @@ let emptyDictionary: [String: Float] = [:]
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
   -> let emptyArray: [String] = []
   -> let emptyDictionary: [String: Float] = [:]
   ```
-}
+-->
 
 If type information can be inferred,
 you can write an empty array as `[]`
@@ -314,9 +314,9 @@ and an empty dictionary as `[:]` ---
 for example, when you set a new value for a variable
 or pass an argument to a function.
 
-@Comment {
+<!--
   iBooks Store screenshot begins here.
-}
+-->
 
 ```swift
 fruits = []
@@ -324,14 +324,14 @@ occupations = [:]
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
   -> fruits = []
   -> occupations = [:]
   ```
-}
+-->
 
 ## Control Flow
 
@@ -356,7 +356,7 @@ print(teamScore)
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -372,20 +372,20 @@ print(teamScore)
   -> print(teamScore)
   <- 11
   ```
-}
+-->
 
-@Comment {
+<!--
   REFERENCE
   Jelly babies are a candy/sweet that was closely associated
   with past incarnations of the Doctor in Dr. Who.
-}
+-->
 
-@Comment {
+<!--
   -> let haveJellyBabies = true
   -> if haveJellyBabies {
      }
   << Would you like a jelly baby?
-}
+-->
 
 In an `if` statement,
 the conditional must be a Boolean expression ---
@@ -400,16 +400,16 @@ or contains `nil` to indicate that a value is missing.
 Write a question mark (`?`) after the type of a value
 to mark the value as optional.
 
-@Comment {
+<!--
   iBooks Store screenshot ends here.
-}
+-->
 
-@Comment {
+<!--
   REFERENCE
   John Appleseed is a stock Apple fake name,
   going back at least to the contacts database
   that ships with the SDK in the simulator.
-}
+-->
 
 ```swift
 var optionalString: String? = "Hello"
@@ -424,7 +424,7 @@ if let name = optionalName {
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -440,7 +440,7 @@ if let name = optionalName {
   >> print(greeting)
   << Hello, John Appleseed
   ```
-}
+-->
 
 > Experiment: Change `optionalName` to `nil`.
 > What greeting do you get?
@@ -466,7 +466,7 @@ let informalGreeting = "Hi \(nickname ?? fullName)"
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -476,7 +476,7 @@ let informalGreeting = "Hi \(nickname ?? fullName)"
   >> print(informalGreeting)
   << Hi John Appleseed
   ```
-}
+-->
 
 You can use a shorter spelling to unwrap a value,
 using the same name for that unwrapped value.
@@ -488,7 +488,7 @@ if let nickname {
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -496,20 +496,20 @@ if let nickname {
          print("Hey, \(nickname)")
      }
   ```
-}
+-->
 
 Switches support any kind of data
 and a wide variety of comparison operations ---
 they aren't limited to integers
 and tests for equality.
 
-@Comment {
+<!--
   REFERENCE
   The vegetables and foods made from vegetables
   were just a convenient choice for a switch statement.
   They have various properties
   and fit with the apples & oranges used in an earlier example.
-}
+-->
 
 ```swift
 let vegetable = "red pepper"
@@ -527,7 +527,7 @@ switch vegetable {
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -544,7 +544,7 @@ switch vegetable {
      }
   <- Is it a spicy red pepper?
   ```
-}
+-->
 
 > Experiment: Try removing the default case.
 > What error do you get?
@@ -559,10 +559,10 @@ Execution doesn't continue to the next case,
 so you don't need to explicitly break out of the switch
 at the end of each case’s code.
 
-@Comment {
+<!--
   Omitting mention of "fallthrough" keyword.
   It's in the guide/reference if you need it.
-}
+-->
 
 You use `for`-`in` to iterate over items in a dictionary
 by providing a pair of names to use
@@ -571,13 +571,13 @@ Dictionaries are an unordered collection,
 so their keys and values are iterated over
 in an arbitrary order.
 
-@Comment {
+<!--
   REFERENCE
   Prime, square, and Fibonacci numbers
   are just convenient sets of numbers
   that many developers are already familiar with
   that we can use for some simple math.
-}
+-->
 
 ```swift
 let interestingNumbers = [
@@ -598,7 +598,7 @@ print(largest)
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -618,7 +618,7 @@ print(largest)
   -> print(largest)
   <- 25
   ```
-}
+-->
 
 > Experiment: Replace the `_` with a variable name,
 > and keep track of which kind of number was the largest.
@@ -627,12 +627,12 @@ Use `while` to repeat a block of code until a condition changes.
 The condition of a loop can be at the end instead,
 ensuring that the loop is run at least once.
 
-@Comment {
+<!--
   REFERENCE
   This example is rather skeletal -- m and n are pretty boring.
   I couldn't come up with anything suitably interesting at the time though,
   so I just went ahead and used this.
-}
+-->
 
 ```swift
 var n = 2
@@ -651,7 +651,7 @@ print(m)
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -669,7 +669,7 @@ print(m)
   -> print(m)
   <- 128
   ```
-}
+-->
 
 You can keep an index in a loop
 by using `..<` to make a range of indexes.
@@ -684,7 +684,7 @@ print(total)
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -695,7 +695,7 @@ print(total)
   -> print(total)
   <- 6
   ```
-}
+-->
 
 Use `..<` to make a range that omits its upper value,
 and use `...` to make a range that includes both values.
@@ -708,13 +708,13 @@ with a list of arguments in parentheses.
 Use `->` to separate the parameter names and types
 from the function's return type.
 
-@Comment {
+<!--
   REFERENCE
   Bob is used as just a generic name,
   but also a callout to Alex's dad.
   Tuesday is used on the assumption that lots of folks would be reading
   on the Tuesday after the WWDC keynote.
-}
+-->
 
 ```swift
 func greet(person: String, day: String) -> String {
@@ -724,7 +724,7 @@ greet(person: "Bob", day: "Tuesday")
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -736,7 +736,7 @@ greet(person: "Bob", day: "Tuesday")
   >> print(greetBob)
   << Hello Bob, today is Tuesday.
   ```
-}
+-->
 
 > Experiment: Remove the `day` parameter.
 > Add a parameter to include today’s lunch special in the greeting.
@@ -755,7 +755,7 @@ greet("John", on: "Wednesday")
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -767,20 +767,20 @@ greet("John", on: "Wednesday")
   >> print(greetJohn)
   << Hello John, today is Wednesday.
   ```
-}
+-->
 
 Use a tuple to make a compound value ---
 for example, to return multiple values from a function.
 The elements of a tuple can be referred to
 either by name or by number.
 
-@Comment {
+<!--
   REFERENCE
   Min, max, and sum are convenient for this example
   because they're all simple operations
   that are performed on the same kind of data.
   This gives the function a reason to return a tuple.
-}
+-->
 
 ```swift
 func calculateStatistics(scores: [Int]) -> (min: Int, max: Int, sum: Int) {
@@ -807,7 +807,7 @@ print(statistics.2)
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -835,7 +835,7 @@ print(statistics.2)
   -> print(statistics.2)
   <- 120
   ```
-}
+-->
 
 Functions can be nested.
 Nested functions have access to variables
@@ -857,7 +857,7 @@ returnFifteen()
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -874,7 +874,7 @@ returnFifteen()
   >> print(fifteen)
   << 15
   ```
-}
+-->
 
 Functions are a first-class type.
 This means that a function can return another function as its value.
@@ -891,7 +891,7 @@ increment(7)
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -907,7 +907,7 @@ increment(7)
   >> print(incrementResult)
   << 8
   ```
-}
+-->
 
 A function can take another function as one of its arguments.
 
@@ -928,7 +928,7 @@ hasAnyMatches(list: numbers, condition: lessThanTen)
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -949,7 +949,7 @@ hasAnyMatches(list: numbers, condition: lessThanTen)
   >> print(anyMatches)
   << true
   ```
-}
+-->
 
 Functions are actually a special case of closures:
 blocks of code that can be called later.
@@ -969,7 +969,7 @@ numbers.map({ (number: Int) -> Int in
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -981,7 +981,7 @@ numbers.map({ (number: Int) -> Int in
   >> print(numbersMap)
   << [60, 57, 21, 36]
   ```
-}
+-->
 
 > Experiment: Rewrite the closure to return zero for all odd numbers.
 
@@ -1000,7 +1000,7 @@ print(mappedNumbers)
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -1008,7 +1008,7 @@ print(mappedNumbers)
   -> print(mappedNumbers)
   <- [60, 57, 21, 36]
   ```
-}
+-->
 
 You can refer to parameters by number instead of by name ---
 this approach is especially useful in very short closures.
@@ -1024,7 +1024,7 @@ print(sortedNumbers)
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -1032,19 +1032,19 @@ print(sortedNumbers)
   -> print(sortedNumbers)
   <- [20, 19, 12, 7]
   ```
-}
+-->
 
-@Comment {
+<!--
   Called sorted() on a variable rather than a literal to work around an issue in Xcode.  See <rdar://17540974>.
-}
+-->
 
-@Comment {
+<!--
   Omitted sort(foo, <) because it often causes a spurious warning in Xcode.  See <rdar://17047529>.
-}
+-->
 
-@Comment {
+<!--
   Omitted custom operators as "advanced" topics.
-}
+-->
 
 ## Objects and Classes
 
@@ -1054,7 +1054,7 @@ as a constant or variable declaration,
 except that it's in the context of a class.
 Likewise, method and function declarations are written the same way.
 
-@Comment {
+<!--
   REFERENCE
   Shapes are used as the example object
   because they're familiar and they have a sense of properties
@@ -1062,7 +1062,7 @@ Likewise, method and function declarations are written the same way.
   They're not a perfect fit --
   they might be better off modeled as structures --
   but that wouldn't let them inherit behavior.
-}
+-->
 
 ```swift
 class Shape {
@@ -1074,7 +1074,7 @@ class Shape {
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -1087,7 +1087,7 @@ class Shape {
   >> print(Shape().simpleDescription())
   << A shape with 0 sides.
   ```
-}
+-->
 
 > Experiment: Add a constant property with `let`,
 > and add another method that takes an argument.
@@ -1104,7 +1104,7 @@ var shapeDescription = shape.simpleDescription()
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -1114,7 +1114,7 @@ var shapeDescription = shape.simpleDescription()
   >> print(shapeDescription)
   << A shape with 7 sides.
   ```
-}
+-->
 
 This version of the `Shape` class is missing something important:
 an initializer to set up the class when an instance is created.
@@ -1136,7 +1136,7 @@ class NamedShape {
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -1157,7 +1157,7 @@ class NamedShape {
   >> print(NamedShape(name: "test name").simpleDescription())
   << A shape with 0 sides.
   ```
-}
+-->
 
 Notice how `self` is used to distinguish the `name` property
 from the `name` argument to the initializer.
@@ -1208,7 +1208,7 @@ test.simpleDescription()
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -1239,7 +1239,7 @@ test.simpleDescription()
   >> print(testDesc)
   << A square with sides of length 5.2.
   ```
-}
+-->
 
 > Experiment: Make another subclass of `NamedShape`
 > called `Circle`
@@ -1283,7 +1283,7 @@ print(triangle.sideLength)
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -1316,7 +1316,7 @@ print(triangle.sideLength)
   -> print(triangle.sideLength)
   <- 3.3000000000000003
   ```
-}
+-->
 
 In the setter for `perimeter`,
 the new value has the implicit name `newValue`.
@@ -1339,12 +1339,12 @@ For example, the class below ensures
 that the side length of its triangle
 is always the same as the side length of its square.
 
-@Comment {
+<!--
   This triangle + square example could use improvement.
   The goal is to show why you would want to use willSet,
   but it was constrained by the fact that
   we're working in the context of geometric shapes.
-}
+-->
 
 ```swift
 class TriangleAndSquare {
@@ -1374,7 +1374,7 @@ print(triangleAndSquare.triangle.sideLength)
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -1403,14 +1403,14 @@ print(triangleAndSquare.triangle.sideLength)
   -> print(triangleAndSquare.triangle.sideLength)
   <- 50.0
   ```
-}
+-->
 
-@Comment {
+<!--
   Grammatically, these clauses are general to variables.
   Not sure what it would look like
   (or if it's even allowed)
   to use them outside a class or a struct.
-}
+-->
 
 When working with optional values,
 you can write `?` before operations like methods, properties, and subscripting.
@@ -1428,14 +1428,14 @@ let sideLength = optionalSquare?.sideLength
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
   -> let optionalSquare: Square? = Square(sideLength: 2.5, name: "optional square")
   -> let sideLength = optionalSquare?.sideLength
   ```
-}
+-->
 
 ## Enumerations and Structures
 
@@ -1443,7 +1443,7 @@ Use `enum` to create an enumeration.
 Like classes and all other named types,
 enumerations can have methods associated with them.
 
-@Comment {
+<!--
   REFERENCE
   Playing cards work pretty well to demonstrate enumerations
   because they have two aspects, suit and rank,
@@ -1451,7 +1451,7 @@ enumerations can have methods associated with them.
   The deck used here is probably the most common,
   at least through most of Europe and the Americas,
   but there are many other regional variations.
-}
+-->
 
 ```swift
 enum Rank: Int {
@@ -1479,7 +1479,7 @@ let aceRawValue = ace.rawValue
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -1508,7 +1508,7 @@ let aceRawValue = ace.rawValue
   >> print(aceRawValue)
   << 1
   ```
-}
+-->
 
 > Experiment: Write a function that compares two `Rank` values
 > by comparing their raw values.
@@ -1534,7 +1534,7 @@ if let convertedRank = Rank(rawValue: 3) {
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -1544,7 +1544,7 @@ if let convertedRank = Rank(rawValue: 3) {
   << 3
   -> }
   ```
-}
+-->
 
 The case values of an enumeration are actual values,
 not just another way of writing their raw values.
@@ -1574,7 +1574,7 @@ let heartsDescription = hearts.simpleDescription()
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -1599,16 +1599,16 @@ let heartsDescription = hearts.simpleDescription()
   >> print(heartsDescription)
   << hearts
   ```
-}
+-->
 
 > Experiment: Add a `color()` method to `Suit` that returns "black"
 > for spades and clubs, and returns "red" for hearts and diamonds.
 
-@Comment {
+<!--
   Suits are in Bridge order, which matches Unicode order.
   In other games, orders differ.
   Wikipedia lists a good half dozen orders.
-}
+-->
 
 Notice the two ways that the `hearts` case of the enumeration
 is referred to above:
@@ -1637,7 +1637,7 @@ the sunrise and sunset times from a server.
 The server either responds with the requested information,
 or it responds with a description of what went wrong.
 
-@Comment {
+<!--
   REFERENCE
   The server response is a simple way to essentially re-implement Optional
   while sidestepping the fact that I'm doing so.
@@ -1669,7 +1669,7 @@ or it responds with a description of what went wrong.
   and told add more cheese if necessary --
   the officer in charge said that he didn't want
   an "out of cheese error" interrupting the calculation.
-}
+-->
 
 ```swift
 enum ServerResponse {
@@ -1690,7 +1690,7 @@ switch success {
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -1710,7 +1710,7 @@ switch success {
      }
   <- Sunrise is at 6:00 am and sunset is at 8:09 pm.
   ```
-}
+-->
 
 > Experiment: Add a third case to `ServerResponse` and to the switch.
 
@@ -1739,7 +1739,7 @@ let threeOfSpadesDescription = threeOfSpades.simpleDescription()
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -1755,7 +1755,7 @@ let threeOfSpadesDescription = threeOfSpades.simpleDescription()
   >> print(threeOfSpadesDescription)
   << The 3 of spades
   ```
-}
+-->
 
 > Experiment: Write a function that returns an array containing
 > a full deck of cards,
@@ -1775,7 +1775,7 @@ func fetchUserID(from server: String) async -> Int {
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -1786,7 +1786,7 @@ func fetchUserID(from server: String) async -> Int {
          return 501
      }
   ```
-}
+-->
 
 You mark a call to an asynchronous function by writing `await` in front of it.
 
@@ -1801,7 +1801,7 @@ func fetchUsername(from server: String) async -> String {
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -1813,7 +1813,7 @@ func fetchUsername(from server: String) async -> String {
          return "Guest"
      }
   ```
-}
+-->
 
 Use `async let` to call an asynchronous function,
 letting it run in parallel with other asynchronous code.
@@ -1829,7 +1829,7 @@ func connectUser(to server: String) async {
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -1840,7 +1840,7 @@ func connectUser(to server: String) async {
          print(greeting)
      }
   ```
-}
+-->
 
 Use `Task` to call asynchronous functions from synchronous code,
 without waiting for them to return.
@@ -1853,7 +1853,7 @@ Task {
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -1863,7 +1863,7 @@ Task {
   >> import Darwin; sleep(1)  // Pause for task to run
   <- Hello Guest, user ID 97
   ```
-}
+-->
 
 ## Protocols and Extensions
 
@@ -1877,7 +1877,7 @@ protocol ExampleProtocol {
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -1886,17 +1886,17 @@ protocol ExampleProtocol {
           mutating func adjust()
      }
   ```
-}
+-->
 
 Classes, enumerations, and structures can all adopt protocols.
 
-@Comment {
+<!--
   REFERENCE
   The use of adjust() is totally a placeholder
   for some more interesting operation.
   Likewise for the struct and classes -- placeholders
   for some more interesting data structure.
-}
+-->
 
 ```swift
 class SimpleClass: ExampleProtocol {
@@ -1922,7 +1922,7 @@ let bDescription = b.simpleDescription
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -1951,7 +1951,7 @@ let bDescription = b.simpleDescription
   >> print(bDescription)
   << A simple structure (adjusted)
   ```
-}
+-->
 
 > Experiment: Add another requirement to `ExampleProtocol`.
 > What changes do you need to make
@@ -1985,7 +1985,7 @@ print(7.simpleDescription)
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -2000,7 +2000,7 @@ print(7.simpleDescription)
   -> print(7.simpleDescription)
   <- The number 7
   ```
-}
+-->
 
 > Experiment: Write an extension for the `Double` type
 > that adds an `absoluteValue` property.
@@ -2020,7 +2020,7 @@ print(protocolValue.simpleDescription)
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -2029,7 +2029,7 @@ print(protocolValue.simpleDescription)
   <- A very simple class.  Now 100% adjusted.
   // print(protocolValue.anotherProperty)  // Uncomment to see the error
   ```
-}
+-->
 
 Even though the variable `protocolValue`
 has a runtime type of `SimpleClass`,
@@ -2042,7 +2042,7 @@ in addition to its protocol conformance.
 
 You represent errors using any type that adopts the `Error` protocol.
 
-@Comment {
+<!--
   REFERENCE
   PrinterError.OnFire is a reference to the Unix printing system's "lp0 on
   fire" error message, used when the kernel can't identify the specific error.
@@ -2059,7 +2059,7 @@ You represent errors using any type that adopts the `Error` protocol.
   to the previous manual typesetting.  It set an entire line of type (hence
   the name) at a time, and was controlled by a keyboard.  The Monotype
   machine, invented in 1885 by Tolbert Lanston, performed similar work.
-}
+-->
 
 ```swift
 enum PrinterError: Error {
@@ -2070,7 +2070,7 @@ enum PrinterError: Error {
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -2080,7 +2080,7 @@ enum PrinterError: Error {
          case onFire
      }
   ```
-}
+-->
 
 Use `throw` to throw an error
 and `throws` to mark a function that can throw an error.
@@ -2098,7 +2098,7 @@ func send(job: Int, toPrinter printerName: String) throws -> String {
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -2109,7 +2109,7 @@ func send(job: Int, toPrinter printerName: String) throws -> String {
          return "Job sent"
      }
   ```
-}
+-->
 
 There are several ways to handle errors.
 One way is to use `do`-`catch`.
@@ -2130,7 +2130,7 @@ do {
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -2142,16 +2142,16 @@ do {
      }
   <- Job sent
   ```
-}
+-->
 
 > Experiment: Change the printer name to `"Never Has Toner"`,
 > so that the `send(job:toPrinter:)` function throws an error.
 
-@Comment {
+<!--
   Assertion tests the change that the Experiment box instructs you to make.
-}
+-->
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -2163,17 +2163,17 @@ do {
      }
   <- noToner
   ```
-}
+-->
 
 You can provide multiple `catch` blocks
 that handle specific errors.
 You write a pattern after `catch` just as you do
 after `case` in a switch.
 
-@Comment {
+<!--
   REFERENCE
   The "rest of the fire" quote comes from The IT Crowd, season 1 episode 2.
-}
+-->
 
 ```swift
 do {
@@ -2190,7 +2190,7 @@ do {
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -2206,7 +2206,7 @@ do {
      }
   <- Job sent
   ```
-}
+-->
 
 > Experiment: Add code to throw an error inside the `do` block.
 > What kind of error do you need to throw
@@ -2226,7 +2226,7 @@ let printerFailure = try? send(job: 1885, toPrinter: "Never Has Toner")
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -2237,7 +2237,7 @@ let printerFailure = try? send(job: 1885, toPrinter: "Never Has Toner")
   >> print(printerFailure as Any)
   << nil
   ```
-}
+-->
 
 Use `defer` to write a block of code
 that's executed after all other code in the function,
@@ -2265,7 +2265,7 @@ print(fridgeIsOpen)
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -2288,19 +2288,19 @@ print(fridgeIsOpen)
   -> print(fridgeIsOpen)
   <- false
   ```
-}
+-->
 
 ## Generics
 
 Write a name inside angle brackets
 to make a generic function or type.
 
-@Comment {
+<!--
   REFERENCE
   The four knocks is a reference to Dr Who series 4,
   in which knocking four times is a running aspect
   of the season's plot.
-}
+-->
 
 ```swift
 func makeArray<Item>(repeating item: Item, numberOfTimes: Int) -> [Item] {
@@ -2314,7 +2314,7 @@ makeArray(repeating: "knock", numberOfTimes: 4)
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -2330,7 +2330,7 @@ makeArray(repeating: "knock", numberOfTimes: 4)
   >> print(fourKnocks)
   << ["knock", "knock", "knock", "knock"]
   ```
-}
+-->
 
 You can make generic forms of functions and methods,
 as well as classes, enumerations, and structures.
@@ -2346,7 +2346,7 @@ possibleInteger = .some(100)
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -2358,7 +2358,7 @@ possibleInteger = .some(100)
   -> var possibleInteger: OptionalValue<Int> = .none
   -> possibleInteger = .some(100)
   ```
-}
+-->
 
 Use `where` right before the body
 to specify a list of requirements ---
@@ -2384,7 +2384,7 @@ anyCommonElements([1, 2, 3], [3])
 ```
 
 
-@Comment {
+<!--
   - test: `guided-tour`
   
   ```swifttest
@@ -2405,7 +2405,7 @@ anyCommonElements([1, 2, 3], [3])
   >> print(hasAnyCommon)
   << true
   ```
-}
+-->
 
 > Experiment: Modify the `anyCommonElements(_:_:)` function
 > to make a function that returns an array
@@ -2415,7 +2415,7 @@ Writing `<T: Equatable>`
 is the same as writing `<T> ... where T: Equatable`.
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -2423,4 +2423,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/AccessControl.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/AccessControl.md
@@ -165,7 +165,7 @@ private func somePrivateFunction() {}
 ```
 
 
-@Comment {
+<!--
   - test: `accessControlSyntax`
   
   ```swifttest
@@ -179,7 +179,7 @@ private func somePrivateFunction() {}
   -> fileprivate func someFilePrivateFunction() {}
   -> private func somePrivateFunction() {}
   ```
-}
+-->
 
 Unless otherwise specified, the default access level is internal,
 as described in <doc:AccessControl#Default-Access-Levels>.
@@ -193,14 +193,14 @@ let someInternalConstant = 0            // implicitly internal
 ```
 
 
-@Comment {
+<!--
   - test: `accessControlDefaulted`
   
   ```swifttest
   -> class SomeInternalClass {}              // implicitly internal
   -> let someInternalConstant = 0            // implicitly internal
   ```
-}
+-->
 
 ## Custom Types
 
@@ -253,7 +253,7 @@ private class SomePrivateClass {                // explicitly private class
 ```
 
 
-@Comment {
+<!--
   - test: `accessControl, accessControlWrong`
   
   ```swifttest
@@ -279,7 +279,7 @@ private class SomePrivateClass {                // explicitly private class
         func somePrivateMethod() {}                  // implicitly private class member
      }
   ```
-}
+-->
 
 ### Tuple Types
 
@@ -289,7 +289,7 @@ For example, if you compose a tuple from two different types,
 one with internal access and one with private access,
 the access level for that compound tuple type will be private.
 
-@Comment {
+<!--
   - test: `tupleTypes_Module1, tupleTypes_Module1_PublicAndInternal, tupleTypes_Module1_Private`
   
   ```swifttest
@@ -306,9 +306,9 @@ the access level for that compound tuple type will be private.
         return (PublicStruct(), FilePrivateStruct())
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `tupleTypes_Module1_PublicAndInternal`
   
   ```swifttest
@@ -316,9 +316,9 @@ the access level for that compound tuple type will be private.
   -> let publicTuple = returnPublicTuple()
   -> let internalTuple = returnInternalTuple()
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `tupleTypes_Module1_Private`
   
   ```swifttest
@@ -328,9 +328,9 @@ the access level for that compound tuple type will be private.
   !! let privateTuple = returnFilePrivateTuple()
   !!                    ^~~~~~~~~~~~~~~~~~~~~~
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `tupleTypes_Module2_Public`
   
   ```swifttest
@@ -338,9 +338,9 @@ the access level for that compound tuple type will be private.
   -> import tupleTypes_Module1
   -> let publicTuple = returnPublicTuple()
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `tupleTypes_Module2_InternalAndPrivate`
   
   ```swifttest
@@ -355,7 +355,7 @@ the access level for that compound tuple type will be private.
   !! let privateTuple = returnFilePrivateTuple()
   !!                    ^~~~~~~~~~~~~~~~~~~~~~
   ```
-}
+-->
 
 > Note: Tuple types don't have a standalone definition in the way that
 > classes, structures, enumerations, and functions do.
@@ -383,7 +383,7 @@ func someFunction() -> (SomeInternalClass, SomePrivateClass) {
 ```
 
 
-@Comment {
+<!--
   - test: `accessControlWrong`
   
   ```swifttest
@@ -395,7 +395,7 @@ func someFunction() -> (SomeInternalClass, SomePrivateClass) {
   !! func someFunction() -> (SomeInternalClass, SomePrivateClass) {
   !! ^
   ```
-}
+-->
 
 The function's return type is
 a tuple type composed from two of the custom classes defined above in <doc:AccessControl#Custom-Types>.
@@ -415,7 +415,7 @@ private func someFunction() -> (SomeInternalClass, SomePrivateClass) {
 ```
 
 
-@Comment {
+<!--
   - test: `accessControl`
   
   ```swifttest
@@ -424,7 +424,7 @@ private func someFunction() -> (SomeInternalClass, SomePrivateClass) {
   >>    return (SomeInternalClass(), SomePrivateClass())
      }
   ```
-}
+-->
 
 It's not valid to mark the definition of `someFunction()`
 with the `public` or `internal` modifiers,
@@ -453,7 +453,7 @@ public enum CompassPoint {
 ```
 
 
-@Comment {
+<!--
   - test: `enumerationCases`
   
   ```swifttest
@@ -464,9 +464,9 @@ public enum CompassPoint {
         case west
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `enumerationCases_Module1`
   
   ```swifttest
@@ -477,16 +477,16 @@ public enum CompassPoint {
         case west
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `enumerationCases_Module2`
   
   ```swifttest
   -> import enumerationCases_Module1
   -> let north = CompassPoint.north
   ```
-}
+-->
 
 #### Raw Values and Associated Values
 
@@ -505,7 +505,7 @@ have an automatic access level of internal.
 If you want a nested type within a public type to be publicly available,
 you must explicitly declare the nested type as public.
 
-@Comment {
+<!--
   - test: `nestedTypes_Module1, nestedTypes_Module1_PublicAndInternal, nestedTypes_Module1_Private`
   
   ```swifttest
@@ -529,9 +529,9 @@ you must explicitly declare the nested type as public.
         private enum PrivateEnumInsidePrivateStruct { case a, b }
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `nestedTypes_Module1_PublicAndInternal`
   
   ```swifttest
@@ -543,9 +543,9 @@ you must explicitly declare the nested type as public.
   -> let internalNestedInsideInternal = InternalStruct.InternalEnumInsideInternalStruct.a
   -> let automaticNestedInsideInternal = InternalStruct.AutomaticEnumInsideInternalStruct.a
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `nestedTypes_Module1_Private`
   
   ```swifttest
@@ -576,9 +576,9 @@ you must explicitly declare the nested type as public.
   !! let automaticNestedInsidePrivate = PrivateStruct.AutomaticEnumInsidePrivateStruct.a
   !!                                    ^~~~~~~~~~~~~
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `nestedTypes_Module2_Public`
   
   ```swifttest
@@ -586,9 +586,9 @@ you must explicitly declare the nested type as public.
   -> import nestedTypes_Module1
   -> let publicNestedInsidePublic = PublicStruct.PublicEnumInsidePublicStruct.a
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `nestedTypes_Module2_InternalAndPrivate`
   
   ```swifttest
@@ -639,7 +639,7 @@ you must explicitly declare the nested type as public.
   !! let automaticNestedInsidePrivate = PrivateStruct.AutomaticEnumInsidePrivateStruct.a
   !!                                    ^~~~~~~~~~~~~
   ```
-}
+-->
 
 ## Subclassing
 
@@ -677,7 +677,7 @@ internal class B: A {
 ```
 
 
-@Comment {
+<!--
   - test: `subclassingNoCall`
   
   ```swifttest
@@ -689,7 +689,7 @@ internal class B: A {
         override internal func someMethod() {}
      }
   ```
-}
+-->
 
 It's even valid for a subclass member to call
 a superclass member that has lower access permissions than the subclass member,
@@ -711,7 +711,7 @@ internal class B: A {
 ```
 
 
-@Comment {
+<!--
   - test: `subclassingWithCall`
   
   ```swifttest
@@ -725,7 +725,7 @@ internal class B: A {
         }
      }
   ```
-}
+-->
 
 Because superclass `A` and subclass `B` are defined in the same source file,
 it's valid for the `B` implementation of `someMethod()` to call
@@ -745,15 +745,15 @@ private var privateInstance = SomePrivateClass()
 ```
 
 
-@Comment {
+<!--
   - test: `accessControl`
   
   ```swifttest
   -> private var privateInstance = SomePrivateClass()
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `useOfPrivateTypeRequiresPrivateModifier`
   
   ```swifttest
@@ -784,7 +784,7 @@ private var privateInstance = SomePrivateClass()
   !! private class SomePrivateClass {}
   !! ^
   ```
-}
+-->
 
 ### Getters and Setters
 
@@ -821,7 +821,7 @@ struct TrackedString {
 ```
 
 
-@Comment {
+<!--
   - test: `reducedSetterScope, reducedSetterScope_error`
   
   ```swifttest
@@ -834,7 +834,7 @@ struct TrackedString {
         }
      }
   ```
-}
+-->
 
 The `TrackedString` structure defines a stored string property called `value`,
 with an initial value of `""` (an empty string).
@@ -857,7 +857,7 @@ This enables `TrackedString` to modify the `numberOfEdits` property internally,
 but to present the property as a read-only property
 when it's used outside the structure's definition.
 
-@Comment {
+<!--
   - test: `reducedSetterScope_error`
   
   ```swifttest
@@ -871,12 +871,12 @@ when it's used outside the structure's definition.
   !! let resultA: Void = { s.numberOfEdits += 1 }()
   !!                       ~~~~~~~~~~~~~~~ ^
   ```
-}
+-->
 
-@Comment {
+<!--
   The assertion above must be compiled because of a REPL bug
   <rdar://problem/54089342> REPL fails to enforce private(set) on struct property
-}
+-->
 
 If you create a `TrackedString` instance and modify its string value a few times,
 you can see the `numberOfEdits` property value update to match the number of modifications:
@@ -891,7 +891,7 @@ print("The number of edits is \(stringToEdit.numberOfEdits)")
 ```
 
 
-@Comment {
+<!--
   - test: `reducedSetterScope`
   
   ```swifttest
@@ -902,7 +902,7 @@ print("The number of edits is \(stringToEdit.numberOfEdits)")
   -> print("The number of edits is \(stringToEdit.numberOfEdits)")
   <- The number of edits is 3
   ```
-}
+-->
 
 Although you can query the current value of the `numberOfEdits` property
 from within another source file,
@@ -934,7 +934,7 @@ public struct TrackedString {
 ```
 
 
-@Comment {
+<!--
   - test: `reducedSetterScopePublic`
   
   ```swifttest
@@ -948,9 +948,9 @@ public struct TrackedString {
         public init() {}
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `reducedSetterScopePublic_Module1_Allowed, reducedSetterScopePublic_Module1_NotAllowed`
   
   ```swifttest
@@ -964,9 +964,9 @@ public struct TrackedString {
         public init() {}
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `reducedSetterScopePublic_Module1_Allowed`
   
   ```swifttest
@@ -974,9 +974,9 @@ public struct TrackedString {
   -> var stringToEdit_Module1B = TrackedString()
   -> let resultB = stringToEdit_Module1B.numberOfEdits
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `reducedSetterScopePublic_Module1_NotAllowed`
   
   ```swifttest
@@ -987,9 +987,9 @@ public struct TrackedString {
   !! let resultC: Void = { stringToEdit_Module1C.numberOfEdits += 1 }()
   !!                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `reducedSetterScopePublic_Module2`
   
   ```swifttest
@@ -1003,7 +1003,7 @@ public struct TrackedString {
   !! let result2Write: Void = { stringToEdit_Module2.numberOfEdits += 1 }()
   !!                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
   ```
-}
+-->
 
 ## Initializers
 
@@ -1061,7 +1061,7 @@ the protocol it supports.
 This ensures that all of the protocol's requirements will be visible
 on any type that adopts the protocol.
 
-@Comment {
+<!--
   - test: `protocolRequirementsCannotBeDifferentThanTheProtocol`
   
   ```swifttest
@@ -1100,7 +1100,7 @@ on any type that adopts the protocol.
   !! private var privateProperty: Int { get }
   !! ^
   ```
-}
+-->
 
 > Note: If you define a public protocol,
 > the protocol's requirements require a public access level
@@ -1109,7 +1109,7 @@ on any type that adopts the protocol.
 > where a public type definition implies
 > an access level of internal for the type's members.
 
-@Comment {
+<!--
   - test: `protocols_Module1, protocols_Module1_PublicAndInternal, protocols_Module1_Private`
   
   ```swifttest
@@ -1130,9 +1130,9 @@ on any type that adopts the protocol.
         func privateMethod()
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `protocols_Module1_PublicAndInternal`
   
   ```swifttest
@@ -1163,9 +1163,9 @@ on any type that adopts the protocol.
         func internalMethod() {}
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `protocols_Module1_Private`
   
   ```swifttest
@@ -1187,9 +1187,9 @@ on any type that adopts the protocol.
   !! public class PublicClassConformingToPrivateProtocol: PrivateProtocol {
   !! ^~~~~~~~~~~~~~~
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `protocols_Module2_Public`
   
   ```swifttest
@@ -1208,9 +1208,9 @@ on any type that adopts the protocol.
         func publicMethod() {}
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `protocols_Module2_InternalAndPrivate`
   
   ```swifttest
@@ -1239,7 +1239,7 @@ on any type that adopts the protocol.
   !! public class PublicClassConformingToPrivateProtocol: PrivateProtocol {
   !! ^~~~~~~~~~~~~~~
   ```
-}
+-->
 
 ### Protocol Inheritance
 
@@ -1294,7 +1294,7 @@ if you're using that extension to add protocol conformance.
 Instead, the protocol's own access level is used to provide
 the default access level for each protocol requirement implementation within the extension.
 
-@Comment {
+<!--
   - test: `extensions_Module1, extensions_Module1_PublicAndInternal, extensions_Module1_Private`
   
   ```swifttest
@@ -1313,9 +1313,9 @@ the default access level for each protocol requirement implementation within the
   -> let sameFileB = publicStructInSameFile.implicitlyInternalMethodFromExtension()
   -> let sameFileC = publicStructInSameFile.filePrivateMethod()
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `extensions_Module1_PublicAndInternal`
   
   ```swifttest
@@ -1323,9 +1323,9 @@ the default access level for each protocol requirement implementation within the
   -> let differentFileA = publicStructInDifferentFile.implicitlyInternalMethodFromStruct()
   -> let differentFileB = publicStructInDifferentFile.implicitlyInternalMethodFromExtension()
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `extensions_Module1_Private`
   
   ```swifttest
@@ -1338,9 +1338,9 @@ the default access level for each protocol requirement implementation within the
   !! func filePrivateMethod() -> Int { return 0 }
   !! ^
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `extensions_Module2`
   
   ```swifttest
@@ -1368,7 +1368,7 @@ the default access level for each protocol requirement implementation within the
   !! fileprivate func filePrivateMethod() -> Int
   !!                  ^
   ```
-}
+-->
 
 ### Private Members in Extensions
 
@@ -1397,7 +1397,7 @@ protocol SomeProtocol {
 ```
 
 
-@Comment {
+<!--
   - test: `extensions_privatemembers`
   
   ```swifttest
@@ -1405,7 +1405,7 @@ protocol SomeProtocol {
          func doSomething()
      }
   ```
-}
+-->
 
 You can use an extension to add protocol conformance, like this:
 
@@ -1422,7 +1422,7 @@ extension SomeStruct: SomeProtocol {
 ```
 
 
-@Comment {
+<!--
   - test: `extensions_privatemembers`
   
   ```swifttest
@@ -1439,7 +1439,7 @@ extension SomeStruct: SomeProtocol {
   >> s.doSomething()
   << 12
   ```
-}
+-->
 
 ## Generics
 
@@ -1456,7 +1456,7 @@ but a public type alias can't alias an internal, file-private, or private type.
 
 > Note: This rule also applies to type aliases for associated types used to satisfy protocol conformances.
 
-@Comment {
+<!--
   - test: `typeAliases`
   
   ```swifttest
@@ -1495,10 +1495,10 @@ but a public type alias can't alias an internal, file-private, or private type.
   !! private struct PrivateStruct {}
   !! ^
   ```
-}
+-->
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -1506,4 +1506,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/AdvancedOperators.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/AdvancedOperators.md
@@ -56,7 +56,7 @@ let invertedBits = ~initialBits  // equals 11110000
 ```
 
 
-@Comment {
+<!--
   - test: `bitwiseOperators`
   
   ```swifttest
@@ -65,7 +65,7 @@ let invertedBits = ~initialBits  // equals 11110000
   -> let invertedBits = ~initialBits  // equals 11110000
   >> assert(invertedBits == 240)
   ```
-}
+-->
 
 `UInt8` integers have eight bits
 and can store any value between `0` and `255`.
@@ -74,9 +74,9 @@ which has its first four bits set to `0`,
 and its second four bits set to `1`.
 This is equivalent to a decimal value of `15`.
 
-@Comment {
+<!--
   iBooks Store screenshot begins here.
-}
+-->
 
 The bitwise NOT operator is then used to create a new constant called `invertedBits`,
 which is equal to `initialBits`,
@@ -107,7 +107,7 @@ let middleFourBits = firstSixBits & lastSixBits  // equals 00111100
 ```
 
 
-@Comment {
+<!--
   - test: `bitwiseOperators`
   
   ```swifttest
@@ -116,7 +116,7 @@ let middleFourBits = firstSixBits & lastSixBits  // equals 00111100
   -> let middleFourBits = firstSixBits & lastSixBits  // equals 00111100
   >> assert(middleFourBits == 0b00111100)
   ```
-}
+-->
 
 ### Bitwise OR Operator
 
@@ -127,9 +127,9 @@ if the bits are equal to `1` in *either* input number:
 ![](bitwiseOR)
 
 
-@Comment {
+<!--
   iBooks Store screenshot ends here.
-}
+-->
 
 In the example below,
 the values of `someBits` and `moreBits` have different bits set to `1`.
@@ -143,7 +143,7 @@ let combinedbits = someBits | moreBits  // equals 11111110
 ```
 
 
-@Comment {
+<!--
   - test: `bitwiseOperators`
   
   ```swifttest
@@ -152,7 +152,7 @@ let combinedbits = someBits | moreBits  // equals 11111110
   -> let combinedbits = someBits | moreBits  // equals 11111110
   >> assert(combinedbits == 0b11111110)
   ```
-}
+-->
 
 ### Bitwise XOR Operator
 
@@ -179,7 +179,7 @@ let outputBits = firstBits ^ otherBits  // equals 00010001
 ```
 
 
-@Comment {
+<!--
   - test: `bitwiseOperators`
   
   ```swifttest
@@ -188,7 +188,7 @@ let outputBits = firstBits ^ otherBits  // equals 00010001
   -> let outputBits = firstBits ^ otherBits  // equals 00010001
   >> assert(outputBits == 0b00010001)
   ```
-}
+-->
 
 ### Bitwise Left and Right Shift Operators
 
@@ -202,9 +202,9 @@ multiplying or dividing an integer by a factor of two.
 Shifting an integer's bits to the left by one position doubles its value,
 whereas shifting it to the right by one position halves its value.
 
-@Comment {
+<!--
   TODO: mention the caveats to this claim.
-}
+-->
 
 #### Shifting Behavior for Unsigned Integers
 
@@ -240,7 +240,7 @@ shiftBits >> 2             // 00000001
 ```
 
 
-@Comment {
+<!--
   - test: `bitwiseShiftOperators`
   
   ```swifttest
@@ -261,12 +261,12 @@ shiftBits >> 2             // 00000001
   -> shiftBits >> 2             // 00000001
   >> assert(r4 == 1)
   ```
-}
+-->
 
-@Comment {
+<!--
   Rewrite the above to avoid bare expressions.
   Tracking bug is <rdar://problem/35301593>
-}
+-->
 
 You can use bit shifting to encode and decode values within other data types:
 
@@ -278,7 +278,7 @@ let blueComponent = pink & 0x0000FF           // blueComponent is 0x99, or 153
 ```
 
 
-@Comment {
+<!--
   - test: `bitwiseShiftOperators`
   
   ```swifttest
@@ -290,7 +290,7 @@ let blueComponent = pink & 0x0000FF           // blueComponent is 0x99, or 153
   >> assert(greenComponent == 102)
   >> assert(blueComponent == 153)
   ```
-}
+-->
 
 This example uses a `UInt32` constant called `pink` to store a
 Cascading Style Sheets color value for the color pink.
@@ -416,7 +416,7 @@ potentialOverflow += 1
 ```
 
 
-@Comment {
+<!--
   - test: `overflowOperatorsWillFailToOverflow`
   
   ```swifttest
@@ -427,7 +427,7 @@ potentialOverflow += 1
   xx overflow
   // this causes an error
   ```
-}
+-->
 
 Providing error handling when values get too large or too small
 gives you much more flexibility when coding for boundary value conditions.
@@ -459,7 +459,7 @@ unsignedOverflow = unsignedOverflow &+ 1
 ```
 
 
-@Comment {
+<!--
   - test: `overflowOperatorsWillOverflowInPositiveDirection`
   
   ```swifttest
@@ -470,7 +470,7 @@ unsignedOverflow = unsignedOverflow &+ 1
   /> unsignedOverflow is now equal to \(unsignedOverflow)
   </ unsignedOverflow is now equal to 0
   ```
-}
+-->
 
 The variable `unsignedOverflow` is initialized with the maximum value a `UInt8` can hold
 (`255`, or `11111111` in binary).
@@ -496,7 +496,7 @@ unsignedOverflow = unsignedOverflow &- 1
 ```
 
 
-@Comment {
+<!--
   - test: `overflowOperatorsWillOverflowInNegativeDirection`
   
   ```swifttest
@@ -507,7 +507,7 @@ unsignedOverflow = unsignedOverflow &- 1
   /> unsignedOverflow is now equal to \(unsignedOverflow)
   </ unsignedOverflow is now equal to 255
   ```
-}
+-->
 
 The minimum value that a `UInt8` can hold is zero,
 or `00000000` in binary.
@@ -531,7 +531,7 @@ signedOverflow = signedOverflow &- 1
 ```
 
 
-@Comment {
+<!--
   - test: `overflowOperatorsWillOverflowSigned`
   
   ```swifttest
@@ -542,7 +542,7 @@ signedOverflow = signedOverflow &- 1
   /> signedOverflow is now equal to \(signedOverflow)
   </ signedOverflow is now equal to 127
   ```
-}
+-->
 
 The minimum value that an `Int8` can hold is `-128`,
 or `10000000` in binary.
@@ -583,7 +583,7 @@ operator precedence explains why the following expression equals `17`.
 ```
 
 
-@Comment {
+<!--
   - test: `evaluationOrder`
   
   ```swifttest
@@ -593,12 +593,12 @@ operator precedence explains why the following expression equals `17`.
   /> this equals \(2 + 3 % 4 * 5)
   </ this equals 17
   ```
-}
+-->
 
-@Comment {
+<!--
   Rewrite the above to avoid bare expressions.
   Tracking bug is <rdar://problem/35301593>
-}
+-->
 
 If you read strictly from left to right,
 you might expect the expression to be calculated as follows:
@@ -626,7 +626,7 @@ starting from their left:
 ```
 
 
-@Comment {
+<!--
   - test: `evaluationOrder`
   
   ```swifttest
@@ -634,12 +634,12 @@ starting from their left:
   -> 2 + ((3 % 4) * 5)
   >> assert(r1 == 17)
   ```
-}
+-->
 
-@Comment {
+<!--
   Rewrite the above to avoid bare expressions.
   Tracking bug is <rdar://problem/35301593>
-}
+-->
 
 `(3 % 4)` is `3`, so this is equivalent to:
 
@@ -648,7 +648,7 @@ starting from their left:
 ```
 
 
-@Comment {
+<!--
   - test: `evaluationOrder`
   
   ```swifttest
@@ -656,12 +656,12 @@ starting from their left:
   -> 2 + (3 * 5)
   >> assert(r2 == 17)
   ```
-}
+-->
 
-@Comment {
+<!--
   Rewrite the above to avoid bare expressions.
   Tracking bug is <rdar://problem/35301593>
-}
+-->
 
 `(3 * 5)` is `15`, so this is equivalent to:
 
@@ -670,7 +670,7 @@ starting from their left:
 ```
 
 
-@Comment {
+<!--
   - test: `evaluationOrder`
   
   ```swifttest
@@ -678,12 +678,12 @@ starting from their left:
   -> 2 + 15
   >> assert(r3 == 17)
   ```
-}
+-->
 
-@Comment {
+<!--
   Rewrite the above to avoid bare expressions.
   Tracking bug is <rdar://problem/35301593>
-}
+-->
 
 This calculation yields the final answer of `17`.
 
@@ -726,7 +726,7 @@ extension Vector2D {
 ```
 
 
-@Comment {
+<!--
   - test: `customOperators`
   
   ```swifttest
@@ -740,7 +740,7 @@ extension Vector2D {
          }
      }
   ```
-}
+-->
 
 The operator method is defined as a type method on `Vector2D`,
 with a method name that matches the operator to be overloaded (`+`).
@@ -770,7 +770,7 @@ let combinedVector = vector + anotherVector
 ```
 
 
-@Comment {
+<!--
   - test: `customOperators`
   
   ```swifttest
@@ -780,7 +780,7 @@ let combinedVector = vector + anotherVector
   /> combinedVector is a Vector2D instance with values of (\(combinedVector.x), \(combinedVector.y))
   </ combinedVector is a Vector2D instance with values of (5.0, 5.0)
   ```
-}
+-->
 
 This example adds together the vectors `(3.0, 1.0)` and `(2.0, 4.0)`
 to make the vector `(5.0, 5.0)`, as illustrated below.
@@ -810,7 +810,7 @@ extension Vector2D {
 ```
 
 
-@Comment {
+<!--
   - test: `customOperators`
   
   ```swifttest
@@ -820,7 +820,7 @@ extension Vector2D {
          }
      }
   ```
-}
+-->
 
 The example above implements the unary minus operator
 (`-a`) for `Vector2D` instances.
@@ -841,7 +841,7 @@ let alsoPositive = -negative
 ```
 
 
-@Comment {
+<!--
   - test: `customOperators`
   
   ```swifttest
@@ -853,7 +853,7 @@ let alsoPositive = -negative
   /> alsoPositive is a Vector2D instance with values of (\(alsoPositive.x), \(alsoPositive.y))
   </ alsoPositive is a Vector2D instance with values of (3.0, 4.0)
   ```
-}
+-->
 
 ### Compound Assignment Operators
 
@@ -875,7 +875,7 @@ extension Vector2D {
 ```
 
 
-@Comment {
+<!--
   - test: `customOperators`
   
   ```swifttest
@@ -885,7 +885,7 @@ extension Vector2D {
          }
      }
   ```
-}
+-->
 
 Because an addition operator was defined earlier,
 you don't need to reimplement the addition process here.
@@ -901,7 +901,7 @@ original += vectorToAdd
 ```
 
 
-@Comment {
+<!--
   - test: `customOperators`
   
   ```swifttest
@@ -911,7 +911,7 @@ original += vectorToAdd
   /> original now has values of (\(original.x), \(original.y))
   </ original now has values of (4.0, 6.0)
   ```
-}
+-->
 
 > Note: It isn't possible to overload the default
 > assignment operator (`=`).
@@ -919,7 +919,7 @@ original += vectorToAdd
 > Similarly, the ternary conditional operator
 > (`a ? b : c`) can't be overloaded.
 
-@Comment {
+<!--
   - test: `cant-overload-assignment`
   
   ```swifttest
@@ -935,7 +935,7 @@ original += vectorToAdd
   !! static func = (left: inout Vector2D, right: Vector2D) {
   !!             ^
   ```
-}
+-->
 
 ### Equivalence Operators
 
@@ -964,7 +964,7 @@ extension Vector2D: Equatable {
 ```
 
 
-@Comment {
+<!--
   - test: `customOperators`
   
   ```swifttest
@@ -974,7 +974,7 @@ extension Vector2D: Equatable {
          }
      }
   ```
-}
+-->
 
 The example above implements an `==` operator
 to check whether two `Vector2D` instances have equivalent values.
@@ -995,7 +995,7 @@ if twoThree == anotherTwoThree {
 ```
 
 
-@Comment {
+<!--
   - test: `customOperators`
   
   ```swifttest
@@ -1006,7 +1006,7 @@ if twoThree == anotherTwoThree {
      }
   <- These two vectors are equivalent.
   ```
-}
+-->
 
 In many simple cases, you can ask Swift
 to provide synthesized implementations of the equivalence operators for you,
@@ -1027,13 +1027,13 @@ prefix operator +++
 ```
 
 
-@Comment {
+<!--
   - test: `customOperators`
   
   ```swifttest
   -> prefix operator +++
   ```
-}
+-->
 
 The example above defines a new prefix operator called `+++`.
 This operator doesn't have an existing meaning in Swift,
@@ -1060,7 +1060,7 @@ let afterDoubling = +++toBeDoubled
 ```
 
 
-@Comment {
+<!--
   - test: `customOperators`
   
   ```swifttest
@@ -1078,7 +1078,7 @@ let afterDoubling = +++toBeDoubled
   /> afterDoubling also has values of (\(afterDoubling.x), \(afterDoubling.y))
   </ afterDoubling also has values of (2.0, 8.0)
   ```
-}
+-->
 
 ### Precedence for Custom Infix Operators
 
@@ -1110,7 +1110,7 @@ let plusMinusVector = firstVector +- secondVector
 ```
 
 
-@Comment {
+<!--
   - test: `customOperators`
   
   ```swifttest
@@ -1126,7 +1126,7 @@ let plusMinusVector = firstVector +- secondVector
   /> plusMinusVector is a Vector2D instance with values of (\(plusMinusVector.x), \(plusMinusVector.y))
   </ plusMinusVector is a Vector2D instance with values of (4.0, -2.0)
   ```
-}
+-->
 
 This operator adds together the `x` values of two vectors,
 and subtracts the `y` value of the second vector from the first.
@@ -1144,7 +1144,7 @@ see <doc:Declarations#Operator-Declaration>.
 > However, if you apply both a prefix and a postfix operator to the same operand,
 > the postfix operator is applied first.
 
-@Comment {
+<!--
   - test: `postfixOperatorsAreAppliedBeforePrefixOperators`
   
   ```swifttest
@@ -1167,7 +1167,7 @@ see <doc:Declarations#Operator-Declaration>.
   <- 0 0 1
   // Note that x==y
   ```
-}
+-->
 
 ## Result Builders
 
@@ -1211,7 +1211,7 @@ struct AllCaps: Drawable {
 ```
 
 
-@Comment {
+<!--
   - test: `result-builder`
   
   ```swifttest
@@ -1241,7 +1241,7 @@ struct AllCaps: Drawable {
          func draw() -> String { return content.draw().uppercased() }
      }
   ```
-}
+-->
 
 The `Drawable` protocol defines the requirement
 for something that can be drawn, like a line or shape:
@@ -1272,7 +1272,7 @@ print(manualDrawing.draw())
 ```
 
 
-@Comment {
+<!--
   - test: `result-builder`
   
   ```swifttest
@@ -1287,7 +1287,7 @@ print(manualDrawing.draw())
   -> print(manualDrawing.draw())
   <- ***Hello RAVI PATEL!**
   ```
-}
+-->
 
 This code works, but it's a little awkward.
 The deeply nested parentheses after `AllCaps` are hard to read.
@@ -1320,7 +1320,7 @@ struct DrawingBuilder {
 ```
 
 
-@Comment {
+<!--
   - test: `result-builder`
   
   ```swifttest
@@ -1337,7 +1337,7 @@ struct DrawingBuilder {
          }
      }
   ```
-}
+-->
 
 The `DrawingBuilder` structure defines three methods
 that implement parts of the result builder syntax.
@@ -1386,7 +1386,7 @@ print(personalGreeting.draw())
 ```
 
 
-@Comment {
+<!--
   - test: `result-builder`
   
   ```swifttest
@@ -1421,7 +1421,7 @@ print(personalGreeting.draw())
   -> print(personalGreeting.draw())
   <- ***Hello RAVI PATEL!**
   ```
-}
+-->
 
 The `makeGreeting(for:)` function takes a `name` parameter
 and uses it to draw a personalized greeting.
@@ -1452,7 +1452,7 @@ let capsDrawing = caps {
 ```
 
 
-@Comment {
+<!--
   - test: `result-builder`
   
   ```swifttest
@@ -1470,7 +1470,7 @@ let capsDrawing = caps {
   >> print(capsDrawing.draw())
   << RAVI PATEL!
   ```
-}
+-->
 
 Swift transforms the `if`-`else` block into
 calls to the `buildEither(first:)` and `buildEither(second:)` methods.
@@ -1498,7 +1498,7 @@ let manyStars = draw {
 ```
 
 
-@Comment {
+<!--
   - test: `result-builder`
   
   ```swifttest
@@ -1517,7 +1517,7 @@ let manyStars = draw {
   >> print(manyStars.draw())
   << Stars: * ** ***
   ```
-}
+-->
 
 In the code above, the `for` loop creates an array of drawings,
 and the `buildArray(_:)` method turns that array into a `Line`.
@@ -1526,7 +1526,7 @@ For a complete list of how Swift transforms builder syntax
 into calls to the builder type's methods,
 see <doc:Attributes#resultBuilder>.
 
-@Comment {
+<!--
   The following needs more work...
   
    Protocol Operator Requirements
@@ -1563,9 +1563,9 @@ see <doc:Attributes#resultBuilder>.
   >> let r0 =
   >> Vector3D(x: 1.1, y: 2.3, z: 12) == Vector3D(x: 1.1, y: 2.3, z: 12)
   >> assert(r0)
-}
+-->
 
-@Comment {
+<!--
   FIXME: This doesn't work
   <rdar://problem/27536066> SE-0091 -- can't have protocol conformance & operator implementation in different types
   
@@ -1598,20 +1598,20 @@ see <doc:Attributes#resultBuilder>.
   -> let unitVector = Vector2D(x: 1.0, y: 1.0)
   -> print(2.5 *** unitVector)
   <- Vector2D(x: 2.5, y: 2.5)
-}
+-->
 
-@Comment {
+<!--
   TODO: However, Doug thought that this might be better covered by Generics,
   where you know that two things are definitely of the same type.
   Perhaps mention it here, but don't actually show an example?
-}
+-->
 
-@Comment {
+<!--
   TODO: generic operators
-}
+-->
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -1619,4 +1619,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/AutomaticReferenceCounting.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/AutomaticReferenceCounting.md
@@ -73,7 +73,7 @@ class Person {
 ```
 
 
-@Comment {
+<!--
   - test: `howARCWorks`
   
   ```swifttest
@@ -88,7 +88,7 @@ class Person {
         }
      }
   ```
-}
+-->
 
 The `Person` class has an initializer that sets the instance's `name` property
 and prints a message to indicate that initialization is underway.
@@ -109,7 +109,7 @@ var reference3: Person?
 ```
 
 
-@Comment {
+<!--
   - test: `howARCWorks`
   
   ```swifttest
@@ -117,7 +117,7 @@ var reference3: Person?
   -> var reference2: Person?
   -> var reference3: Person?
   ```
-}
+-->
 
 You can now create a new `Person` instance
 and assign it to one of these three variables:
@@ -128,14 +128,14 @@ reference1 = Person(name: "John Appleseed")
 ```
 
 
-@Comment {
+<!--
   - test: `howARCWorks`
   
   ```swifttest
   -> reference1 = Person(name: "John Appleseed")
   <- John Appleseed is being initialized
   ```
-}
+-->
 
 Note that the message `"John Appleseed is being initialized"` is printed
 at the point that you call the `Person` class's initializer.
@@ -155,14 +155,14 @@ reference3 = reference1
 ```
 
 
-@Comment {
+<!--
   - test: `howARCWorks`
   
   ```swifttest
   -> reference2 = reference1
   -> reference3 = reference1
   ```
-}
+-->
 
 There are now *three* strong references to this single `Person` instance.
 
@@ -177,14 +177,14 @@ reference2 = nil
 ```
 
 
-@Comment {
+<!--
   - test: `howARCWorks`
   
   ```swifttest
   -> reference1 = nil
   -> reference2 = nil
   ```
-}
+-->
 
 ARC doesn't deallocate the `Person` instance until
 the third and final strong reference is broken,
@@ -196,14 +196,14 @@ reference3 = nil
 ```
 
 
-@Comment {
+<!--
   - test: `howARCWorks`
   
   ```swifttest
   -> reference3 = nil
   <- John Appleseed is being deinitialized
   ```
-}
+-->
 
 ## Strong Reference Cycles Between Class Instances
 
@@ -246,7 +246,7 @@ class Apartment {
 ```
 
 
-@Comment {
+<!--
   - test: `referenceCycles`
   
   ```swifttest
@@ -264,7 +264,7 @@ class Apartment {
         deinit { print("Apartment \(unit) is being deinitialized") }
      }
   ```
-}
+-->
 
 Every `Person` instance has a `name` property of type `String`
 and an optional `apartment` property that's initially `nil`.
@@ -290,14 +290,14 @@ var unit4A: Apartment?
 ```
 
 
-@Comment {
+<!--
   - test: `referenceCycles`
   
   ```swifttest
   -> var john: Person?
   -> var unit4A: Apartment?
   ```
-}
+-->
 
 You can now create a specific `Person` instance and `Apartment` instance
 and assign these new instances to the `john` and `unit4A` variables:
@@ -308,14 +308,14 @@ unit4A = Apartment(unit: "4A")
 ```
 
 
-@Comment {
+<!--
   - test: `referenceCycles`
   
   ```swifttest
   -> john = Person(name: "John Appleseed")
   -> unit4A = Apartment(unit: "4A")
   ```
-}
+-->
 
 Here's how the strong references look after creating and assigning these two instances.
 The `john` variable now has a strong reference to the new `Person` instance,
@@ -336,14 +336,14 @@ unit4A!.tenant = john
 ```
 
 
-@Comment {
+<!--
   - test: `referenceCycles`
   
   ```swifttest
   -> john!.apartment = unit4A
   -> unit4A!.tenant = john
   ```
-}
+-->
 
 Here's how the strong references look after you link the two instances together:
 
@@ -365,14 +365,14 @@ unit4A = nil
 ```
 
 
-@Comment {
+<!--
   - test: `referenceCycles`
   
   ```swifttest
   -> john = nil
   -> unit4A = nil
   ```
-}
+-->
 
 Note that neither deinitializer was called
 when you set these two variables to `nil`.
@@ -407,11 +407,11 @@ and so a weak reference is an appropriate way to break the reference cycle in th
 In contrast, use an unowned reference when the other instance
 has the same lifetime or a longer lifetime.
 
-@Comment {
+<!--
   QUESTION: how do I answer the question
   "which of the two properties in the reference cycle
   should be marked as weak or unowned?"
-}
+-->
 
 ### Weak References
 
@@ -439,7 +439,7 @@ a reference to an invalid instance that no longer exists.
 > Note: Property observers aren't called
 > when ARC sets a weak reference to `nil`.
 
-@Comment {
+<!--
   - test: `weak-reference-doesnt-trigger-didset`
   
   ```swifttest
@@ -456,7 +456,7 @@ a reference to an invalid instance that no longer exists.
   -> } // ARC deallocates c2; didSet doesn't fire.
   -> assert(c1.w == nil)
   ```
-}
+-->
 
 The example below is identical to the `Person` and `Apartment` example from above,
 with one important difference.
@@ -480,7 +480,7 @@ class Apartment {
 ```
 
 
-@Comment {
+<!--
   - test: `weakReferences`
   
   ```swifttest
@@ -498,7 +498,7 @@ class Apartment {
         deinit { print("Apartment \(unit) is being deinitialized") }
      }
   ```
-}
+-->
 
 The strong references from the two variables (`john` and `unit4A`)
 and the links between the two instances are created as before:
@@ -515,7 +515,7 @@ unit4A!.tenant = john
 ```
 
 
-@Comment {
+<!--
   - test: `weakReferences`
   
   ```swifttest
@@ -528,7 +528,7 @@ unit4A!.tenant = john
   -> john!.apartment = unit4A
   -> unit4A!.tenant = john
   ```
-}
+-->
 
 Here's how the references look now that you've linked the two instances together:
 
@@ -547,14 +547,14 @@ john = nil
 ```
 
 
-@Comment {
+<!--
   - test: `weakReferences`
   
   ```swifttest
   -> john = nil
   <- John Appleseed is being deinitialized
   ```
-}
+-->
 
 Because there are no more strong references to the `Person` instance,
 it's deallocated
@@ -574,14 +574,14 @@ unit4A = nil
 ```
 
 
-@Comment {
+<!--
   - test: `weakReferences`
   
   ```swifttest
   -> unit4A = nil
   <- Apartment 4A is being deinitialized
   ```
-}
+-->
 
 Because there are no more strong references to the `Apartment` instance,
 it too is deallocated:
@@ -614,26 +614,26 @@ As a result,
 marking a value as unowned doesn't make it optional,
 and ARC never sets an unowned reference's value to `nil`.
 
-@Comment {
+<!--
   Everything that unowned can do, weak can do slower and more awkwardly
   (but still correctly).
   Unowned is interesting because it's faster and easier (no optionals) ---
   in the cases where it's actually correct for your data.
-}
+-->
 
 > Important: Use an unowned reference only when you are sure that
 > the reference *always* refers to an instance that hasn't been deallocated.If you try to access the value of an unowned reference
 > after that instance has been deallocated,
 > you'll get a runtime error.
 
-@Comment {
+<!--
   One way to satisfy that requirement is to
   always access objects that have unmanaged properties through their owner
   instead of keeping a reference to them directly,
   because those direct references could outlive the owner.
   However... this strategy really only works when the unowned reference
   is a backpointer from an object up to its owner.
-}
+-->
 
 The following example defines two classes, `Customer` and `CreditCard`,
 which model a bank customer and a possible credit card for that customer.
@@ -681,7 +681,7 @@ class CreditCard {
 ```
 
 
-@Comment {
+<!--
   - test: `unownedReferences`
   
   ```swifttest
@@ -704,7 +704,7 @@ class CreditCard {
         deinit { print("Card #\(number) is being deinitialized") }
      }
   ```
-}
+-->
 
 > Note: The `number` property of the `CreditCard` class is defined with
 > a type of `UInt64` rather than `Int`,
@@ -720,13 +720,13 @@ var john: Customer?
 ```
 
 
-@Comment {
+<!--
   - test: `unownedReferences`
   
   ```swifttest
   -> var john: Customer?
   ```
-}
+-->
 
 You can now create a `Customer` instance,
 and use it to initialize and assign a new `CreditCard` instance
@@ -738,14 +738,14 @@ john!.card = CreditCard(number: 1234_5678_9012_3456, customer: john!)
 ```
 
 
-@Comment {
+<!--
   - test: `unownedReferences`
   
   ```swifttest
   -> john = Customer(name: "John Appleseed")
   -> john!.card = CreditCard(number: 1234_5678_9012_3456, customer: john!)
   ```
-}
+-->
 
 Here's how the references look, now that you've linked the two instances:
 
@@ -775,7 +775,7 @@ john = nil
 ```
 
 
-@Comment {
+<!--
   - test: `unownedReferences`
   
   ```swifttest
@@ -783,7 +783,7 @@ john = nil
   <- John Appleseed is being deinitialized
   <- Card #1234567890123456 is being deinitialized
   ```
-}
+-->
 
 The final code snippet above shows that
 the deinitializers for the `Customer` instance and `CreditCard` instance
@@ -802,10 +802,10 @@ after the `john` variable is set to `nil`.
 > where the instance used to be,
 > which is an unsafe operation.
 
-@Comment {
+<!--
   <rdar://problem/28805121> TSPL: ARC - Add discussion of "unowned" with different lifetimes
   Try expanding the example above so each customer has an array of credit cards.
-}
+-->
 
 ### Unowned Optional References
 
@@ -843,7 +843,7 @@ class Course {
 ```
 
 
-@Comment {
+<!--
   - test: `unowned-optional-references`
   
   ```swifttest
@@ -867,7 +867,7 @@ class Course {
          }
      }
   ```
-}
+-->
 
 `Department` maintains a strong reference
 to each course that the department offers.
@@ -897,7 +897,7 @@ department.courses = [intro, intermediate, advanced]
 ```
 
 
-@Comment {
+<!--
   - test: `unowned-optional-references`
   
   ```swifttest
@@ -911,7 +911,7 @@ department.courses = [intro, intermediate, advanced]
   -> intermediate.nextCourse = advanced
   -> department.courses = [intro, intermediate, advanced]
   ```
-}
+-->
 
 The code above creates a department and its three courses.
 The intro and intermediate courses both have a suggested next course
@@ -943,7 +943,7 @@ that other courses might have.
 > doesn't use reference counting,
 > so you don't need to maintain a strong reference to the optional.
 
-@Comment {
+<!--
   - test: `unowned-can-be-optional`
   
   ```swifttest
@@ -969,7 +969,7 @@ that other courses might have.
   >> print(d.b?.x as Any)
   << nil
   ```
-}
+-->
 
 ### Unowned References and Implicitly Unwrapped Optional Properties
 
@@ -1027,7 +1027,7 @@ class City {
 ```
 
 
-@Comment {
+<!--
   - test: `implicitlyUnwrappedOptionals`
   
   ```swifttest
@@ -1049,7 +1049,7 @@ class City {
         }
      }
   ```
-}
+-->
 
 To set up the interdependency between the two classes,
 the initializer for `City` takes a `Country` instance,
@@ -1090,7 +1090,7 @@ print("\(country.name)'s capital city is called \(country.capitalCity.name)")
 ```
 
 
-@Comment {
+<!--
   - test: `implicitlyUnwrappedOptionals`
   
   ```swifttest
@@ -1098,7 +1098,7 @@ print("\(country.name)'s capital city is called \(country.capitalCity.name)")
   -> print("\(country.name)'s capital city is called \(country.capitalCity.name)")
   <- Canada's capital city is called Ottawa
   ```
-}
+-->
 
 In the example above, the use of an implicitly unwrapped optional
 means that all of the two-phase class initializer requirements are satisfied.
@@ -1167,7 +1167,7 @@ class HTMLElement {
 ```
 
 
-@Comment {
+<!--
   - test: `strongReferenceCyclesForClosures`
   
   ```swifttest
@@ -1195,7 +1195,7 @@ class HTMLElement {
   ---
      }
   ```
-}
+-->
 
 The `HTMLElement` class defines a `name` property,
 which indicates the name of the element,
@@ -1240,7 +1240,7 @@ print(heading.asHTML())
 ```
 
 
-@Comment {
+<!--
   - test: `strongReferenceCyclesForClosures`
   
   ```swifttest
@@ -1252,7 +1252,7 @@ print(heading.asHTML())
   -> print(heading.asHTML())
   <- <h1>some default text</h1>
   ```
-}
+-->
 
 > Note: The `asHTML` property is declared as a lazy property,
 > because it's only needed if and when the element actually needs to be rendered
@@ -1277,7 +1277,7 @@ print(paragraph!.asHTML())
 ```
 
 
-@Comment {
+<!--
   - test: `strongReferenceCyclesForClosures`
   
   ```swifttest
@@ -1285,7 +1285,7 @@ print(paragraph!.asHTML())
   -> print(paragraph!.asHTML())
   <- <p>hello, world</p>
   ```
-}
+-->
 
 > Note: The `paragraph` variable above is defined as an *optional* `HTMLElement`,
 > so that it can be set to `nil` below to demonstrate
@@ -1321,13 +1321,13 @@ paragraph = nil
 ```
 
 
-@Comment {
+<!--
   - test: `strongReferenceCyclesForClosures`
   
   ```swifttest
   -> paragraph = nil
   ```
-}
+-->
 
 Note that the message in the `HTMLElement` deinitializer isn't printed,
 which shows that the `HTMLElement` instance isn't deallocated.
@@ -1368,7 +1368,7 @@ lazy var someClosure = {
 ```
 
 
-@Comment {
+<!--
   - test: `strongReferenceCyclesForClosures`
   
   ```swifttest
@@ -1382,7 +1382,7 @@ lazy var someClosure = {
      }
   >> }
   ```
-}
+-->
 
 If a closure doesn't specify a parameter list or return type
 because they can be inferred from context,
@@ -1397,7 +1397,7 @@ lazy var someClosure = {
 ```
 
 
-@Comment {
+<!--
   - test: `strongReferenceCyclesForClosures`
   
   ```swifttest
@@ -1410,7 +1410,7 @@ lazy var someClosure = {
      }
   >> }
   ```
-}
+-->
 
 ### Weak and Unowned References
 
@@ -1424,9 +1424,9 @@ Weak references are always of an optional type,
 and automatically become `nil` when the instance they reference is deallocated.
 This enables you to check for their existence within the closure's body.
 
-@Comment {
+<!--
   <rdar://problem/28812110> Reframe discussion of weak/unowned closure capture in terms of object graph
-}
+-->
 
 > Note: If the captured reference will never become `nil`,
 > it should always be captured as an unowned reference,
@@ -1465,7 +1465,7 @@ class HTMLElement {
 ```
 
 
-@Comment {
+<!--
   - test: `unownedReferencesForClosures`
   
   ```swifttest
@@ -1494,7 +1494,7 @@ class HTMLElement {
   ---
      }
   ```
-}
+-->
 
 This implementation of `HTMLElement` is identical to the previous implementation,
 apart from the addition of a capture list within the `asHTML` closure.
@@ -1510,7 +1510,7 @@ print(paragraph!.asHTML())
 ```
 
 
-@Comment {
+<!--
   - test: `unownedReferencesForClosures`
   
   ```swifttest
@@ -1518,7 +1518,7 @@ print(paragraph!.asHTML())
   -> print(paragraph!.asHTML())
   <- <p>hello, world</p>
   ```
-}
+-->
 
 Here's how the references look with the capture list in place:
 
@@ -1537,20 +1537,20 @@ paragraph = nil
 ```
 
 
-@Comment {
+<!--
   - test: `unownedReferencesForClosures`
   
   ```swifttest
   -> paragraph = nil
   <- p is being deinitialized
   ```
-}
+-->
 
 For more information about capture lists,
 see <doc:Expressions#Capture-Lists>.
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -1558,4 +1558,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/BasicOperators.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/BasicOperators.md
@@ -61,7 +61,7 @@ a = b
 ```
 
 
-@Comment {
+<!--
   - test: `assignmentOperator`
   
   ```swifttest
@@ -71,7 +71,7 @@ a = b
   /> a is now equal to \(a)
   </ a is now equal to 10
   ```
-}
+-->
 
 If the right side of the assignment is a tuple with multiple values,
 its elements can be decomposed into multiple constants or variables at once:
@@ -82,7 +82,7 @@ let (x, y) = (1, 2)
 ```
 
 
-@Comment {
+<!--
   - test: `assignmentOperator`
   
   ```swifttest
@@ -90,24 +90,24 @@ let (x, y) = (1, 2)
   /> x is equal to \(x), and y is equal to \(y)
   </ x is equal to 1, and y is equal to 2
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `tuple-unwrapping-with-var`
   
   ```swifttest
   >> var (x, y) = (1, 2)
   ```
-}
+-->
 
-@Comment {
+<!--
   This still allows assignment to variables,
   even though var patterns have been removed,
   because it's parsed as a variable-declaration,
   using the first alternative where (x, y) is a pattern,
   but `var` comes from the variable-declaration-head
   rather than from the pattern.
-}
+-->
 
 Unlike the assignment operator in C and Objective-C,
 the assignment operator in Swift doesn't itself return a value.
@@ -120,7 +120,7 @@ if x = y {
 ```
 
 
-@Comment {
+<!--
   - test: `assignmentOperatorInvalid`
   
   ```swifttest
@@ -134,17 +134,17 @@ if x = y {
   !! if x = y {
   !!        ^
   ```
-}
+-->
 
 This feature prevents the assignment operator (`=`) from being used by accident
 when the equal to operator (`==`) is actually intended.
 By making `if x = y` invalid,
 Swift helps you to avoid these kinds of errors in your code.
 
-@Comment {
+<!--
   TODO: Should we mention that x = y = z is also not valid?
   If so, is there a convincing argument as to why this is a good thing?
-}
+-->
 
 ## Arithmetic Operators
 
@@ -163,7 +163,7 @@ Swift supports the four standard *arithmetic operators* for all number types:
 ```
 
 
-@Comment {
+<!--
   - test: `arithmeticOperators`
   
   ```swifttest
@@ -180,7 +180,7 @@ Swift supports the four standard *arithmetic operators* for all number types:
   -> 10.0 / 2.5  // equals 4.0
   >> assert(r3 == 4.0)
   ```
-}
+-->
 
 Unlike the arithmetic operators in C and Objective-C,
 the Swift arithmetic operators don't allow values to overflow by default.
@@ -194,7 +194,7 @@ The addition operator is also supported for `String` concatenation:
 ```
 
 
-@Comment {
+<!--
   - test: `arithmeticOperators`
   
   ```swifttest
@@ -202,7 +202,7 @@ The addition operator is also supported for `String` concatenation:
   -> "hello, " + "world"  // equals "hello, world"
   >> assert(r4 == "hello, world")
   ```
-}
+-->
 
 ### Remainder Operator
 
@@ -216,7 +216,7 @@ and returns the value that's left over
 > However, its behavior in Swift for negative numbers means that,
 > strictly speaking, it's a remainder rather than a modulo operation.
 
-@Comment {
+<!--
   - test: `percentOperatorIsRemainderNotModulo`
   
   ```swifttest
@@ -230,7 +230,7 @@ and returns the value that's left over
   << -1
   << 0
   ```
-}
+-->
 
 Here's how the remainder operator works.
 To calculate `9 % 4`, you first work out how many `4`s will fit inside `9`:
@@ -247,7 +247,7 @@ In Swift, this would be written as:
 ```
 
 
-@Comment {
+<!--
   - test: `arithmeticOperators`
   
   ```swifttest
@@ -255,7 +255,7 @@ In Swift, this would be written as:
   -> 9 % 4    // equals 1
   >> assert(r5 == 1)
   ```
-}
+-->
 
 To determine the answer for `a % b`,
 the `%` operator calculates the following equation
@@ -277,7 +277,7 @@ The same method is applied when calculating the remainder for a negative value o
 ```
 
 
-@Comment {
+<!--
   - test: `arithmeticOperators`
   
   ```swifttest
@@ -285,7 +285,7 @@ The same method is applied when calculating the remainder for a negative value o
   -> -9 % 4   // equals -1
   >> assert(r6 == -1)
   ```
-}
+-->
 
 Inserting `-9` and `4` into the equation yields:
 
@@ -308,7 +308,7 @@ let plusThree = -minusThree   // plusThree equals 3, or "minus minus three"
 ```
 
 
-@Comment {
+<!--
   - test: `arithmeticOperators`
   
   ```swifttest
@@ -316,7 +316,7 @@ let plusThree = -minusThree   // plusThree equals 3, or "minus minus three"
   -> let minusThree = -three       // minusThree equals -3
   -> let plusThree = -minusThree   // plusThree equals 3, or "minus minus three"
   ```
-}
+-->
 
 The unary minus operator (`-`) is prepended directly before the value it operates on,
 without any white space.
@@ -332,7 +332,7 @@ let alsoMinusSix = +minusSix  // alsoMinusSix equals -6
 ```
 
 
-@Comment {
+<!--
   - test: `arithmeticOperators`
   
   ```swifttest
@@ -340,7 +340,7 @@ let alsoMinusSix = +minusSix  // alsoMinusSix equals -6
   -> let alsoMinusSix = +minusSix  // alsoMinusSix equals -6
   >> assert(alsoMinusSix == minusSix)
   ```
-}
+-->
 
 Although the unary plus operator doesn't actually do anything,
 you can use it to provide symmetry in your code for positive numbers
@@ -358,7 +358,7 @@ a += 2
 ```
 
 
-@Comment {
+<!--
   - test: `compoundAssignment`
   
   ```swifttest
@@ -367,7 +367,7 @@ a += 2
   /> a is now equal to \(a)
   </ a is now equal to 3
   ```
-}
+-->
 
 The expression `a += 2` is shorthand for `a = a + 2`.
 Effectively, the addition and the assignment are combined into one operator
@@ -406,7 +406,7 @@ Each of the comparison operators returns a `Bool` value to indicate whether or n
 ```
 
 
-@Comment {
+<!--
   - test: `comparisonOperators`
   
   ```swifttest
@@ -429,7 +429,7 @@ Each of the comparison operators returns a `Bool` value to indicate whether or n
   -> 2 <= 1   // false because 2 isn't less than or equal to 1
   >> ) )
   ```
-}
+-->
 
 Comparison operators are often used in conditional statements,
 such as the `if` statement:
@@ -445,7 +445,7 @@ if name == "world" {
 ```
 
 
-@Comment {
+<!--
   - test: `comparisonOperators`
   
   ```swifttest
@@ -458,7 +458,7 @@ if name == "world" {
   << hello, world
   // Prints "hello, world", because name is indeed equal to "world".
   ```
-}
+-->
 
 For more about the `if` statement, see <doc:ControlFlow>.
 
@@ -482,7 +482,7 @@ For example:
 ```
 
 
-@Comment {
+<!--
   - test: `tuple-comparison-operators`
   
   ```swifttest
@@ -495,7 +495,7 @@ For example:
   >> print(a, b, c)
   << true true true
   ```
-}
+-->
 
 In the example above,
 you can see the left-to-right comparison behavior on the first line.
@@ -525,7 +525,7 @@ with the `<` operator because the `<` operator can't be applied to
 ```
 
 
-@Comment {
+<!--
   - test: `tuple-comparison-operators-err`
   
   ```swifttest
@@ -543,9 +543,9 @@ with the `<` operator because the `<` operator can't be applied to
   !! ("blue", false) < ("purple", true)  // Error because < can't compare Boolean values
   !!                 ^
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `tuple-comparison-operators-ok`
   
   ```swifttest
@@ -553,18 +553,18 @@ with the `<` operator because the `<` operator can't be applied to
   >> print(x)
   << true
   ```
-}
+-->
 
 > Note: The Swift standard library includes tuple comparison operators
 > for tuples with fewer than seven elements.
 > To compare tuples with seven or more elements,
 > you must implement the comparison operators yourself.
 
-@Comment {
+<!--
   TODO: which types do these operate on by default?
   How do they work with strings?
   How about with your own types?
-}
+-->
 
 ## Ternary Conditional Operator
 
@@ -586,7 +586,7 @@ if question {
 ```
 
 
-@Comment {
+<!--
   - test: `ternaryConditionalOperatorOutline`
   
   ```swifttest
@@ -605,12 +605,12 @@ if question {
   !! answer2
   !! ^~~~~~~
   ```
-}
+-->
 
-@Comment {
+<!--
   FIXME This example has too much hand waving.
   Swift doesn't have 'if' expressions.
-}
+-->
 
 Here's an example, which calculates the height for a table row.
 The row height should be 50 points taller than the content height
@@ -624,7 +624,7 @@ let rowHeight = contentHeight + (hasHeader ? 50 : 20)
 ```
 
 
-@Comment {
+<!--
   - test: `ternaryConditionalOperatorPart1`
   
   ```swifttest
@@ -634,7 +634,7 @@ let rowHeight = contentHeight + (hasHeader ? 50 : 20)
   /> rowHeight is equal to \(rowHeight)
   </ rowHeight is equal to 90
   ```
-}
+-->
 
 The example above is shorthand for the code below:
 
@@ -651,7 +651,7 @@ if hasHeader {
 ```
 
 
-@Comment {
+<!--
   - test: `ternaryConditionalOperatorPart2`
   
   ```swifttest
@@ -666,7 +666,7 @@ if hasHeader {
   /> rowHeight is equal to \(rowHeight)
   </ rowHeight is equal to 90
   ```
-}
+-->
 
 The first example's use of the ternary conditional operator means that
 `rowHeight` can be set to the correct value on a single line of code,
@@ -693,7 +693,7 @@ a != nil ? a! : b
 ```
 
 
-@Comment {
+<!--
   - test: `nilCoalescingOperatorOutline`
   
   ```swifttest
@@ -704,7 +704,7 @@ a != nil ? a! : b
   >> print(c)
   << 42
   ```
-}
+-->
 
 The code above uses the ternary conditional operator and forced unwrapping (`a!`)
 to access the value wrapped inside `a` when `a` isn't `nil`,
@@ -728,7 +728,7 @@ var colorNameToUse = userDefinedColorName ?? defaultColorName
 ```
 
 
-@Comment {
+<!--
   - test: `nilCoalescingOperator`
   
   ```swifttest
@@ -739,7 +739,7 @@ var colorNameToUse = userDefinedColorName ?? defaultColorName
   /> userDefinedColorName is nil, so colorNameToUse is set to the default of \"\(colorNameToUse)\"
   </ userDefinedColorName is nil, so colorNameToUse is set to the default of "red"
   ```
-}
+-->
 
 The `userDefinedColorName` variable is defined as an optional `String`,
 with a default value of `nil`.
@@ -762,7 +762,7 @@ colorNameToUse = userDefinedColorName ?? defaultColorName
 ```
 
 
-@Comment {
+<!--
   - test: `nilCoalescingOperator`
   
   ```swifttest
@@ -771,7 +771,7 @@ colorNameToUse = userDefinedColorName ?? defaultColorName
   /> userDefinedColorName isn't nil, so colorNameToUse is set to \"\(colorNameToUse)\"
   </ userDefinedColorName isn't nil, so colorNameToUse is set to "green"
   ```
-}
+-->
 
 ## Range Operators
 
@@ -785,7 +785,7 @@ defines a range that runs from `a` to `b`,
 and includes the values `a` and `b`.
 The value of `a` must not be greater than `b`.
 
-@Comment {
+<!--
   - test: `closedRangeStartCanBeLessThanEnd`
   
   ```swifttest
@@ -793,24 +793,24 @@ The value of `a` must not be greater than `b`.
   >> print(type(of: range))
   << ClosedRange<Int>
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `closedRangeStartCanBeTheSameAsEnd`
   
   ```swifttest
   -> let range = 1...1
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `closedRangeStartCannotBeGreaterThanEnd`
   
   ```swifttest
   -> let range = 1...0
   xx assertion
   ```
-}
+-->
 
 The closed range operator is useful when iterating over a range
 in which you want all of the values to be used,
@@ -828,7 +828,7 @@ for index in 1...5 {
 ```
 
 
-@Comment {
+<!--
   - test: `rangeOperators`
   
   ```swifttest
@@ -841,7 +841,7 @@ for index in 1...5 {
   </ 4 times 5 is 20
   </ 5 times 5 is 25
   ```
-}
+-->
 
 For more about `for`-`in` loops, see <doc:ControlFlow>.
 
@@ -857,7 +857,7 @@ the value of `a` must not be greater than `b`.
 If the value of `a` is equal to `b`,
 then the resulting range will be empty.
 
-@Comment {
+<!--
   - test: `halfOpenRangeStartCanBeLessThanEnd`
   
   ```swifttest
@@ -865,24 +865,24 @@ then the resulting range will be empty.
   >> print(type(of: range))
   << Range<Int>
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `halfOpenRangeStartCanBeTheSameAsEnd`
   
   ```swifttest
   -> let range = 1..<1
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `halfOpenRangeStartCannotBeGreaterThanEnd`
   
   ```swifttest
   -> let range = 1..<0
   xx assertion
   ```
-}
+-->
 
 Half-open ranges are particularly useful when you work with
 zero-based lists such as arrays,
@@ -901,7 +901,7 @@ for i in 0..<count {
 ```
 
 
-@Comment {
+<!--
   - test: `rangeOperators`
   
   ```swifttest
@@ -916,7 +916,7 @@ for i in 0..<count {
   </ Person 3 is called Brian
   </ Person 4 is called Jack
   ```
-}
+-->
 
 Note that the array contains four items,
 but `0..<count` only counts as far as `3`
@@ -954,7 +954,7 @@ for name in names[...2] {
 ```
 
 
-@Comment {
+<!--
   - test: `rangeOperators`
   
   ```swifttest
@@ -971,7 +971,7 @@ for name in names[...2] {
   </ Alex
   </ Brian
   ```
-}
+-->
 
 The half-open range operator also has
 a one-sided form that's written
@@ -989,7 +989,7 @@ for name in names[..<2] {
 ```
 
 
-@Comment {
+<!--
   - test: `rangeOperators`
   
   ```swifttest
@@ -999,7 +999,7 @@ for name in names[..<2] {
   </ Anna
   </ Alex
   ```
-}
+-->
 
 One-sided ranges can be used in other contexts,
 not just in subscripts.
@@ -1020,7 +1020,7 @@ range.contains(-1)  // true
 ```
 
 
-@Comment {
+<!--
   - test: `rangeOperators`
   
   ```swifttest
@@ -1036,7 +1036,7 @@ range.contains(-1)  // true
   >> print(a, b, c)
   << false true true
   ```
-}
+-->
 
 ## Logical Operators
 
@@ -1067,7 +1067,7 @@ if !allowedEntry {
 ```
 
 
-@Comment {
+<!--
   - test: `logicalOperators`
   
   ```swifttest
@@ -1077,7 +1077,7 @@ if !allowedEntry {
      }
   <- ACCESS DENIED
   ```
-}
+-->
 
 The phrase `if !allowedEntry` can be read as “if not allowed entry.”
 The subsequent line is only executed if “not allowed entry” is true;
@@ -1115,7 +1115,7 @@ if enteredDoorCode && passedRetinaScan {
 ```
 
 
-@Comment {
+<!--
   - test: `logicalOperators`
   
   ```swifttest
@@ -1128,7 +1128,7 @@ if enteredDoorCode && passedRetinaScan {
      }
   <- ACCESS DENIED
   ```
-}
+-->
 
 ### Logical OR Operator
 
@@ -1163,7 +1163,7 @@ if hasDoorKey || knowsOverridePassword {
 ```
 
 
-@Comment {
+<!--
   - test: `logicalOperators`
   
   ```swifttest
@@ -1176,7 +1176,7 @@ if hasDoorKey || knowsOverridePassword {
      }
   <- Welcome!
   ```
-}
+-->
 
 ### Combining Logical Operators
 
@@ -1192,7 +1192,7 @@ if enteredDoorCode && passedRetinaScan || hasDoorKey || knowsOverridePassword {
 ```
 
 
-@Comment {
+<!--
   - test: `logicalOperators`
   
   ```swifttest
@@ -1203,7 +1203,7 @@ if enteredDoorCode && passedRetinaScan || hasDoorKey || knowsOverridePassword {
      }
   <- Welcome!
   ```
-}
+-->
 
 This example uses multiple `&&` and `||` operators to create a longer compound expression.
 However, the `&&` and `||` operators still operate on only two values,
@@ -1242,7 +1242,7 @@ if (enteredDoorCode && passedRetinaScan) || hasDoorKey || knowsOverridePassword 
 ```
 
 
-@Comment {
+<!--
   - test: `logicalOperators`
   
   ```swifttest
@@ -1253,7 +1253,7 @@ if (enteredDoorCode && passedRetinaScan) || hasDoorKey || knowsOverridePassword 
      }
   <- Welcome!
   ```
-}
+-->
 
 The parentheses make it clear that the first two values
 are considered as part of a separate possible state in the overall logic.
@@ -1263,7 +1263,7 @@ Readability is always preferred over brevity;
 use parentheses where they help to make your intentions clear.
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -1271,4 +1271,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/ClassesAndStructures.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/ClassesAndStructures.md
@@ -78,7 +78,7 @@ class SomeClass {
 ```
 
 
-@Comment {
+<!--
   - test: `ClassesAndStructures`
   
   ```swifttest
@@ -89,7 +89,7 @@ class SomeClass {
         // class definition goes here
      }
   ```
-}
+-->
 
 > Note: Whenever you define a new structure or class,
 > you define a new Swift type.
@@ -117,7 +117,7 @@ class VideoMode {
 ```
 
 
-@Comment {
+<!--
   - test: `ClassesAndStructures`
   
   ```swifttest
@@ -132,7 +132,7 @@ class VideoMode {
         var name: String?
      }
   ```
-}
+-->
 
 The example above defines a new structure called `Resolution`,
 to describe a pixel-based display resolution.
@@ -170,14 +170,14 @@ let someVideoMode = VideoMode()
 ```
 
 
-@Comment {
+<!--
   - test: `ClassesAndStructures`
   
   ```swifttest
   -> let someResolution = Resolution()
   -> let someVideoMode = VideoMode()
   ```
-}
+-->
 
 Structures and classes both use initializer syntax for new instances.
 The simplest form of initializer syntax uses the type name of the class or structure
@@ -187,10 +187,10 @@ with any properties initialized to their default values.
 Class and structure initialization is described in more detail
 in <doc:Initialization>.
 
-@Comment {
+<!--
   TODO: note that you can only use the default constructor if you provide default values
   for all properties on a structure or class.
-}
+-->
 
 ### Accessing Properties
 
@@ -204,14 +204,14 @@ print("The width of someResolution is \(someResolution.width)")
 ```
 
 
-@Comment {
+<!--
   - test: `ClassesAndStructures`
   
   ```swifttest
   -> print("The width of someResolution is \(someResolution.width)")
   <- The width of someResolution is 0
   ```
-}
+-->
 
 In this example,
 `someResolution.width` refers to the `width` property of `someResolution`,
@@ -226,14 +226,14 @@ print("The width of someVideoMode is \(someVideoMode.resolution.width)")
 ```
 
 
-@Comment {
+<!--
   - test: `ClassesAndStructures`
   
   ```swifttest
   -> print("The width of someVideoMode is \(someVideoMode.resolution.width)")
   <- The width of someVideoMode is 0
   ```
-}
+-->
 
 You can also use dot syntax to assign a new value to a variable property:
 
@@ -244,7 +244,7 @@ print("The width of someVideoMode is now \(someVideoMode.resolution.width)")
 ```
 
 
-@Comment {
+<!--
   - test: `ClassesAndStructures`
   
   ```swifttest
@@ -252,7 +252,7 @@ print("The width of someVideoMode is now \(someVideoMode.resolution.width)")
   -> print("The width of someVideoMode is now \(someVideoMode.resolution.width)")
   <- The width of someVideoMode is now 1280
   ```
-}
+-->
 
 ### Memberwise Initializers for Structure Types
 
@@ -266,18 +266,18 @@ let vga = Resolution(width: 640, height: 480)
 ```
 
 
-@Comment {
+<!--
   - test: `ClassesAndStructures`
   
   ```swifttest
   -> let vga = Resolution(width: 640, height: 480)
   ```
-}
+-->
 
 Unlike structures, class instances don't receive a default memberwise initializer.
 Initializers are described in more detail in <doc:Initialization>.
 
-@Comment {
+<!--
   - test: `classesDontHaveADefaultMemberwiseInitializer`
   
   ```swifttest
@@ -288,7 +288,7 @@ Initializers are described in more detail in <doc:Initialization>.
   !!         ^~~~~~~~~~~~
   !!-
   ```
-}
+-->
 
 ## Structures and Enumerations Are Value Types
 
@@ -296,12 +296,12 @@ A *value type* is a type whose value is *copied*
 when it's assigned to a variable or constant,
 or when it's passed to a function.
 
-@Comment {
+<!--
   Alternate definition:
   A type has value semantics when
   mutation of one variable of that type
   can never be observed through a different variable of the same type.
-}
+-->
 
 You've actually been using value types extensively throughout the previous chapters.
 In fact, all of the basic types in Swift ---
@@ -332,14 +332,14 @@ var cinema = hd
 ```
 
 
-@Comment {
+<!--
   - test: `ClassesAndStructures`
   
   ```swifttest
   -> let hd = Resolution(width: 1920, height: 1080)
   -> var cinema = hd
   ```
-}
+-->
 
 This example declares a constant called `hd`
 and sets it to a `Resolution` instance initialized with
@@ -363,13 +363,13 @@ cinema.width = 2048
 ```
 
 
-@Comment {
+<!--
   - test: `ClassesAndStructures`
   
   ```swifttest
   -> cinema.width = 2048
   ```
-}
+-->
 
 Checking the `width` property of `cinema`
 shows that it has indeed changed to be `2048`:
@@ -380,14 +380,14 @@ print("cinema is now \(cinema.width) pixels wide")
 ```
 
 
-@Comment {
+<!--
   - test: `ClassesAndStructures`
   
   ```swifttest
   -> print("cinema is now \(cinema.width) pixels wide")
   <- cinema is now 2048 pixels wide
   ```
-}
+-->
 
 However, the `width` property of the original `hd` instance
 still has the old value of `1920`:
@@ -398,14 +398,14 @@ print("hd is still \(hd.width) pixels wide")
 ```
 
 
-@Comment {
+<!--
   - test: `ClassesAndStructures`
   
   ```swifttest
   -> print("hd is still \(hd.width) pixels wide")
   <- hd is still 1920 pixels wide
   ```
-}
+-->
 
 When `cinema` was given the current value of `hd`,
 the *values* stored in `hd` were copied into the new `cinema` instance.
@@ -439,7 +439,7 @@ print("The remembered direction is \(rememberedDirection)")
 ```
 
 
-@Comment {
+<!--
   - test: `ClassesAndStructures`
   
   ```swifttest
@@ -458,16 +458,16 @@ print("The remembered direction is \(rememberedDirection)")
   <- The current direction is north
   <- The remembered direction is west
   ```
-}
+-->
 
 When `rememberedDirection` is assigned the value of `currentDirection`,
 it's actually set to a copy of that value.
 Changing the value of `currentDirection` thereafter doesn't affect
 the copy of the original value that was stored in `rememberedDirection`.
 
-@Comment {
+<!--
   TODO: Should I give an example of passing a value type to a function here?
-}
+-->
 
 ## Classes Are Reference Types
 
@@ -487,7 +487,7 @@ tenEighty.frameRate = 25.0
 ```
 
 
-@Comment {
+<!--
   - test: `ClassesAndStructures`
   
   ```swifttest
@@ -497,7 +497,7 @@ tenEighty.frameRate = 25.0
   -> tenEighty.name = "1080i"
   -> tenEighty.frameRate = 25.0
   ```
-}
+-->
 
 This example declares a new constant called `tenEighty`
 and sets it to refer to a new instance of the `VideoMode` class.
@@ -515,14 +515,14 @@ alsoTenEighty.frameRate = 30.0
 ```
 
 
-@Comment {
+<!--
   - test: `ClassesAndStructures`
   
   ```swifttest
   -> let alsoTenEighty = tenEighty
   -> alsoTenEighty.frameRate = 30.0
   ```
-}
+-->
 
 Because classes are reference types,
 `tenEighty` and `alsoTenEighty` actually both refer to the *same* `VideoMode` instance.
@@ -542,14 +542,14 @@ print("The frameRate property of tenEighty is now \(tenEighty.frameRate)")
 ```
 
 
-@Comment {
+<!--
   - test: `ClassesAndStructures`
   
   ```swifttest
   -> print("The frameRate property of tenEighty is now \(tenEighty.frameRate)")
   <- The frameRate property of tenEighty is now 30.0
   ```
-}
+-->
 
 This example also shows how reference types can be harder to reason about.
 If `tenEighty` and `alsoTenEighty` were far apart in your program's code,
@@ -570,21 +570,21 @@ instead, they both *refer* to a `VideoMode` instance behind the scenes.
 It's the `frameRate` property of the underlying `VideoMode` that's changed,
 not the values of the constant references to that `VideoMode`.
 
-@Comment {
+<!--
   TODO: reiterate here that arrays and dictionaries are value types rather than reference types,
   and demonstrate what that means for the values they store
   when they themselves are value types or reference types.
   Also make a note about what this means for key copying,
   as per the swift-discuss email thread "Dictionaries and key copying"
   started by Alex Migicovsky on Mar 1 2014.
-}
+-->
 
-@Comment {
+<!--
   TODO: Add discussion about how
   a struct that has a member of some reference type
   is itself actually a reference type,
   and about how you can make a class that's a value type.
-}
+-->
 
 ### Identity Operators
 
@@ -595,7 +595,7 @@ the same single instance of a class behind the scenes.
 because they're always copied when they're assigned to a constant or variable,
 or passed to a function.)
 
-@Comment {
+<!--
   - test: `structuresDontSupportTheIdentityOperators`
   
   ```swifttest
@@ -610,9 +610,9 @@ or passed to a function.)
   !! if s1 === s2 { print("s1 === s2") } else { print("s1 !== s2") }
   !!       ^
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `enumerationsDontSupportTheIdentityOperators`
   
   ```swifttest
@@ -627,7 +627,7 @@ or passed to a function.)
   !! if e1 === e2 { print("e1 === e2") } else { print("e1 !== e2") }
   !!       ^
   ```
-}
+-->
 
 It can sometimes be useful to find out whether two constants or variables refer to
 exactly the same instance of a class.
@@ -646,7 +646,7 @@ if tenEighty === alsoTenEighty {
 ```
 
 
-@Comment {
+<!--
   - test: `ClassesAndStructures`
   
   ```swifttest
@@ -655,7 +655,7 @@ if tenEighty === alsoTenEighty {
      }
   <- tenEighty and alsoTenEighty refer to the same VideoMode instance.
   ```
-}
+-->
 
 Note that *identical to* (represented by three equals signs, or `===`)
 doesn't mean the same thing as *equal to* (represented by two equals signs, or `==`).
@@ -670,7 +670,7 @@ it's your responsibility to decide what qualifies as two instances being equal.
 The process of defining your own implementations of the `==` and `!=` operators
 is described in <doc:AdvancedOperators#Equivalence-Operators>.
 
-@Comment {
+<!--
   - test: `classesDontGetEqualityByDefault`
   
   ```swifttest
@@ -682,9 +682,9 @@ is described in <doc:AdvancedOperators#Equivalence-Operators>.
   !! if c1 == c2 { print("c1 == c2") } else { print("c1 != c2") }
   !!    ~~ ^  ~~
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `structuresDontGetEqualityByDefault`
   
   ```swifttest
@@ -696,11 +696,11 @@ is described in <doc:AdvancedOperators#Equivalence-Operators>.
   !! if s1 == s2 { print("s1 == s2") } else { print("s1 != s2") }
   !!    ~~ ^  ~~
   ```
-}
+-->
 
-@Comment {
+<!--
   TODO: This needs clarifying with regards to function references.
-}
+-->
 
 ### Pointers
 
@@ -716,20 +716,20 @@ The standard library provides pointer and buffer types
 that you can use if you need to interact with pointers directly ---
 see [Manual Memory Management](https://developer.apple.com/documentation/swift/swift_standard_library/manual_memory_management).
 
-@Comment {
+<!--
   TODO: functions aren't "instances". This needs clarifying.
-}
+-->
 
-@Comment {
+<!--
   TODO: Add a justification here to say why this is a good thing.
-}
+-->
 
-@Comment {
+<!--
   QUESTION: what's the deal with tuples and reference types / value types?
-}
+-->
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -737,4 +737,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Closures.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Closures.md
@@ -71,13 +71,13 @@ let names = ["Chris", "Alex", "Ewa", "Barry", "Daniella"]
 ```
 
 
-@Comment {
+<!--
   - test: `closureSyntax`
   
   ```swifttest
   -> let names = ["Chris", "Alex", "Ewa", "Barry", "Daniella"]
   ```
-}
+-->
 
 The `sorted(by:)` method accepts a closure that takes two arguments
 of the same type as the array's contents,
@@ -102,7 +102,7 @@ var reversedNames = names.sorted(by: backward)
 ```
 
 
-@Comment {
+<!--
   - test: `closureSyntax`
   
   ```swifttest
@@ -113,7 +113,7 @@ var reversedNames = names.sorted(by: backward)
   /> reversedNames is equal to \(reversedNames)
   </ reversedNames is equal to ["Ewa", "Daniella", "Chris", "Barry", "Alex"]
   ```
-}
+-->
 
 If the first string (`s1`) is greater than the second string (`s2`),
 the `backward(_:_:)` function will return `true`,
@@ -157,7 +157,7 @@ reversedNames = names.sorted(by: { (s1: String, s2: String) -> Bool in
 ```
 
 
-@Comment {
+<!--
   - test: `closureSyntax`
   
   ```swifttest
@@ -166,7 +166,7 @@ reversedNames = names.sorted(by: { (s1: String, s2: String) -> Bool in
      })
   >> assert(reversedNames == ["Ewa", "Daniella", "Chris", "Barry", "Alex"])
   ```
-}
+-->
 
 Note that the declaration of parameters and return type for this inline closure
 is identical to the declaration from the `backward(_:_:)` function.
@@ -188,14 +188,14 @@ reversedNames = names.sorted(by: { (s1: String, s2: String) -> Bool in return s1
 ```
 
 
-@Comment {
+<!--
   - test: `closureSyntax`
   
   ```swifttest
   -> reversedNames = names.sorted(by: { (s1: String, s2: String) -> Bool in return s1 > s2 } )
   >> assert(reversedNames == ["Ewa", "Daniella", "Chris", "Barry", "Alex"])
   ```
-}
+-->
 
 This illustrates that the overall call to the `sorted(by:)` method has remained the same.
 A pair of parentheses still wrap the entire argument for the method.
@@ -219,14 +219,14 @@ reversedNames = names.sorted(by: { s1, s2 in return s1 > s2 } )
 ```
 
 
-@Comment {
+<!--
   - test: `closureSyntax`
   
   ```swifttest
   -> reversedNames = names.sorted(by: { s1, s2 in return s1 > s2 } )
   >> assert(reversedNames == ["Ewa", "Daniella", "Chris", "Barry", "Alex"])
   ```
-}
+-->
 
 It's always possible to infer the parameter types and return type
 when passing a closure to a function or method as an inline closure expression.
@@ -252,14 +252,14 @@ reversedNames = names.sorted(by: { s1, s2 in s1 > s2 } )
 ```
 
 
-@Comment {
+<!--
   - test: `closureSyntax`
   
   ```swifttest
   -> reversedNames = names.sorted(by: { s1, s2 in s1 > s2 } )
   >> assert(reversedNames == ["Ewa", "Daniella", "Chris", "Barry", "Alex"])
   ```
-}
+-->
 
 Here, the function type of the `sorted(by:)` method's argument
 makes it clear that a `Bool` value must be returned by the closure.
@@ -287,14 +287,14 @@ reversedNames = names.sorted(by: { $0 > $1 } )
 ```
 
 
-@Comment {
+<!--
   - test: `closureSyntax`
   
   ```swifttest
   -> reversedNames = names.sorted(by: { $0 > $1 } )
   >> assert(reversedNames == ["Ewa", "Daniella", "Chris", "Barry", "Alex"])
   ```
-}
+-->
 
 Here, `$0` and `$1` refer to the closure's first and second `String` arguments.
 Because `$1` is the shorthand argument with highest number,
@@ -303,7 +303,7 @@ Because the `sorted(by:)` function here expects a closure
 whose arguments are both strings,
 the shorthand arguments `$0` and `$1` are both of type `String`.
 
-@Comment {
+<!--
   - test: `closure-syntax-arity-inference`
   
   ```swifttest
@@ -315,7 +315,7 @@ the shorthand arguments `$0` and `$1` are both of type `String`.
   !! b.merge(a, uniquingKeysWith: { $0 })
   !! ^
   ```
-}
+-->
 
 ### Operator Methods
 
@@ -333,14 +333,14 @@ reversedNames = names.sorted(by: >)
 ```
 
 
-@Comment {
+<!--
   - test: `closureSyntax`
   
   ```swifttest
   -> reversedNames = names.sorted(by: >)
   >> assert(reversedNames == ["Ewa", "Daniella", "Chris", "Barry", "Alex"])
   ```
-}
+-->
 
 For more about operator methods, see <doc:AdvancedOperators#Operator-Methods>.
 
@@ -376,7 +376,7 @@ someFunctionThatTakesAClosure() {
 ```
 
 
-@Comment {
+<!--
   - test: `closureSyntax`
   
   ```swifttest
@@ -396,7 +396,7 @@ someFunctionThatTakesAClosure() {
         // trailing closure's body goes here
      }
   ```
-}
+-->
 
 The string-sorting closure from the <doc:Closures#Closure-Expression-Syntax> section above
 can be written outside of the `sorted(by:)` method's parentheses as a trailing closure:
@@ -406,14 +406,14 @@ reversedNames = names.sorted() { $0 > $1 }
 ```
 
 
-@Comment {
+<!--
   - test: `closureSyntax`
   
   ```swifttest
   -> reversedNames = names.sorted() { $0 > $1 }
   >> assert(reversedNames == ["Ewa", "Daniella", "Chris", "Barry", "Alex"])
   ```
-}
+-->
 
 If a closure expression is provided as the function's or method's only argument
 and you provide that expression as a trailing closure,
@@ -425,14 +425,14 @@ reversedNames = names.sorted { $0 > $1 }
 ```
 
 
-@Comment {
+<!--
   - test: `closureSyntax`
   
   ```swifttest
   -> reversedNames = names.sorted { $0 > $1 }
   >> assert(reversedNames == ["Ewa", "Daniella", "Chris", "Barry", "Alex"])
   ```
-}
+-->
 
 Trailing closures are most useful when the closure is sufficiently long that
 it isn't possible to write it inline on a single line.
@@ -462,7 +462,7 @@ let numbers = [16, 58, 510]
 ```
 
 
-@Comment {
+<!--
   - test: `arrayMap`
   
   ```swifttest
@@ -472,7 +472,7 @@ let numbers = [16, 58, 510]
      ]
   -> let numbers = [16, 58, 510]
   ```
-}
+-->
 
 The code above creates a dictionary of mappings between
 the integer digits and English-language versions of their names.
@@ -496,7 +496,7 @@ let strings = numbers.map { (number) -> String in
 ```
 
 
-@Comment {
+<!--
   - test: `arrayMap`
   
   ```swifttest
@@ -513,7 +513,7 @@ let strings = numbers.map { (number) -> String in
   /> its value is [\"\(strings[0])\", \"\(strings[1])\", \"\(strings[2])\"]
   </ its value is ["OneSix", "FiveEight", "FiveOneZero"]
   ```
-}
+-->
 
 The `map(_:)` method calls the closure expression once for each item in the array.
 You don't need to specify the type of the closure's input parameter, `number`,
@@ -577,7 +577,7 @@ func loadPicture(from server: Server, completion: (Picture) -> Void, onFailure: 
 ```
 
 
-@Comment {
+<!--
   - test: `multiple-trailing-closures`
   
   ```swifttest
@@ -594,7 +594,7 @@ func loadPicture(from server: Server, completion: (Picture) -> Void, onFailure: 
          }
      }
   ```
-}
+-->
 
 When you call this function to load a picture,
 you provide two closures.
@@ -612,7 +612,7 @@ loadPicture(from: someServer) { picture in
 ```
 
 
-@Comment {
+<!--
   - test: `multiple-trailing-closures`
   
   ```swifttest
@@ -628,7 +628,7 @@ loadPicture(from: someServer) { picture in
      }
   << Changed picture
   ```
-}
+-->
 
 In this example,
 the `loadPicture(from:completion:onFailure:)` function
@@ -678,7 +678,7 @@ func makeIncrementer(forIncrement amount: Int) -> () -> Int {
 ```
 
 
-@Comment {
+<!--
   - test: `closures`
   
   ```swifttest
@@ -691,7 +691,7 @@ func makeIncrementer(forIncrement amount: Int) -> () -> Int {
         return incrementer
      }
   ```
-}
+-->
 
 The return type of `makeIncrementer` is `() -> Int`.
 This means that it returns a *function*, rather than a simple value.
@@ -724,7 +724,7 @@ func incrementer() -> Int {
 ```
 
 
-@Comment {
+<!--
   - test: `closuresPullout`
   
   ```swifttest
@@ -735,7 +735,7 @@ func incrementer() -> Int {
         return runningTotal
      }
   ```
-}
+-->
 
 The `incrementer()` function doesn't have any parameters,
 and yet it refers to `runningTotal` and `amount` from within its function body.
@@ -759,13 +759,13 @@ let incrementByTen = makeIncrementer(forIncrement: 10)
 ```
 
 
-@Comment {
+<!--
   - test: `closures`
   
   ```swifttest
   -> let incrementByTen = makeIncrementer(forIncrement: 10)
   ```
-}
+-->
 
 This example sets a constant called `incrementByTen`
 to refer to an incrementer function that adds `10` to
@@ -782,7 +782,7 @@ incrementByTen()
 ```
 
 
-@Comment {
+<!--
   - test: `closures`
   
   ```swifttest
@@ -799,12 +799,12 @@ incrementByTen()
   /> returns a value of \(r2)
   </ returns a value of 30
   ```
-}
+-->
 
-@Comment {
+<!--
   Rewrite the above to avoid discarding the function's return value.
   Tracking bug is <rdar://problem/35301593>
-}
+-->
 
 If you create a second incrementer,
 it will have its own stored reference to a new, separate `runningTotal` variable:
@@ -816,7 +816,7 @@ incrementBySeven()
 ```
 
 
-@Comment {
+<!--
   - test: `closures`
   
   ```swifttest
@@ -826,7 +826,7 @@ incrementBySeven()
   /> returns a value of \(r3)
   </ returns a value of 7
   ```
-}
+-->
 
 Calling the original incrementer (`incrementByTen`) again
 continues to increment its own `runningTotal` variable,
@@ -838,7 +838,7 @@ incrementByTen()
 ```
 
 
-@Comment {
+<!--
   - test: `closures`
   
   ```swifttest
@@ -847,7 +847,7 @@ incrementByTen()
   /> returns a value of \(r4)
   </ returns a value of 40
   ```
-}
+-->
 
 > Note: If you assign a closure to a property of a class instance,
 > and the closure captures that instance by referring to the instance or its members,
@@ -883,7 +883,7 @@ incrementByTen()
 ```
 
 
-@Comment {
+<!--
   - test: `closures`
   
   ```swifttest
@@ -898,7 +898,7 @@ incrementByTen()
   /> returns a value of \(r6)
   </ returns a value of 60
   ```
-}
+-->
 
 The example above shows that calling `alsoIncrementByTen`
 is the same as calling `incrementByTen`.
@@ -932,7 +932,7 @@ func someFunctionWithEscapingClosure(completionHandler: @escaping () -> Void) {
 ```
 
 
-@Comment {
+<!--
   - test: `noescape-closure-as-argument, implicit-self-struct`
   
   ```swifttest
@@ -941,7 +941,7 @@ func someFunctionWithEscapingClosure(completionHandler: @escaping () -> Void) {
          completionHandlers.append(completionHandler)
      }
   ```
-}
+-->
 
 The `someFunctionWithEscapingClosure(_:)` function takes a closure as its argument
 and adds it to an array that's declared outside the function.
@@ -993,7 +993,7 @@ print(instance.x)
 ```
 
 
-@Comment {
+<!--
   - test: `noescape-closure-as-argument`
   
   ```swifttest
@@ -1018,7 +1018,7 @@ print(instance.x)
   -> print(instance.x)
   <- 100
   ```
-}
+-->
 
 Here's a version of `doSomething()` that captures `self`
 by including it in the closure's capture list,
@@ -1035,7 +1035,7 @@ class SomeOtherClass {
 ```
 
 
-@Comment {
+<!--
   - test: `noescape-closure-as-argument`
   
   ```swifttest
@@ -1055,7 +1055,7 @@ class SomeOtherClass {
   >> print(instance2.x)
   << 100
   ```
-}
+-->
 
 If `self` is an instance of a structure or an enumeration,
 you can always refer to `self` implicitly.
@@ -1076,7 +1076,7 @@ struct SomeStruct {
 ```
 
 
-@Comment {
+<!--
   - test: `struct-capture-mutable-self`
   
   ```swifttest
@@ -1101,7 +1101,7 @@ struct SomeStruct {
   !! someFunctionWithEscapingClosure { x = 100 }     // Error
   !! ^
   ```
-}
+-->
 
 The call to the `someFunctionWithEscapingClosure` function
 in the example above is an error
@@ -1110,7 +1110,7 @@ so `self` is mutable.
 That violates the rule that escaping closures can't capture
 a mutable reference to `self` for structures.
 
-@Comment {
+<!--
   - test: `noescape-closure-as-argument`
   
   ```swifttest
@@ -1128,9 +1128,9 @@ a mutable reference to `self` for structures.
   >> print(instance3.x)
   << 200
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `noescape-closure-as-argument`
   
   ```swifttest
@@ -1148,7 +1148,7 @@ a mutable reference to `self` for structures.
   >> completionHandlers.first?()
   << 10
   ```
-}
+-->
 
 ## Autoclosures
 
@@ -1191,7 +1191,7 @@ print(customersInLine.count)
 ```
 
 
-@Comment {
+<!--
   - test: `autoclosures`
   
   ```swifttest
@@ -1208,9 +1208,9 @@ print(customersInLine.count)
   -> print(customersInLine.count)
   <- 4
   ```
-}
+-->
 
-@Comment {
+<!--
   Using remove(at:) instead of popFirst() because the latter only works
   with ArraySlice, not with Array:
       customersInLine[0..<3].popLast()     // fine
@@ -1218,11 +1218,11 @@ print(customersInLine.count)
       customersInLine.popLast()            // fine
       customersInLine.popFirst()           // FAIL
   It also returns an optional, which complicates the listing.
-}
+-->
 
-@Comment {
+<!--
   TODO: It may be worth describing the differences between ``lazy`` and autoclousures.
-}
+-->
 
 Even though the first element of the `customersInLine` array is removed
 by the code inside the closure,
@@ -1247,7 +1247,7 @@ serve(customer: { customersInLine.remove(at: 0) } )
 ```
 
 
-@Comment {
+<!--
   - test: `autoclosures-function`
   
   ```swifttest
@@ -1260,7 +1260,7 @@ serve(customer: { customersInLine.remove(at: 0) } )
   -> serve(customer: { customersInLine.remove(at: 0) } )
   <- Now serving Alex!
   ```
-}
+-->
 
 The `serve(customer:)` function in the listing above
 takes an explicit closure that returns a customer's name.
@@ -1284,7 +1284,7 @@ serve(customer: customersInLine.remove(at: 0))
 ```
 
 
-@Comment {
+<!--
   - test: `autoclosures-function-with-autoclosure`
   
   ```swifttest
@@ -1297,7 +1297,7 @@ serve(customer: customersInLine.remove(at: 0))
   -> serve(customer: customersInLine.remove(at: 0))
   <- Now serving Ewa!
   ```
-}
+-->
 
 > Note: Overusing autoclosures can make your code hard to understand.
 > The context and function name should make it clear
@@ -1326,7 +1326,7 @@ for customerProvider in customerProviders {
 ```
 
 
-@Comment {
+<!--
   - test: `autoclosures-function-with-escape`
   
   ```swifttest
@@ -1348,7 +1348,7 @@ for customerProvider in customerProviders {
   <- Now serving Barry!
   <- Now serving Daniella!
   ```
-}
+-->
 
 In the code above,
 instead of calling the closure passed to it
@@ -1362,7 +1362,7 @@ the value of the `customerProvider` argument
 must be allowed to escape the function's scope.
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -1370,4 +1370,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/CollectionTypes.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/CollectionTypes.md
@@ -22,17 +22,17 @@ you will retrieve from a collection.
 > Note: Swift's array, set, and dictionary types are implemented as *generic collections*.
 > For more about generic types and collections, see <doc:Generics>.
 
-@Comment {
+<!--
   TODO: should I mention the Collection protocol, to which both of these conform?
-}
+-->
 
-@Comment {
+<!--
   TODO: mention for i in indices(collection) { collection[i] }
-}
+-->
 
-@Comment {
+<!--
   TODO: discuss collection equality
-}
+-->
 
 ## Mutability of Collections
 
@@ -79,7 +79,7 @@ print("someInts is of type [Int] with \(someInts.count) items.")
 ```
 
 
-@Comment {
+<!--
   - test: `arraysEmpty`
   
   ```swifttest
@@ -87,7 +87,7 @@ print("someInts is of type [Int] with \(someInts.count) items.")
   -> print("someInts is of type [Int] with \(someInts.count) items.")
   <- someInts is of type [Int] with 0 items.
   ```
-}
+-->
 
 Note that the type of the `someInts` variable is inferred to be `[Int]`
 from the type of the initializer.
@@ -106,7 +106,7 @@ someInts = []
 ```
 
 
-@Comment {
+<!--
   - test: `arraysEmpty`
   
   ```swifttest
@@ -116,7 +116,7 @@ someInts = []
   -> someInts = []
   // someInts is now an empty array, but is still of type [Int]
   ```
-}
+-->
 
 ### Creating an Array with a Default Value
 
@@ -133,7 +133,7 @@ var threeDoubles = Array(repeating: 0.0, count: 3)
 ```
 
 
-@Comment {
+<!--
   - test: `arraysEmpty`
   
   ```swifttest
@@ -141,7 +141,7 @@ var threeDoubles = Array(repeating: 0.0, count: 3)
   /> threeDoubles is of type [Double], and equals [\(threeDoubles[0]), \(threeDoubles[1]), \(threeDoubles[2])]
   </ threeDoubles is of type [Double], and equals [0.0, 0.0, 0.0]
   ```
-}
+-->
 
 ### Creating an Array by Adding Two Arrays Together
 
@@ -158,7 +158,7 @@ var sixDoubles = threeDoubles + anotherThreeDoubles
 ```
 
 
-@Comment {
+<!--
   - test: `arraysEmpty`
   
   ```swifttest
@@ -170,20 +170,20 @@ var sixDoubles = threeDoubles + anotherThreeDoubles
   /> sixDoubles is inferred as [Double], and equals \(sixDoubles)
   </ sixDoubles is inferred as [Double], and equals [0.0, 0.0, 0.0, 2.5, 2.5, 2.5]
   ```
-}
+-->
 
-@Comment {
+<!--
   TODO: func find<T: Equatable>(array: [T], value: T) -> Int?
   This is defined in Algorithm.swift,
   and gives a way to find the index of a value in an array if it exists.
   I'm holding off writing about it until NewArray lands.
-}
+-->
 
-@Comment {
+<!--
   TODO: mutating func sort(by: (T, T) -> Bool)
   This is defined in Array.swift.
   Likewise I'm holding off writing about it until NewArray lands.
-}
+-->
 
 ### Creating an Array with an Array Literal
 
@@ -205,14 +205,14 @@ var shoppingList: [String] = ["Eggs", "Milk"]
 ```
 
 
-@Comment {
+<!--
   - test: `arrays`
   
   ```swifttest
   -> var shoppingList: [String] = ["Eggs", "Milk"]
   // shoppingList has been initialized with two initial items
   ```
-}
+-->
 
 The `shoppingList` variable is declared as
 “an array of string values”, written as `[String]`.
@@ -241,13 +241,13 @@ var shoppingList = ["Eggs", "Milk"]
 ```
 
 
-@Comment {
+<!--
   - test: `arraysInferred`
   
   ```swifttest
   -> var shoppingList = ["Eggs", "Milk"]
   ```
-}
+-->
 
 Because all values in the array literal are of the same type,
 Swift can infer that `[String]` is
@@ -266,14 +266,14 @@ print("The shopping list contains \(shoppingList.count) items.")
 ```
 
 
-@Comment {
+<!--
   - test: `arraysInferred`
   
   ```swifttest
   -> print("The shopping list contains \(shoppingList.count) items.")
   <- The shopping list contains 2 items.
   ```
-}
+-->
 
 Use the Boolean `isEmpty` property
 as a shortcut for checking whether the `count` property is equal to `0`:
@@ -288,7 +288,7 @@ if shoppingList.isEmpty {
 ```
 
 
-@Comment {
+<!--
   - test: `arraysInferred`
   
   ```swifttest
@@ -299,7 +299,7 @@ if shoppingList.isEmpty {
      }
   <- The shopping list isn't empty.
   ```
-}
+-->
 
 You can add a new item to the end of an array by calling the array's `append(_:)` method:
 
@@ -309,7 +309,7 @@ shoppingList.append("Flour")
 ```
 
 
-@Comment {
+<!--
   - test: `arraysInferred`
   
   ```swifttest
@@ -317,7 +317,7 @@ shoppingList.append("Flour")
   /> shoppingList now contains \(shoppingList.count) items, and someone is making pancakes
   </ shoppingList now contains 3 items, and someone is making pancakes
   ```
-}
+-->
 
 Alternatively, append an array of one or more compatible items
 with the addition assignment operator (`+=`):
@@ -330,7 +330,7 @@ shoppingList += ["Chocolate Spread", "Cheese", "Butter"]
 ```
 
 
-@Comment {
+<!--
   - test: `arraysInferred`
   
   ```swifttest
@@ -341,7 +341,7 @@ shoppingList += ["Chocolate Spread", "Cheese", "Butter"]
   /> shoppingList now contains \(shoppingList.count) items
   </ shoppingList now contains 7 items
   ```
-}
+-->
 
 Retrieve a value from the array by using *subscript syntax*,
 passing the index of the value you want to retrieve within square brackets
@@ -353,7 +353,7 @@ var firstItem = shoppingList[0]
 ```
 
 
-@Comment {
+<!--
   - test: `arraysInferred`
   
   ```swifttest
@@ -361,7 +361,7 @@ var firstItem = shoppingList[0]
   /> firstItem is equal to \"\(firstItem)\"
   </ firstItem is equal to "Eggs"
   ```
-}
+-->
 
 > Note: The first item in the array has an index of `0`, not `1`.
 > Arrays in Swift are always zero-indexed.
@@ -374,7 +374,7 @@ shoppingList[0] = "Six eggs"
 ```
 
 
-@Comment {
+<!--
   - test: `arraysInferred`
   
   ```swifttest
@@ -382,7 +382,7 @@ shoppingList[0] = "Six eggs"
   /> the first item in the list is now equal to \"\(shoppingList[0])\" rather than \"Eggs\"
   </ the first item in the list is now equal to "Six eggs" rather than "Eggs"
   ```
-}
+-->
 
 When you use subscript syntax,
 the index you specify needs to be valid.
@@ -390,11 +390,11 @@ For example, writing `shoppingList[shoppingList.count] = "Salt"`
 to try to append an item to the end of the array
 results in a runtime error.
 
-@Comment {
+<!--
   Unlike Ruby and Javascript, where accessing an invalid index
   extends the array with nil or similar placeholder values,
   to make that index become valid.
-}
+-->
 
 You can also use subscript syntax to change a range of values at once,
 even if the replacement set of values has a different length than the range you are replacing.
@@ -407,7 +407,7 @@ shoppingList[4...6] = ["Bananas", "Apples"]
 ```
 
 
-@Comment {
+<!--
   - test: `arraysInferred`
   
   ```swifttest
@@ -415,7 +415,7 @@ shoppingList[4...6] = ["Bananas", "Apples"]
   /> shoppingList now contains \(shoppingList.count) items
   </ shoppingList now contains 6 items
   ```
-}
+-->
 
 To insert an item into the array at a specified index,
 call the array's `insert(_:at:)` method:
@@ -427,7 +427,7 @@ shoppingList.insert("Maple Syrup", at: 0)
 ```
 
 
-@Comment {
+<!--
   - test: `arraysInferred`
   
   ```swifttest
@@ -437,7 +437,7 @@ shoppingList.insert("Maple Syrup", at: 0)
   /> \"\(shoppingList[0])\" is now the first item in the list
   </ "Maple Syrup" is now the first item in the list
   ```
-}
+-->
 
 This call to the `insert(_:at:)` method inserts a new item with a value of `"Maple Syrup"`
 at the very beginning of the shopping list,
@@ -455,7 +455,7 @@ let mapleSyrup = shoppingList.remove(at: 0)
 ```
 
 
-@Comment {
+<!--
   - test: `arraysInferred`
   
   ```swifttest
@@ -466,7 +466,7 @@ let mapleSyrup = shoppingList.remove(at: 0)
   /> the mapleSyrup constant is now equal to the removed \"\(mapleSyrup)\" string
   </ the mapleSyrup constant is now equal to the removed "Maple Syrup" string
   ```
-}
+-->
 
 > Note: If you try to access or modify a value for an index
 > that's outside of an array's existing bounds,
@@ -487,7 +487,7 @@ firstItem = shoppingList[0]
 ```
 
 
-@Comment {
+<!--
   - test: `arraysInferred`
   
   ```swifttest
@@ -495,7 +495,7 @@ firstItem = shoppingList[0]
   /> firstItem is now equal to \"\(firstItem)\"
   </ firstItem is now equal to "Six eggs"
   ```
-}
+-->
 
 If you want to remove the final item from an array,
 use the `removeLast()` method rather than the `remove(at:)` method
@@ -510,7 +510,7 @@ let apples = shoppingList.removeLast()
 ```
 
 
-@Comment {
+<!--
   - test: `arraysInferred`
   
   ```swifttest
@@ -521,7 +521,7 @@ let apples = shoppingList.removeLast()
   /> the apples constant is now equal to the removed \"\(apples)\" string
   </ the apples constant is now equal to the removed "Apples" string
   ```
-}
+-->
 
 ### Iterating Over an Array
 
@@ -539,7 +539,7 @@ for item in shoppingList {
 ```
 
 
-@Comment {
+<!--
   - test: `arraysInferred`
   
   ```swifttest
@@ -552,7 +552,7 @@ for item in shoppingList {
   </ Baking Powder
   </ Bananas
   ```
-}
+-->
 
 If you need the integer index of each item as well as its value,
 use the `enumerated()` method to iterate over the array instead.
@@ -577,7 +577,7 @@ for (index, value) in shoppingList.enumerated() {
 ```
 
 
-@Comment {
+<!--
   - test: `arraysInferred`
   
   ```swifttest
@@ -590,7 +590,7 @@ for (index, value) in shoppingList.enumerated() {
   </ Item 4: Baking Powder
   </ Item 5: Bananas
   ```
-}
+-->
 
 For more about the `for`-`in` loop, see <doc:ControlFlow#For-In-Loops>.
 
@@ -604,9 +604,9 @@ or when you need to ensure that an item only appears once.
 > Note: Swift's `Set` type is bridged to Foundation's `NSSet` class.For more information about using `Set` with Foundation and Cocoa,
 > see [Bridging Between Set and NSSet](https://developer.apple.com/documentation/swift/set#2845530).
 
-@Comment {
+<!--
   TODO: Add note about performance characteristics of contains on sets as opposed to arrays?
-}
+-->
 
 ### Hash Values for Set Types
 
@@ -647,7 +647,7 @@ print("letters is of type Set<Character> with \(letters.count) items.")
 ```
 
 
-@Comment {
+<!--
   - test: `setsEmpty`
   
   ```swifttest
@@ -655,7 +655,7 @@ print("letters is of type Set<Character> with \(letters.count) items.")
   -> print("letters is of type Set<Character> with \(letters.count) items.")
   <- letters is of type Set<Character> with 0 items.
   ```
-}
+-->
 
 > Note: The type of the `letters` variable is inferred to be `Set<Character>`,
 > from the type of the initializer.
@@ -672,7 +672,7 @@ letters = []
 ```
 
 
-@Comment {
+<!--
   - test: `setsEmpty`
   
   ```swifttest
@@ -682,7 +682,7 @@ letters = []
   -> letters = []
   // letters is now an empty set, but is still of type Set<Character>
   ```
-}
+-->
 
 ### Creating a Set with an Array Literal
 
@@ -697,14 +697,14 @@ var favoriteGenres: Set<String> = ["Rock", "Classical", "Hip hop"]
 ```
 
 
-@Comment {
+<!--
   - test: `sets`
   
   ```swifttest
   -> var favoriteGenres: Set<String> = ["Rock", "Classical", "Hip hop"]
   // favoriteGenres has been initialized with three initial items
   ```
-}
+-->
 
 The `favoriteGenres` variable is declared as
 “a set of `String` values”, written as `Set<String>`.
@@ -730,13 +730,13 @@ var favoriteGenres: Set = ["Rock", "Classical", "Hip hop"]
 ```
 
 
-@Comment {
+<!--
   - test: `setsInferred`
   
   ```swifttest
   -> var favoriteGenres: Set = ["Rock", "Classical", "Hip hop"]
   ```
-}
+-->
 
 Because all values in the array literal are of the same type,
 Swift can infer that `Set<String>` is
@@ -755,7 +755,7 @@ print("I have \(favoriteGenres.count) favorite music genres.")
 ```
 
 
-@Comment {
+<!--
   - test: `setUsage`
   
   ```swifttest
@@ -763,7 +763,7 @@ print("I have \(favoriteGenres.count) favorite music genres.")
   -> print("I have \(favoriteGenres.count) favorite music genres.")
   <- I have 3 favorite music genres.
   ```
-}
+-->
 
 Use the Boolean `isEmpty` property
 as a shortcut for checking whether the `count` property is equal to `0`:
@@ -778,7 +778,7 @@ if favoriteGenres.isEmpty {
 ```
 
 
-@Comment {
+<!--
   - test: `setUsage`
   
   ```swifttest
@@ -789,7 +789,7 @@ if favoriteGenres.isEmpty {
      }
   <- I have particular music preferences.
   ```
-}
+-->
 
 You can add a new item into a set by calling the set's `insert(_:)` method:
 
@@ -799,7 +799,7 @@ favoriteGenres.insert("[Tool J]")
 ```
 
 
-@Comment {
+<!--
   - test: `setUsage`
   
   ```swifttest
@@ -807,7 +807,7 @@ favoriteGenres.insert("[Tool J]")
   /> favoriteGenres now contains \(favoriteGenres.count) items
   </ favoriteGenres now contains 4 items
   ```
-}
+-->
 
 You can remove an item from a set by calling the set's `remove(_:)` method,
 which removes the item if it's a member of the set,
@@ -825,7 +825,7 @@ if let removedGenre = favoriteGenres.remove("Rock") {
 ```
 
 
-@Comment {
+<!--
   - test: `setUsage`
   
   ```swifttest
@@ -836,7 +836,7 @@ if let removedGenre = favoriteGenres.remove("Rock") {
      }
   <- Rock? I'm over it.
   ```
-}
+-->
 
 To check whether a set contains a particular item, use the `contains(_:)` method.
 
@@ -850,7 +850,7 @@ if favoriteGenres.contains("Funk") {
 ```
 
 
-@Comment {
+<!--
   - test: `setUsage`
   
   ```swifttest
@@ -861,7 +861,7 @@ if favoriteGenres.contains("Funk") {
      }
   <- It's too funky in here.
   ```
-}
+-->
 
 ### Iterating Over a Set
 
@@ -877,7 +877,7 @@ for genre in favoriteGenres {
 ```
 
 
-@Comment {
+<!--
   - test: `setUsage`
   
   ```swifttest
@@ -888,7 +888,7 @@ for genre in favoriteGenres {
   </ [Tool J]
   </ Hip hop
   ```
-}
+-->
 
 For more about the `for`-`in` loop, see <doc:ControlFlow#For-In-Loops>.
 
@@ -908,7 +908,7 @@ for genre in favoriteGenres.sorted() {
 ```
 
 
-@Comment {
+<!--
   - test: `setUsage`
   
   ```swifttest
@@ -919,7 +919,7 @@ for genre in favoriteGenres.sorted() {
   </ Hip hop
   </ [Tool J]
   ```
-}
+-->
 
 ## Performing Set Operations
 
@@ -957,7 +957,7 @@ oddDigits.symmetricDifference(singleDigitPrimeNumbers).sorted()
 ```
 
 
-@Comment {
+<!--
   - test: `setOperations`
   
   ```swifttest
@@ -982,12 +982,12 @@ oddDigits.symmetricDifference(singleDigitPrimeNumbers).sorted()
   >> assert(d == [1, 2, 9])
   // [1, 2, 9]
   ```
-}
+-->
 
-@Comment {
+<!--
   Rewrite the above to avoid bare expressions.
   Tracking bug is <rdar://problem/35301593>
-}
+-->
 
 ### Set Membership and Equality
 
@@ -1023,7 +1023,7 @@ farmAnimals.isDisjoint(with: cityAnimals)
 ```
 
 
-@Comment {
+<!--
   - test: `setOperations`
   
   ```swifttest
@@ -1044,12 +1044,12 @@ farmAnimals.isDisjoint(with: cityAnimals)
   >> assert(cc == true)
   // true
   ```
-}
+-->
 
-@Comment {
+<!--
   Rewrite the above to avoid bare expressions.
   Tracking bug is <rdar://problem/35301593>
-}
+-->
 
 ## Dictionaries
 
@@ -1091,14 +1091,14 @@ var namesOfIntegers: [Int: String] = [:]
 ```
 
 
-@Comment {
+<!--
   - test: `dictionariesEmpty`
   
   ```swifttest
   -> var namesOfIntegers: [Int: String] = [:]
   // namesOfIntegers is an empty [Int: String] dictionary
   ```
-}
+-->
 
 This example creates an empty dictionary of type `[Int: String]`
 to store human-readable names of integer values.
@@ -1117,7 +1117,7 @@ namesOfIntegers = [:]
 ```
 
 
-@Comment {
+<!--
   - test: `dictionariesEmpty`
   
   ```swifttest
@@ -1127,7 +1127,7 @@ namesOfIntegers = [:]
   -> namesOfIntegers = [:]
   // namesOfIntegers is once again an empty dictionary of type [Int: String]
   ```
-}
+-->
 
 ### Creating a Dictionary with a Dictionary Literal
 
@@ -1156,13 +1156,13 @@ var airports: [String: String] = ["YYZ": "Toronto Pearson", "DUB": "Dublin"]
 ```
 
 
-@Comment {
+<!--
   - test: `dictionaries`
   
   ```swifttest
   -> var airports: [String: String] = ["YYZ": "Toronto Pearson", "DUB": "Dublin"]
   ```
-}
+-->
 
 The `airports` dictionary is declared as having a type of `[String: String]`,
 which means “a `Dictionary` whose keys are of type `String`,
@@ -1193,13 +1193,13 @@ var airports = ["YYZ": "Toronto Pearson", "DUB": "Dublin"]
 ```
 
 
-@Comment {
+<!--
   - test: `dictionariesInferred`
   
   ```swifttest
   -> var airports = ["YYZ": "Toronto Pearson", "DUB": "Dublin"]
   ```
-}
+-->
 
 Because all keys in the literal are of the same type as each other,
 and likewise all values are of the same type as each other,
@@ -1220,14 +1220,14 @@ print("The airports dictionary contains \(airports.count) items.")
 ```
 
 
-@Comment {
+<!--
   - test: `dictionariesInferred`
   
   ```swifttest
   -> print("The airports dictionary contains \(airports.count) items.")
   <- The airports dictionary contains 2 items.
   ```
-}
+-->
 
 Use the Boolean `isEmpty` property
 as a shortcut for checking whether the `count` property is equal to `0`:
@@ -1242,7 +1242,7 @@ if airports.isEmpty {
 ```
 
 
-@Comment {
+<!--
   - test: `dictionariesInferred`
   
   ```swifttest
@@ -1253,7 +1253,7 @@ if airports.isEmpty {
      }
   <- The airports dictionary isn't empty.
   ```
-}
+-->
 
 You can add a new item to a dictionary with subscript syntax.
 Use a new key of the appropriate type as the subscript index,
@@ -1265,7 +1265,7 @@ airports["LHR"] = "London"
 ```
 
 
-@Comment {
+<!--
   - test: `dictionariesInferred`
   
   ```swifttest
@@ -1273,7 +1273,7 @@ airports["LHR"] = "London"
   /> the airports dictionary now contains \(airports.count) items
   </ the airports dictionary now contains 3 items
   ```
-}
+-->
 
 You can also use subscript syntax to change the value associated with a particular key:
 
@@ -1283,7 +1283,7 @@ airports["LHR"] = "London Heathrow"
 ```
 
 
-@Comment {
+<!--
   - test: `dictionariesInferred`
   
   ```swifttest
@@ -1291,7 +1291,7 @@ airports["LHR"] = "London Heathrow"
   /> the value for \"LHR\" has been changed to \"\(airports["LHR"]!)\"
   </ the value for "LHR" has been changed to "London Heathrow"
   ```
-}
+-->
 
 As an alternative to subscripting,
 use a dictionary's `updateValue(_:forKey:)` method
@@ -1319,7 +1319,7 @@ if let oldValue = airports.updateValue("Dublin Airport", forKey: "DUB") {
 ```
 
 
-@Comment {
+<!--
   - test: `dictionariesInferred`
   
   ```swifttest
@@ -1328,7 +1328,7 @@ if let oldValue = airports.updateValue("Dublin Airport", forKey: "DUB") {
      }
   <- The old value for DUB was Dublin.
   ```
-}
+-->
 
 You can also use subscript syntax to retrieve a value from the dictionary for a particular key.
 Because it's possible to request a key for which no value exists,
@@ -1347,7 +1347,7 @@ if let airportName = airports["DUB"] {
 ```
 
 
-@Comment {
+<!--
   - test: `dictionariesInferred`
   
   ```swifttest
@@ -1358,7 +1358,7 @@ if let airportName = airports["DUB"] {
      }
   <- The name of the airport is Dublin Airport.
   ```
-}
+-->
 
 You can use subscript syntax to remove a key-value pair from a dictionary
 by assigning a value of `nil` for that key:
@@ -1371,7 +1371,7 @@ airports["APL"] = nil
 ```
 
 
-@Comment {
+<!--
   - test: `dictionariesInferred`
   
   ```swifttest
@@ -1387,7 +1387,7 @@ airports["APL"] = nil
   >> }
   << APL has now been removed from the dictionary
   ```
-}
+-->
 
 Alternatively, remove a key-value pair from a dictionary
 with the `removeValue(forKey:)` method.
@@ -1405,7 +1405,7 @@ if let removedValue = airports.removeValue(forKey: "DUB") {
 ```
 
 
-@Comment {
+<!--
   - test: `dictionariesInferred`
   
   ```swifttest
@@ -1416,7 +1416,7 @@ if let removedValue = airports.removeValue(forKey: "DUB") {
      }
   <- The removed airport's name is Dublin Airport.
   ```
-}
+-->
 
 ### Iterating Over a Dictionary
 
@@ -1434,7 +1434,7 @@ for (airportCode, airportName) in airports {
 ```
 
 
-@Comment {
+<!--
   - test: `dictionariesInferred`
   
   ```swifttest
@@ -1444,7 +1444,7 @@ for (airportCode, airportName) in airports {
   </ LHR: London Heathrow
   </ YYZ: Toronto Pearson
   ```
-}
+-->
 
 For more about the `for`-`in` loop, see <doc:ControlFlow#For-In-Loops>.
 
@@ -1466,7 +1466,7 @@ for airportName in airports.values {
 ```
 
 
-@Comment {
+<!--
   - test: `dictionariesInferred`
   
   ```swifttest
@@ -1482,7 +1482,7 @@ for airportName in airports.values {
   </ Airport name: London Heathrow
   </ Airport name: Toronto Pearson
   ```
-}
+-->
 
 If you need to use a dictionary's keys or values
 with an API that takes an `Array` instance, initialize a new array
@@ -1497,7 +1497,7 @@ let airportNames = [String](airports.values)
 ```
 
 
-@Comment {
+<!--
   - test: `dictionariesInferred`
   
   ```swifttest
@@ -1509,14 +1509,14 @@ let airportNames = [String](airports.values)
   /> airportNames is [\"\(airportNames[0])\", \"\(airportNames[1])\"]
   </ airportNames is ["London Heathrow", "Toronto Pearson"]
   ```
-}
+-->
 
 Swift's `Dictionary` type doesn't have a defined ordering.
 To iterate over the keys or values of a dictionary in a specific order,
 use the `sorted()` method on its `keys` or `values` property.
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -1524,4 +1524,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Concurrency.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Concurrency.md
@@ -65,7 +65,7 @@ listPhotos(inGallery: "Summer Vacation") { photoNames in
 ```
 
 
-@Comment {
+<!--
   - test: `async-via-nested-completion-handlers`
   
   ```swifttest
@@ -85,7 +85,7 @@ listPhotos(inGallery: "Summer Vacation") { photoNames in
          }
      }
   ```
-}
+-->
 
 Even in this simple case,
 because the code has to be written as a series of completion handlers,
@@ -121,7 +121,7 @@ func listPhotos(inGallery name: String) async -> [String] {
 ```
 
 
-@Comment {
+<!--
   - test: `async-function-shape`
   
   ```swifttest
@@ -131,12 +131,12 @@ func listPhotos(inGallery name: String) async -> [String] {
          return result
      }
   ```
-}
+-->
 
 For a function or method that's both asynchronous and throwing,
 you write `async` before `throws`.
 
-@Comment {
+<!--
   - test: `async-comes-before-throws`
   
   ```swifttest
@@ -147,7 +147,7 @@ you write `async` before `throws`.
   !! ^~~~~~
   !! async
   ```
-}
+-->
 
 When calling an asynchronous method,
 execution suspends until that method returns.
@@ -173,7 +173,7 @@ show(photo)
 ```
 
 
-@Comment {
+<!--
   - test: `defining-async-function`
   
   ```swifttest
@@ -191,7 +191,7 @@ show(photo)
   -> show(photo)
   >> }
   ```
-}
+-->
 
 Because the `listPhotos(inGallery:)` and `downloadPhoto(named:)` functions
 both need to make network requests,
@@ -243,13 +243,13 @@ only certain places in your program can call asynchronous functions or methods:
 - Code in an unstructured child task,
   as shown in <doc:Concurrency#Unstructured-Concurrency> below.
 
-@Comment {
+<!--
   SE-0296 specifically calls out that top-level code is *not* an async context,
   contrary to what you might expect.
   If that gets changed, add this bullet to the list above:
   
   - Code at the top level that forms an implicit main function.
-}
+-->
 
 Code in between possible suspension points runs sequentially,
 without the possibility of interruption from other concurrent code.
@@ -290,17 +290,17 @@ if you try to add concurrent code to this function,
 introducing a possible suspension point,
 you'll get compile-time error instead of introducing a bug.
 
-@Comment {
+<!--
   TODO you can also explicitly insert a suspension point
   by calling ``Task.yield()``
   https://developer.apple.com/documentation/swift/task/3814840-yield
-}
+-->
 
-@Comment {
+<!--
   TODO add detail above about how the *compiler* can reason about
   the async/await version better too
   and give you better guarantees and clearer errors
-}
+-->
 
 > Note: The [Task.sleep(until:tolerance:clock:)](https://developer.apple.com/documentation/swift/task/sleep(until:tolerance:clock:)) method
 > is useful when writing simple code
@@ -318,7 +318,7 @@ you'll get compile-time error instead of introducing a bug.
 > ```
 > 
 > 
-> @Comment {
+> <!--
   > - test: `sleep-in-toy-code`
   > 
   > ```swifttest
@@ -328,16 +328,16 @@ you'll get compile-time error instead of introducing a bug.
   >        return ["IMG001", "IMG99", "IMG0404"]
   > }
   > ```
-> }
+> -->
 
-@Comment {
+<!--
   TODO either add an example or maybe a short section
   about throwing and async together
   to give a place where I can note the order of the keywords
   in the declaration and in the calls
-}
+-->
 
-@Comment {
+<!--
   TODO closures can be async too -- outline
   
   like how you can have an async function, a closure con be async
@@ -345,7 +345,7 @@ you'll get compile-time error instead of introducing a bug.
   you can mark it explicitly with "async -> in"
   
   (discussion of @MainActor closures can probably go here too)
-}
+-->
 
 ## Asynchronous Sequences
 
@@ -367,7 +367,7 @@ for try await line in handle.bytes.lines {
 ```
 
 
-@Comment {
+<!--
   - test: `async-sequence`
   
   ```swifttest
@@ -380,7 +380,7 @@ for try await line in handle.bytes.lines {
      }
   >> }
   ```
-}
+-->
 
 Instead of using an ordinary `for`-`in` loop,
 the example above writes `for` with `await` after it.
@@ -390,9 +390,9 @@ A `for`-`await`-`in` loop potentially suspends execution
 at the beginning of each iteration,
 when it's waiting for the next element to be available.
 
-@Comment {
+<!--
   FIXME TR: Where does the 'try' above come from?
-}
+-->
 
 In the same way that you can use your own types in a `for`-`in` loop
 by adding conformance to the [Sequence](https://developer.apple.com/documentation/swift/sequence) protocol,
@@ -400,7 +400,7 @@ you can use your own types in a `for`-`await`-`in` loop
 by adding conformance to the
 [AsyncSequence](https://developer.apple.com/documentation/swift/asyncsequence) protocol.
 
-@Comment {
+<!--
   TODO what happened to ``Series`` which was supposed to be a currency type?
   Is that coming from Combine instead of the stdlib maybe?
   
@@ -422,11 +422,11 @@ by adding conformance to the
   for await photo in Photos(names: names) {
       show(photo)
   }
-}
+-->
 
 ## Calling Asynchronous Functions in Parallel
 
-@Comment {
+<!--
   FIXME
   As pointed out on the Swift forums
   <https://forums.swift.org/t/swift-concurrency-feedback-wanted/49336/53>
@@ -435,7 +435,7 @@ by adding conformance to the
   However,
   the syntax introduced in this section contrasts to the previous section
   in that async-let makes it *possible* for that work to be parallel.
-}
+-->
 
 Calling an asynchronous function with `await`
 runs only one piece of code at a time.
@@ -457,7 +457,7 @@ show(photos)
 ```
 
 
-@Comment {
+<!--
   - test: `defining-async-function`
   
   ```swifttest
@@ -472,7 +472,7 @@ show(photos)
   -> show(photos)
   >> }
   ```
-}
+-->
 
 This approach has an important drawback:
 Although the download is asynchronous
@@ -497,7 +497,7 @@ show(photos)
 ```
 
 
-@Comment {
+<!--
   - test: `calling-with-async-let`
   
   ```swifttest
@@ -514,7 +514,7 @@ show(photos)
   -> show(photos)
   >> }
   ```
-}
+-->
 
 In this example,
 all three calls to `downloadPhoto(named:)` start
@@ -576,14 +576,14 @@ await withTaskGroup(of: Data.self) { taskGroup in
 ```
 
 
-@Comment {
+<!--
   TODO walk through the example
-}
+-->
 
 For more information about task groups,
 see [TaskGroup](https://developer.apple.com/documentation/swift/taskgroup).
 
-@Comment {
+<!--
   OUTLINE
   
   - A task itself doesn't have any concurrency; it does one thing at a time
@@ -669,9 +669,9 @@ see [TaskGroup](https://developer.apple.com/documentation/swift/taskgroup).
   > It makes it easier to reason about
   > the concurrent tasks that are executing within a given scope,
   > and also enables various optimizations.
-}
+-->
 
-@Comment {
+<!--
   OUTLINE
   
   .. _Concurrency_TaskPriority:
@@ -696,7 +696,7 @@ see [TaskGroup](https://developer.apple.com/documentation/swift/taskgroup).
   - In addition, or instead of, setting a low priority,
   you can use ``Task.yield()`` to explicitly pass execution to the next scheduled task.
   This is a sort of cooperative multitasking for long-running work.
-}
+-->
 
 ### Unstructured Concurrency
 
@@ -728,12 +728,12 @@ let result = await handle.value
 For more information about managing detached tasks,
 see [Task](https://developer.apple.com/documentation/swift/task).
 
-@Comment {
+<!--
   TODO Add some conceptual guidance about
   when to make a method do its work in a detached task
   versus making the method itself async?
   (Pull from my 2021-04-21 notes from Ben's talk rehearsal.)
-}
+-->
 
 ### Task Cancellation
 
@@ -760,7 +760,7 @@ might need to delete partial downloads and close network connections.
 To propagate cancellation manually,
 call [Task.cancel()](https://developer.apple.com/documentation/swift/task/3851218-cancel).
 
-@Comment {
+<!--
   OUTLINE
   
   - task
@@ -786,7 +786,7 @@ call [Task.cancel()](https://developer.apple.com/documentation/swift/task/385121
   if the task is canceled
   along with a closure that defines the task's work
   (it doesn't throw like ``checkCancellation`` does)
-}
+-->
 
 ## Actors
 
@@ -821,7 +821,7 @@ actor TemperatureLogger {
 ```
 
 
-@Comment {
+<!--
   - test: `actors, actors-implicitly-sendable`
   
   ```swifttest
@@ -837,7 +837,7 @@ actor TemperatureLogger {
          }
      }
   ```
-}
+-->
 
 You introduce an actor with the `actor` keyword,
 followed by its definition in a pair of braces.
@@ -931,13 +931,13 @@ Swift guarantees that
 only code inside an actor can access the actor's local state.
 This guarantee is known as *actor isolation*.
 
-@Comment {
+<!--
   OUTLINE -- design patterns for actors
   
   - do your mutation in a sync function
-}
+-->
 
-@Comment {
+<!--
   OUTLINE
   
   Add this post-WWDC when we have a more solid story to tell around Sendable
@@ -997,7 +997,7 @@ This guarantee is known as *actor isolation*.
   
        await logger.update(with: "27 C")
        print(await logger.getMax())
-}
+-->
 
 ## Sendable Types
 
@@ -1044,7 +1044,7 @@ In general, there are three ways for a type to be sendable:
   or a class that serializes access to its properties
   on a particular thread or queue.
 
-@Comment {
+<!--
   There's no example of the third case,
   where you serialize access to the class's members,
   because the stdlib doesn't include the locking primitives you'd need.
@@ -1052,7 +1052,7 @@ In general, there are three ways for a type to be sendable:
   isn't a good fit for TSPL.
   Implementing it in terms of isKnownUniquelyReferenced(_:)
   and copy-on-write is also probably too involved for TSPL.
-}
+-->
 
 For a detailed list of the semantic requirements,
 see the [Sendable](https://developer.apple.com/documentation/swift/sendable) protocol reference.
@@ -1079,7 +1079,7 @@ await logger.addReading(from: reading)
 ```
 
 
-@Comment {
+<!--
   - test: `actors`
   
   ```swifttest
@@ -1097,7 +1097,7 @@ await logger.addReading(from: reading)
   -> let reading = TemperatureReading(measurement: 45)
   -> await logger.addReading(from: reading)
   ```
-}
+-->
 
 Because `TemperatureReading` is a structure that has only sendable properties,
 and the structure isn't marked `public` or `@usableFromInline`,
@@ -1112,7 +1112,7 @@ struct TemperatureReading {
 ```
 
 
-@Comment {
+<!--
   - test: `actors-implicitly-sendable`
   
   ```swifttest
@@ -1120,9 +1120,9 @@ struct TemperatureReading {
          var measurement: Int
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   OUTLINE
   .. _Concurrency_MainActor:
   
@@ -1147,9 +1147,9 @@ struct TemperatureReading {
   If you mark the property of a type with one of these implicit-main-actor properties,
   that has the same effect as marking the type with ``@MainActor``
   you can wait for each child of a task
-}
+-->
 
-@Comment {
+<!--
   LEFTOVER OUTLINE BITS
   
   - like classes, actors can inherit from other actors
@@ -1182,10 +1182,10 @@ struct TemperatureReading {
   
   Probably don't cover unsafe continuations (SE-0300) in TSPL,
   but maybe link to them?
-}
+-->
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -1193,4 +1193,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Concurrency.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Concurrency.md
@@ -316,19 +316,18 @@ you'll get compile-time error instead of introducing a bug.
 >     return ["IMG001", "IMG99", "IMG0404"]
 > }
 > ```
-> 
-> 
-> <!--
-  > - test: `sleep-in-toy-code`
-  > 
-  > ```swifttest
-  > >> struct Data {}  // Instead of actually importing Foundation
-  > -> func listPhotos(inGallery name: String) async throws -> [String] {
-  >        try await Task.sleep(until: .now + .seconds(2), clock: .continuous)
-  >        return ["IMG001", "IMG99", "IMG0404"]
-  > }
-  > ```
-> -->
+
+<!--
+  - test: `sleep-in-toy-code`
+
+  ```swifttest
+  >> struct Data {}  // Instead of actually importing Foundation
+  -> func listPhotos(inGallery name: String) async throws -> [String] {
+         try await Task.sleep(until: .now + .seconds(2), clock: .continuous)
+         return ["IMG001", "IMG99", "IMG0404"]
+  }
+  ```
+-->
 
 <!--
   TODO either add an example or maybe a short section

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/ControlFlow.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/ControlFlow.md
@@ -39,7 +39,7 @@ for name in names {
 ```
 
 
-@Comment {
+<!--
   - test: `forLoops`
   
   ```swifttest
@@ -52,7 +52,7 @@ for name in names {
   </ Hello, Brian!
   </ Hello, Jack!
   ```
-}
+-->
 
 You can also iterate over a dictionary to access its key-value pairs.
 Each item in the dictionary is returned as a `(key, value)` tuple
@@ -73,7 +73,7 @@ for (animalName, legCount) in numberOfLegs {
 ```
 
 
-@Comment {
+<!--
   - test: `forLoops`
   
   ```swifttest
@@ -85,7 +85,7 @@ for (animalName, legCount) in numberOfLegs {
   </ ants have 6 legs
   </ spiders have 8 legs
   ```
-}
+-->
 
 The contents of a `Dictionary` are inherently unordered,
 and iterating over them doesn't guarantee the order
@@ -95,10 +95,10 @@ the order you insert items into a `Dictionary`
 doesn't define the order they're iterated.
 For more about arrays and dictionaries, see <doc:CollectionTypes>.
 
-@Comment {
+<!--
   TODO: provide some advice on how to iterate over a Dictionary in order
   (perhaps sorted by key), using a predicate or array sort or some kind.
-}
+-->
 
 You can also use `for`-`in` loops with numeric ranges.
 This example prints the first few entries in a five-times table:
@@ -115,7 +115,7 @@ for index in 1...5 {
 ```
 
 
-@Comment {
+<!--
   - test: `forLoops`
   
   ```swifttest
@@ -128,7 +128,7 @@ for index in 1...5 {
   </ 4 times 5 is 20
   </ 5 times 5 is 25
   ```
-}
+-->
 
 The sequence being iterated over is
 a range of numbers from `1` to `5`, inclusive,
@@ -163,7 +163,7 @@ print("\(base) to the power of \(power) is \(answer)")
 ```
 
 
-@Comment {
+<!--
   - test: `forLoops`
   
   ```swifttest
@@ -176,7 +176,7 @@ print("\(base) to the power of \(power) is \(answer)")
   -> print("\(base) to the power of \(power) is \(answer)")
   <- 3 to the power of 10 is 59049
   ```
-}
+-->
 
 The example above calculates the value of one number to the power of another
 (in this case, `3` to the power of `10`).
@@ -207,7 +207,7 @@ for tickMark in 0..<minutes {
 ```
 
 
-@Comment {
+<!--
   - test: `forLoops`
   
   ```swifttest
@@ -220,7 +220,7 @@ for tickMark in 0..<minutes {
   >> print(result.first!, result.last!, result.count)
   << 0 59 60
   ```
-}
+-->
 
 Some users might want fewer tick marks in their UI.
 They could prefer one mark every `5` minutes instead.
@@ -234,7 +234,7 @@ for tickMark in stride(from: 0, to: minutes, by: minuteInterval) {
 ```
 
 
-@Comment {
+<!--
   - test: `forLoops`
   
   ```swifttest
@@ -247,7 +247,7 @@ for tickMark in stride(from: 0, to: minutes, by: minuteInterval) {
   >> print(result.first!, result.last!, result.count)
   << 0 55 12
   ```
-}
+-->
 
 Closed ranges are also available, by using `stride(from:through:by:)` instead:
 
@@ -260,7 +260,7 @@ for tickMark in stride(from: 3, through: hours, by: hourInterval) {
 ```
 
 
-@Comment {
+<!--
   - test: `forLoops`
   
   ```swifttest
@@ -275,7 +275,7 @@ for tickMark in stride(from: 3, through: hours, by: hourInterval) {
   << 9
   << 12
   ```
-}
+-->
 
 The examples above use a `for`-`in` loop to iterate
 ranges, arrays, dictionaries, and strings.
@@ -283,10 +283,10 @@ However, you can use this syntax to iterate *any* collection,
 including your own classes and collection types,
 as long as those types conform to the [Sequence](https://developer.apple.com/documentation/swift/sequence) protocol.
 
-@Comment {
+<!--
   TODO: for (index, object) in enumerate(collection)
   and also for i in indices(collection) { collection[i] }
-}
+-->
 
 ## While Loops
 
@@ -316,9 +316,9 @@ while <#condition#> {
 This example plays a simple game of *Snakes and Ladders*
 (also known as *Chutes and Ladders*):
 
-@Comment {
+<!--
   iBooks Store screenshot begins here.
-}
+-->
 
 ![](snakesAndLadders)
 
@@ -346,7 +346,7 @@ var board = [Int](repeating: 0, count: finalSquare + 1)
 ```
 
 
-@Comment {
+<!--
   - test: `snakesAndLadders1`
   
   ```swifttest
@@ -354,7 +354,7 @@ var board = [Int](repeating: 0, count: finalSquare + 1)
   -> var board = [Int](repeating: 0, count: finalSquare + 1)
   >> assert(board == [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
   ```
-}
+-->
 
 Some squares are then set to have more specific values for the snakes and ladders.
 Squares with a ladder base have a positive number to move you up the board,
@@ -366,18 +366,18 @@ board[14] = -10; board[19] = -11; board[22] = -02; board[24] = -08
 ```
 
 
-@Comment {
+<!--
   - test: `snakesAndLadders1`
   
   ```swifttest
   -> board[03] = +08; board[06] = +11; board[09] = +09; board[10] = +02
   -> board[14] = -10; board[19] = -11; board[22] = -02; board[24] = -08
   ```
-}
+-->
 
-@Comment {
+<!--
   iBooks Store screenshot ends here.
-}
+-->
 
 Square 3 contains the bottom of a ladder that moves you up to square 11.
 To represent this, `board[03]` is equal to `+08`,
@@ -408,7 +408,7 @@ print("Game over!")
 ```
 
 
-@Comment {
+<!--
   - test: `snakesAndLadders1`
   
   ```swifttest
@@ -460,7 +460,7 @@ print("Game over!")
   << after diceRoll, square is 27
   << Game over!
   ```
-}
+-->
 
 The example above uses a very simple approach to dice rolling.
 Instead of generating a random number,
@@ -530,7 +530,7 @@ var diceRoll = 0
 ```
 
 
-@Comment {
+<!--
   - test: `snakesAndLadders2`
   
   ```swifttest
@@ -542,7 +542,7 @@ var diceRoll = 0
   -> var square = 0
   -> var diceRoll = 0
   ```
-}
+-->
 
 In this version of the game,
 the *first* action in the loop is to check for a ladder or a snake.
@@ -567,7 +567,7 @@ print("Game over!")
 ```
 
 
-@Comment {
+<!--
   - test: `snakesAndLadders2`
   
   ```swifttest
@@ -616,7 +616,7 @@ print("Game over!")
   << after diceRoll, square is 27
   << Game over!
   ```
-}
+-->
 
 After the code checks for snakes and ladders,
 the dice is rolled and the player is moved forward by `diceRoll` squares.
@@ -663,7 +663,7 @@ if temperatureInFahrenheit <= 32 {
 ```
 
 
-@Comment {
+<!--
   - test: `ifElse`
   
   ```swifttest
@@ -673,7 +673,7 @@ if temperatureInFahrenheit <= 32 {
      }
   <- It's very cold. Consider wearing a scarf.
   ```
-}
+-->
 
 The example above checks whether the temperature
 is less than or equal to 32 degrees Fahrenheit
@@ -698,7 +698,7 @@ if temperatureInFahrenheit <= 32 {
 ```
 
 
-@Comment {
+<!--
   - test: `ifElse`
   
   ```swifttest
@@ -710,7 +710,7 @@ if temperatureInFahrenheit <= 32 {
      }
   <- It's not that cold. Wear a t-shirt.
   ```
-}
+-->
 
 One of these two branches is always executed.
 Because the temperature has increased to `40` degrees Fahrenheit,
@@ -733,7 +733,7 @@ if temperatureInFahrenheit <= 32 {
 ```
 
 
-@Comment {
+<!--
   - test: `ifElse`
   
   ```swifttest
@@ -747,7 +747,7 @@ if temperatureInFahrenheit <= 32 {
      }
   <- It's really warm. Don't forget to wear sunscreen.
   ```
-}
+-->
 
 Here, an additional `if` statement was added to respond to particularly warm temperatures.
 The final `else` clause remains,
@@ -766,7 +766,7 @@ if temperatureInFahrenheit <= 32 {
 ```
 
 
-@Comment {
+<!--
   - test: `ifElse`
   
   ```swifttest
@@ -777,7 +777,7 @@ if temperatureInFahrenheit <= 32 {
         print("It's really warm. Don't forget to wear sunscreen.")
      }
   ```
-}
+-->
 
 Because the temperature is neither too cold nor too warm to trigger the `if` or `else if` conditions,
 no message is printed.
@@ -843,7 +843,7 @@ switch someCharacter {
 ```
 
 
-@Comment {
+<!--
   - test: `switch`
   
   ```swifttest
@@ -858,7 +858,7 @@ switch someCharacter {
      }
   <- The last letter of the alphabet
   ```
-}
+-->
 
 The `switch` statement's first case matches
 the first letter of the English alphabet, `a`,
@@ -901,7 +901,7 @@ switch anotherCharacter {
 ```
 
 
-@Comment {
+<!--
   - test: `noFallthrough`
   
   ```swifttest
@@ -919,7 +919,7 @@ switch anotherCharacter {
   !!                break
   // This will report a compile-time error.
   ```
-}
+-->
 
 Unlike a `switch` statement in C,
 this `switch` statement doesn't match both `"a"` and `"A"`.
@@ -945,7 +945,7 @@ switch anotherCharacter {
 ```
 
 
-@Comment {
+<!--
   - test: `compoundCaseInsteadOfFallthrough`
   
   ```swifttest
@@ -958,7 +958,7 @@ switch anotherCharacter {
      }
   <- The letter A
   ```
-}
+-->
 
 For readability,
 a compound case can also be written over multiple lines.
@@ -975,10 +975,10 @@ Values in `switch` cases can be checked for their inclusion in an interval.
 This example uses number intervals
 to provide a natural-language count for numbers of any size:
 
-@Comment {
+<!--
   REFERENCE
   Saturn has 62 moons with confirmed orbits.
-}
+-->
 
 ```swift
 let approximateCount = 62
@@ -1003,7 +1003,7 @@ print("There are \(naturalCount) \(countedThings).")
 ```
 
 
-@Comment {
+<!--
   - test: `intervalMatching`
   
   ```swifttest
@@ -1027,7 +1027,7 @@ print("There are \(naturalCount) \(countedThings).")
   -> print("There are \(naturalCount) \(countedThings).")
   <- There are dozens of moons orbiting Saturn.
   ```
-}
+-->
 
 In the above example, `approximateCount` is evaluated in a `switch` statement.
 Each `case` compares that value to a number or interval.
@@ -1065,7 +1065,7 @@ switch somePoint {
 ```
 
 
-@Comment {
+<!--
   - test: `tuples`
   
   ```swifttest
@@ -1084,7 +1084,7 @@ switch somePoint {
      }
   <- (1, 1) is inside the box
   ```
-}
+-->
 
 ![](coordinateGraphSimple)
 
@@ -1128,7 +1128,7 @@ switch anotherPoint {
 ```
 
 
-@Comment {
+<!--
   - test: `valueBindings`
   
   ```swifttest
@@ -1143,7 +1143,7 @@ switch anotherPoint {
      }
   <- on the x-axis with an x value of 2
   ```
-}
+-->
 
 ![](coordinateGraphMedium)
 
@@ -1193,7 +1193,7 @@ switch yetAnotherPoint {
 ```
 
 
-@Comment {
+<!--
   - test: `where`
   
   ```swifttest
@@ -1208,7 +1208,7 @@ switch yetAnotherPoint {
      }
   <- (1, -1) is on the line x == -y
   ```
-}
+-->
 
 ![](coordinateGraphComplex)
 
@@ -1252,7 +1252,7 @@ switch someCharacter {
 ```
 
 
-@Comment {
+<!--
   - test: `compound-switch-case`
   
   ```swifttest
@@ -1268,7 +1268,7 @@ switch someCharacter {
      }
   <- e is a vowel
   ```
-}
+-->
 
 The `switch` statement's first case matches
 all five lowercase vowels in the English language.
@@ -1298,7 +1298,7 @@ switch stillAnotherPoint {
 ```
 
 
-@Comment {
+<!--
   - test: `compound-switch-case`
   
   ```swifttest
@@ -1311,7 +1311,7 @@ switch stillAnotherPoint {
      }
   <- On an axis, 9 from the origin
   ```
-}
+-->
 
 The `case` above has two patterns:
 `(let distance, 0)` matches points on the x-axis
@@ -1362,7 +1362,7 @@ print(puzzleOutput)
 ```
 
 
-@Comment {
+<!--
   - test: `continue`
   
   ```swifttest
@@ -1378,7 +1378,7 @@ print(puzzleOutput)
   -> print(puzzleOutput)
   <- grtmndsthnklk
   ```
-}
+-->
 
 The code above calls the `continue` keyword whenever it matches a vowel or a space,
 causing the current iteration of the loop to end immediately
@@ -1399,9 +1399,9 @@ and transfers control to the code after the loop's closing brace (`}`).
 No further code from the current iteration of the loop is executed,
 and no further iterations of the loop are started.
 
-@Comment {
+<!--
   TODO: I need an example here.
-}
+-->
 
 #### Break in a Switch Statement
 
@@ -1451,7 +1451,7 @@ if let integerValue = possibleIntegerValue {
 ```
 
 
-@Comment {
+<!--
   - test: `breakInASwitchStatement`
   
   ```swifttest
@@ -1476,7 +1476,7 @@ if let integerValue = possibleIntegerValue {
      }
   <- The integer value of 三 is 3.
   ```
-}
+-->
 
 This example checks `numberSymbol` to determine whether it's
 a Latin, Arabic, Chinese, or Thai symbol for
@@ -1531,7 +1531,7 @@ print(description)
 ```
 
 
-@Comment {
+<!--
   - test: `fallthrough`
   
   ```swifttest
@@ -1547,7 +1547,7 @@ print(description)
   -> print(description)
   <- The number 5 is a prime number, and also an integer.
   ```
-}
+-->
 
 This example declares a new `String` variable called `description`
 and assigns it an initial value.
@@ -1637,7 +1637,7 @@ var diceRoll = 0
 ```
 
 
-@Comment {
+<!--
   - test: `labels`
   
   ```swifttest
@@ -1649,7 +1649,7 @@ var diceRoll = 0
   -> var square = 0
   -> var diceRoll = 0
   ```
-}
+-->
 
 This version of the game uses a `while` loop and a `switch` statement
 to implement the game's logic.
@@ -1680,7 +1680,7 @@ print("Game over!")
 ```
 
 
-@Comment {
+<!--
   - test: `labels`
   
   ```swifttest
@@ -1752,7 +1752,7 @@ print("Game over!")
   << finalSquare, game is over
   << Game over!
   ```
-}
+-->
 
 The dice is rolled at the start of each loop.
 Rather than moving the player immediately,
@@ -1818,7 +1818,7 @@ greet(person: ["name": "Jane", "location": "Cupertino"])
 ```
 
 
-@Comment {
+<!--
   - test: `guard`
   
   ```swifttest
@@ -1844,7 +1844,7 @@ greet(person: ["name": "Jane", "location": "Cupertino"])
   <- Hello Jane!
   <- I hope the weather is nice in Cupertino.
   ```
-}
+-->
 
 If the `guard` statement's condition is met,
 code execution continues after the `guard` statement's closing brace.
@@ -1897,7 +1897,7 @@ if #available(iOS 10, macOS 10.12, *) {
 ```
 
 
-@Comment {
+<!--
   - test: `availability`
   
   ```swifttest
@@ -1907,7 +1907,7 @@ if #available(iOS 10, macOS 10.12, *) {
          // Fall back to earlier iOS and macOS APIs
      }
   ```
-}
+-->
 
 The availability condition above specifies that in iOS,
 the body of the `if` statement executes only in iOS 10 and later;
@@ -1951,7 +1951,7 @@ func chooseBestColor() -> String {
 ```
 
 
-@Comment {
+<!--
   - test: `guard-with-pound-available`
   
   ```swifttest
@@ -1970,7 +1970,7 @@ func chooseBestColor() -> String {
   >> print(chooseBestColor())
   << blue
   ```
-}
+-->
 
 In the example above,
 the `ColorPreference` structure requires macOS 10.12 or later.
@@ -1996,7 +1996,7 @@ if #unavailable(iOS 10) {
 ```
 
 
-@Comment {
+<!--
   - test: `availability-and-unavailability`
   
   ```swifttest
@@ -2009,19 +2009,19 @@ if #unavailable(iOS 10) {
         // Fallback code
      }
   ```
-}
+-->
 
 Using the `#unavailable` form helps make your code more readable
 when the check contains only fallback code.
 
-@Comment {
+<!--
   FIXME
   Not a general purpose condition; can't combine with &&, etc.
   You can use it with if-let, and other Boolean conditions, using a comma
-}
+-->
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -2029,4 +2029,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Deinitialization.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Deinitialization.md
@@ -31,7 +31,7 @@ deinit {
 ```
 
 
-@Comment {
+<!--
   - test: `deinitializer`
   
   ```swifttest
@@ -41,7 +41,7 @@ deinit {
      }
   >> }
   ```
-}
+-->
 
 Deinitializers are called automatically, just before instance deallocation takes place.
 You aren't allowed to call a deinitializer yourself.
@@ -81,7 +81,7 @@ class Bank {
 ```
 
 
-@Comment {
+<!--
   - test: `deinitializer`
   
   ```swifttest
@@ -97,7 +97,7 @@ class Bank {
         }
      }
   ```
-}
+-->
 
 `Bank` keeps track of the current number of coins it holds with its `coinsInBank` property.
 It also offers two methods --- `distribute(coins:)` and `receive(coins:)` ---
@@ -131,7 +131,7 @@ class Player {
 ```
 
 
-@Comment {
+<!--
   - test: `deinitializer`
   
   ```swifttest
@@ -148,7 +148,7 @@ class Player {
         }
      }
   ```
-}
+-->
 
 Each `Player` instance is initialized with a starting allowance of
 a specified number of coins from the bank during initialization,
@@ -171,7 +171,7 @@ print("There are now \(Bank.coinsInBank) coins left in the bank")
 ```
 
 
-@Comment {
+<!--
   - test: `deinitializer`
   
   ```swifttest
@@ -181,7 +181,7 @@ print("There are now \(Bank.coinsInBank) coins left in the bank")
   -> print("There are now \(Bank.coinsInBank) coins left in the bank")
   <- There are now 9900 coins left in the bank
   ```
-}
+-->
 
 A new `Player` instance is created, with a request for 100 coins if they're available.
 This `Player` instance is stored in an optional `Player` variable called `playerOne`.
@@ -201,7 +201,7 @@ print("The bank now only has \(Bank.coinsInBank) coins left")
 ```
 
 
-@Comment {
+<!--
   - test: `deinitializer`
   
   ```swifttest
@@ -211,7 +211,7 @@ print("The bank now only has \(Bank.coinsInBank) coins left")
   -> print("The bank now only has \(Bank.coinsInBank) coins left")
   <- The bank now only has 7900 coins left
   ```
-}
+-->
 
 Here, the player has won 2,000 coins.
 The player's purse now contains 2,100 coins,
@@ -226,7 +226,7 @@ print("The bank now has \(Bank.coinsInBank) coins")
 ```
 
 
-@Comment {
+<!--
   - test: `deinitializer`
   
   ```swifttest
@@ -236,7 +236,7 @@ print("The bank now has \(Bank.coinsInBank) coins")
   -> print("The bank now has \(Bank.coinsInBank) coins")
   <- The bank now has 10000 coins
   ```
-}
+-->
 
 The player has now left the game.
 This is indicated by setting the optional `playerOne` variable to `nil`,
@@ -249,7 +249,7 @@ Just before this happens, its deinitializer is called automatically,
 and its coins are returned to the bank.
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -257,4 +257,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Enumerations.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Enumerations.md
@@ -33,10 +33,10 @@ For more about these capabilities, see
 <doc:Properties>, <doc:Methods>, <doc:Initialization>,
 <doc:Extensions>, and <doc:Protocols>.
 
-@Comment {
+<!--
   TODO: this chapter should probably mention that enums without associated values
   are hashable and equatable by default (and what that means in practice)
-}
+-->
 
 ## Enumeration Syntax
 
@@ -50,7 +50,7 @@ enum SomeEnumeration {
 ```
 
 
-@Comment {
+<!--
   - test: `enums`
   
   ```swifttest
@@ -58,7 +58,7 @@ enum SomeEnumeration {
         // enumeration definition goes here
      }
   ```
-}
+-->
 
 Here's an example for the four main points of a compass:
 
@@ -72,7 +72,7 @@ enum CompassPoint {
 ```
 
 
-@Comment {
+<!--
   - test: `enums`
   
   ```swifttest
@@ -83,7 +83,7 @@ enum CompassPoint {
         case west
      }
   ```
-}
+-->
 
 The values defined in an enumeration
 (such as `north`, `south`, `east`, and `west`)
@@ -108,7 +108,7 @@ enum Planet {
 ```
 
 
-@Comment {
+<!--
   - test: `enums`
   
   ```swifttest
@@ -116,7 +116,7 @@ enum Planet {
         case mercury, venus, earth, mars, jupiter, saturn, uranus, neptune
      }
   ```
-}
+-->
 
 Each enumeration definition defines a new type.
 Like other types in Swift, their names
@@ -130,13 +130,13 @@ var directionToHead = CompassPoint.west
 ```
 
 
-@Comment {
+<!--
   - test: `enums`
   
   ```swifttest
   -> var directionToHead = CompassPoint.west
   ```
-}
+-->
 
 The type of `directionToHead` is inferred
 when it's initialized with one of the possible values of `CompassPoint`.
@@ -148,13 +148,13 @@ directionToHead = .east
 ```
 
 
-@Comment {
+<!--
   - test: `enums`
   
   ```swifttest
   -> directionToHead = .east
   ```
-}
+-->
 
 The type of `directionToHead` is already known,
 and so you can drop the type when setting its value.
@@ -180,7 +180,7 @@ switch directionToHead {
 ```
 
 
-@Comment {
+<!--
   - test: `enums`
   
   ```swifttest
@@ -197,7 +197,7 @@ switch directionToHead {
      }
   <- Watch out for penguins
   ```
-}
+-->
 
 You can read this code as:
 
@@ -231,7 +231,7 @@ switch somePlanet {
 ```
 
 
-@Comment {
+<!--
   - test: `enums`
   
   ```swifttest
@@ -244,7 +244,7 @@ switch somePlanet {
      }
   <- Mostly harmless
   ```
-}
+-->
 
 ## Iterating over Enumeration Cases
 
@@ -266,7 +266,7 @@ print("\(numberOfChoices) beverages available")
 ```
 
 
-@Comment {
+<!--
   - test: `enums`
   
   ```swifttest
@@ -277,7 +277,7 @@ print("\(numberOfChoices) beverages available")
   -> print("\(numberOfChoices) beverages available")
   <- 3 beverages available
   ```
-}
+-->
 
 In the example above,
 you write `Beverage.allCases` to access a collection
@@ -298,7 +298,7 @@ for beverage in Beverage.allCases {
 ```
 
 
-@Comment {
+<!--
   - test: `enums`
   
   ```swifttest
@@ -312,7 +312,7 @@ for beverage in Beverage.allCases {
   // tea
   // juice
   ```
-}
+-->
 
 The syntax used in the examples above
 marks the enumeration as conforming to the
@@ -368,7 +368,7 @@ enum Barcode {
 ```
 
 
-@Comment {
+<!--
   - test: `enums`
   
   ```swifttest
@@ -377,7 +377,7 @@ enum Barcode {
         case qrCode(String)
      }
   ```
-}
+-->
 
 This can be read as:
 
@@ -398,13 +398,13 @@ var productBarcode = Barcode.upc(8, 85909, 51226, 3)
 ```
 
 
-@Comment {
+<!--
   - test: `enums`
   
   ```swifttest
   -> var productBarcode = Barcode.upc(8, 85909, 51226, 3)
   ```
-}
+-->
 
 This example creates a new variable called `productBarcode`
 and assigns it a value of `Barcode.upc`
@@ -417,13 +417,13 @@ productBarcode = .qrCode("ABCDEFGHIJKLMNOP")
 ```
 
 
-@Comment {
+<!--
   - test: `enums`
   
   ```swifttest
   -> productBarcode = .qrCode("ABCDEFGHIJKLMNOP")
   ```
-}
+-->
 
 At this point,
 the original `Barcode.upc` and its integer values are replaced by
@@ -452,7 +452,7 @@ switch productBarcode {
 ```
 
 
-@Comment {
+<!--
   - test: `enums`
   
   ```swifttest
@@ -464,7 +464,7 @@ switch productBarcode {
      }
   <- QR code: ABCDEFGHIJKLMNOP.
   ```
-}
+-->
 
 If all of the associated values for an enumeration case
 are extracted as constants, or if all are extracted as variables,
@@ -481,7 +481,7 @@ switch productBarcode {
 ```
 
 
-@Comment {
+<!--
   - test: `enums`
   
   ```swifttest
@@ -493,7 +493,7 @@ switch productBarcode {
      }
   <- QR code: ABCDEFGHIJKLMNOP.
   ```
-}
+-->
 
 ## Raw Values
 
@@ -516,7 +516,7 @@ enum ASCIIControlCharacter: Character {
 ```
 
 
-@Comment {
+<!--
   - test: `rawValues`
   
   ```swifttest
@@ -526,7 +526,7 @@ enum ASCIIControlCharacter: Character {
         case carriageReturn = "\r"
      }
   ```
-}
+-->
 
 Here, the raw values for an enumeration called `ASCIIControlCharacter`
 are defined to be of type `Character`,
@@ -566,7 +566,7 @@ enum Planet: Int {
 ```
 
 
-@Comment {
+<!--
   - test: `rawValues`
   
   ```swifttest
@@ -574,7 +574,7 @@ enum Planet: Int {
         case mercury = 1, venus, earth, mars, jupiter, saturn, uranus, neptune
      }
   ```
-}
+-->
 
 In the example above,
 `Planet.mercury` has an explicit raw value of `1`,
@@ -593,7 +593,7 @@ enum CompassPoint: String {
 ```
 
 
-@Comment {
+<!--
   - test: `rawValues`
   
   ```swifttest
@@ -601,7 +601,7 @@ enum CompassPoint: String {
         case north, south, east, west
      }
   ```
-}
+-->
 
 In the example above,
 `CompassPoint.south` has an implicit raw value of `"south"`, and so on.
@@ -617,7 +617,7 @@ let sunsetDirection = CompassPoint.west.rawValue
 ```
 
 
-@Comment {
+<!--
   - test: `rawValues`
   
   ```swifttest
@@ -629,7 +629,7 @@ let sunsetDirection = CompassPoint.west.rawValue
   /> sunsetDirection is \"\(sunsetDirection)\"
   </ sunsetDirection is "west"
   ```
-}
+-->
 
 ### Initializing from a Raw Value
 
@@ -647,7 +647,7 @@ let possiblePlanet = Planet(rawValue: 7)
 ```
 
 
-@Comment {
+<!--
   - test: `rawValues`
   
   ```swifttest
@@ -657,7 +657,7 @@ let possiblePlanet = Planet(rawValue: 7)
   >> assert(possiblePlanet == .uranus)
   // possiblePlanet is of type Planet? and equals Planet.uranus
   ```
-}
+-->
 
 Not all possible `Int` values will find a matching planet, however.
 Because of this, the raw value initializer always returns an *optional* enumeration case.
@@ -687,7 +687,7 @@ if let somePlanet = Planet(rawValue: positionToFind) {
 ```
 
 
-@Comment {
+<!--
   - test: `rawValues`
   
   ```swifttest
@@ -704,7 +704,7 @@ if let somePlanet = Planet(rawValue: positionToFind) {
      }
   <- There isn't a planet at position 11
   ```
-}
+-->
 
 This example uses optional binding to try to access a planet with a raw value of `11`.
 The statement `if let somePlanet = Planet(rawValue: 11)` creates an optional `Planet`,
@@ -712,10 +712,10 @@ and sets `somePlanet` to the value of that optional `Planet` if it can be retrie
 In this case, it isn't possible to retrieve a planet with a position of `11`,
 and so the `else` branch is executed instead.
 
-@Comment {
+<!--
   TODO: Switch around the order of this chapter so that all of the non-union stuff
   is together, and the union bits (aka Associated Values) come last.
-}
+-->
 
 ## Recursive Enumerations
 
@@ -737,7 +737,7 @@ enum ArithmeticExpression {
 ```
 
 
-@Comment {
+<!--
   - test: `recursive-enum-intro`
   
   ```swifttest
@@ -747,7 +747,7 @@ enum ArithmeticExpression {
          indirect case multiplication(ArithmeticExpression, ArithmeticExpression)
      }
   ```
-}
+-->
 
 You can also write `indirect` before the beginning of the enumeration
 to enable indirection for all of the enumeration's cases that have an associated value:
@@ -761,7 +761,7 @@ indirect enum ArithmeticExpression {
 ```
 
 
-@Comment {
+<!--
   - test: `recursive-enum`
   
   ```swifttest
@@ -771,7 +771,7 @@ indirect enum ArithmeticExpression {
          case multiplication(ArithmeticExpression, ArithmeticExpression)
      }
   ```
-}
+-->
 
 This enumeration can store three kinds of arithmetic expressions:
 a plain number,
@@ -797,7 +797,7 @@ let product = ArithmeticExpression.multiplication(sum, ArithmeticExpression.numb
 ```
 
 
-@Comment {
+<!--
   - test: `recursive-enum`
   
   ```swifttest
@@ -806,7 +806,7 @@ let product = ArithmeticExpression.multiplication(sum, ArithmeticExpression.numb
   -> let sum = ArithmeticExpression.addition(five, four)
   -> let product = ArithmeticExpression.multiplication(sum, ArithmeticExpression.number(2))
   ```
-}
+-->
 
 A recursive function is a straightforward way
 to work with data that has a recursive structure.
@@ -829,7 +829,7 @@ print(evaluate(product))
 ```
 
 
-@Comment {
+<!--
   - test: `recursive-enum`
   
   ```swifttest
@@ -847,7 +847,7 @@ print(evaluate(product))
   -> print(evaluate(product))
   <- 18
   ```
-}
+-->
 
 This function evaluates a plain number
 by simply returning the associated value.
@@ -857,7 +857,7 @@ evaluating the expression on the right-hand side,
 and then adding them or multiplying them.
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -865,4 +865,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/ErrorHandling.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/ErrorHandling.md
@@ -52,7 +52,7 @@ enum VendingMachineError: Error {
 ```
 
 
-@Comment {
+<!--
   - test: `throw-enum-error`
   
   ```swifttest
@@ -62,7 +62,7 @@ enum VendingMachineError: Error {
          case outOfStock
      }
   ```
-}
+-->
 
 Throwing an error lets you indicate that something unexpected happened
 and the normal flow of execution can't continue.
@@ -76,14 +76,14 @@ throw VendingMachineError.insufficientFunds(coinsNeeded: 5)
 ```
 
 
-@Comment {
+<!--
   - test: `throw-enum-error`
   
   ```swifttest
   -> throw VendingMachineError.insufficientFunds(coinsNeeded: 5)
   xx fatal error
   ```
-}
+-->
 
 ## Handling Errors
 
@@ -128,9 +128,9 @@ A function marked with `throws` is called a *throwing function*.
 If the function specifies a return type,
 you write the `throws` keyword before the return arrow (`->`).
 
-@Comment {
+<!--
   TODO Add discussion of throwing initializers
-}
+-->
 
 ```swift
 func canThrowErrors() throws -> String
@@ -139,7 +139,7 @@ func cannotThrowErrors() -> String
 ```
 
 
-@Comment {
+<!--
   - test: `throwingFunctionDeclaration`
   
   ```swifttest
@@ -149,9 +149,9 @@ func cannotThrowErrors() -> String
   -> func cannotThrowErrors() -> String
   >> { return "foo" }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `throwing-function-cant-overload-nonthrowing`
   
   ```swifttest
@@ -164,25 +164,25 @@ func cannotThrowErrors() -> String
   !! func f() -> Int { return 10 }
   !! ^
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `throwing-parameter-can-overload-nonthrowing`
   
   ```swifttest
   -> func f(callback: () -> Int) {}
   -> func f(callback: () throws -> Int) {} // Allowed
   ```
-}
+-->
 
-@Comment {
+<!--
   TODO: Add more assertions to test these behaviors
-}
+-->
 
-@Comment {
+<!--
   TODO: Write about the fact the above rules that govern overloading
   for throwing and nonthrowing functions.
-}
+-->
 
 A throwing function propagates errors that are thrown inside of it
 to the scope from which it's called.
@@ -237,7 +237,7 @@ class VendingMachine {
 ```
 
 
-@Comment {
+<!--
   - test: `errorHandling`
   
   ```swifttest
@@ -282,7 +282,7 @@ class VendingMachine {
          }
      }
   ```
-}
+-->
 
 The implementation of the `vend(itemNamed:)` method
 uses `guard` statements to exit the method early and throw appropriate errors
@@ -313,7 +313,7 @@ func buyFavoriteSnack(person: String, vendingMachine: VendingMachine) throws {
 ```
 
 
-@Comment {
+<!--
   - test: `errorHandling`
   
   ```swifttest
@@ -331,7 +331,7 @@ func buyFavoriteSnack(person: String, vendingMachine: VendingMachine) throws {
   >> try buyFavoriteSnack(person: "Alice", vendingMachine: v)
   << Dispensing Chips
   ```
-}
+-->
 
 In this example,
 the `buyFavoriteSnack(person: vendingMachine:)` function looks up a given person's favorite snack
@@ -356,7 +356,7 @@ struct PurchasedSnack {
 ```
 
 
-@Comment {
+<!--
   - test: `errorHandling`
   
   ```swifttest
@@ -383,7 +383,7 @@ struct PurchasedSnack {
   >> }
   << Threw EXPECTED error.
   ```
-}
+-->
 
 ### Handling Errors Using Do-Catch
 
@@ -419,11 +419,11 @@ and binds the error to a local constant named `error`.
 For more information about pattern matching,
 see <doc:Patterns>.
 
-@Comment {
+<!--
   TODO: Call out the reasoning why we don't let you
   consider a catch clause exhaustive by just matching
   the errors in an given enum without a general catch/default.
-}
+-->
 
 For example, the following code matches against all three cases
 of the `VendingMachineError` enumeration.
@@ -447,7 +447,7 @@ do {
 ```
 
 
-@Comment {
+<!--
   - test: `errorHandling`
   
   ```swifttest
@@ -467,7 +467,7 @@ do {
      }
   <- Insufficient funds. Please insert an additional 2 coins.
   ```
-}
+-->
 
 In the above example,
 the `buyFavoriteSnack(person:vendingMachine:)` function is called in a `try` expression,
@@ -519,7 +519,7 @@ do {
 ```
 
 
-@Comment {
+<!--
   - test: `errorHandling`
   
   ```swifttest
@@ -538,7 +538,7 @@ do {
      }
   <- Couldn't buy that from the vending machine.
   ```
-}
+-->
 
 In the `nourish(with:)` function,
 if `vend(itemNamed:)` throws an error that's
@@ -563,7 +563,7 @@ func eat(item: String) throws {
 ```
 
 
-@Comment {
+<!--
   - test: `errorHandling`
   
   ```swifttest
@@ -581,11 +581,11 @@ func eat(item: String) throws {
   >> }
   << Invalid selection, out of stock, or not enough money.
   ```
-}
+-->
 
-@Comment {
+<!--
   FIXME the catch clause is getting indented oddly in HTML output if I hard wrap it
-}
+-->
 
 The `eat(item:)` function lists the vending machine errors to catch,
 and its error text corresponds to the items in that list.
@@ -618,7 +618,7 @@ do {
 ```
 
 
-@Comment {
+<!--
   - test: `optional-try`
   
   ```swifttest
@@ -640,7 +640,7 @@ do {
   >> print(y as Any)
   << Optional(40)
   ```
-}
+-->
 
 If `someThrowingFunction()` throws an error,
 the value of `x` and `y` is `nil`.
@@ -664,7 +664,7 @@ func fetchData() -> Data? {
 ```
 
 
-@Comment {
+<!--
   - test: `optional-try-cached-data`
   
   ```swifttest
@@ -677,7 +677,7 @@ func fetchData() -> Data? {
          return nil
      }
   ```
-}
+-->
 
 ### Disabling Error Propagation
 
@@ -700,7 +700,7 @@ let photo = try! loadImage(atPath: "./Resources/John Appleseed.jpg")
 ```
 
 
-@Comment {
+<!--
   - test: `forceTryStatement`
   
   ```swifttest
@@ -710,7 +710,7 @@ let photo = try! loadImage(atPath: "./Resources/John Appleseed.jpg")
   >> }
   -> let photo = try! loadImage(atPath: "./Resources/John Appleseed.jpg")
   ```
-}
+-->
 
 ## Specifying Cleanup Actions
 
@@ -754,7 +754,7 @@ func processFile(filename: String) throws {
 ```
 
 
-@Comment {
+<!--
   - test: `defer`
   
   ```swifttest
@@ -778,7 +778,7 @@ func processFile(filename: String) throws {
         }
      }
   ```
-}
+-->
 
 The above example uses a `defer` statement
 to ensure that the `open(_:)` function
@@ -788,7 +788,7 @@ has a corresponding call to `close(_:)`.
 > even when no error handling code is involved.
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -796,4 +796,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Extensions.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Extensions.md
@@ -27,7 +27,7 @@ For more details, see <doc:Protocols#Protocol-Extensions>.
 > Note: Extensions can add new functionality to a type,
 > but they can't override existing functionality.
 
-@Comment {
+<!--
   - test: `extensionsCannotOverrideExistingBehavior`
   
   ```swifttest
@@ -73,7 +73,7 @@ For more details, see <doc:Protocols#Protocol-Extensions>.
   !! func foo() {}
   !!      ^
   ```
-}
+-->
 
 ## Extension Syntax
 
@@ -86,7 +86,7 @@ extension SomeType {
 ```
 
 
-@Comment {
+<!--
   - test: `extensionSyntax`
   
   ```swifttest
@@ -95,7 +95,7 @@ extension SomeType {
         // new functionality to add to SomeType goes here
      }
   ```
-}
+-->
 
 An extension can extend an existing type to make it adopt one or more protocols.
 To add protocol conformance,
@@ -109,7 +109,7 @@ extension SomeType: SomeProtocol, AnotherProtocol {
 ```
 
 
-@Comment {
+<!--
   - test: `extensionSyntax`
   
   ```swifttest
@@ -119,7 +119,7 @@ extension SomeType: SomeProtocol, AnotherProtocol {
         // implementation of protocol requirements goes here
      }
   ```
-}
+-->
 
 Adding protocol conformance in this way is described in
 <doc:Protocols#Adding-Protocol-Conformance-with-an-Extension>.
@@ -156,7 +156,7 @@ print("Three feet is \(threeFeet) meters")
 ```
 
 
-@Comment {
+<!--
   - test: `extensionsComputedProperties`
   
   ```swifttest
@@ -174,7 +174,7 @@ print("Three feet is \(threeFeet) meters")
   -> print("Three feet is \(threeFeet) meters")
   <- Three feet is 0.914399970739201 meters
   ```
-}
+-->
 
 These computed properties express that a `Double` value
 should be considered as a certain unit of length.
@@ -207,7 +207,7 @@ print("A marathon is \(aMarathon) meters long")
 ```
 
 
-@Comment {
+<!--
   - test: `extensionsComputedProperties`
   
   ```swifttest
@@ -215,12 +215,12 @@ print("A marathon is \(aMarathon) meters long")
   -> print("A marathon is \(aMarathon) meters long")
   <- A marathon is 42195.0 meters long
   ```
-}
+-->
 
 > Note: Extensions can add new computed properties, but they can't add stored properties,
 > or add property observers to existing properties.
 
-@Comment {
+<!--
   - test: `extensionsCannotAddStoredProperties`
   
   ```swifttest
@@ -230,11 +230,11 @@ print("A marathon is \(aMarathon) meters long")
   !! extension C { var x = 0 }
   !!                   ^
   ```
-}
+-->
 
-@Comment {
+<!--
   TODO: change this example to something more advisable / less contentious.
-}
+-->
 
 ## Initializers
 
@@ -281,7 +281,7 @@ struct Rect {
 ```
 
 
-@Comment {
+<!--
   - test: `extensionsInitializers`
   
   ```swifttest
@@ -296,7 +296,7 @@ struct Rect {
         var size = Size()
      }
   ```
-}
+-->
 
 Because the `Rect` structure provides default values for all of its properties,
 it receives a default initializer and a memberwise initializer automatically,
@@ -310,7 +310,7 @@ let memberwiseRect = Rect(origin: Point(x: 2.0, y: 2.0),
 ```
 
 
-@Comment {
+<!--
   - test: `extensionsInitializers`
   
   ```swifttest
@@ -318,7 +318,7 @@ let memberwiseRect = Rect(origin: Point(x: 2.0, y: 2.0),
   -> let memberwiseRect = Rect(origin: Point(x: 2.0, y: 2.0),
         size: Size(width: 5.0, height: 5.0))
   ```
-}
+-->
 
 You can extend the `Rect` structure to provide an additional initializer
 that takes a specific center point and size:
@@ -334,7 +334,7 @@ extension Rect {
 ```
 
 
-@Comment {
+<!--
   - test: `extensionsInitializers`
   
   ```swifttest
@@ -346,7 +346,7 @@ extension Rect {
         }
      }
   ```
-}
+-->
 
 This new initializer starts by calculating an appropriate origin point based on
 the provided `center` point and `size` value.
@@ -361,7 +361,7 @@ let centerRect = Rect(center: Point(x: 4.0, y: 4.0),
 ```
 
 
-@Comment {
+<!--
   - test: `extensionsInitializers`
   
   ```swifttest
@@ -370,7 +370,7 @@ let centerRect = Rect(center: Point(x: 4.0, y: 4.0),
   /> centerRect's origin is (\(centerRect.origin.x), \(centerRect.origin.y)) and its size is (\(centerRect.size.width), \(centerRect.size.height))
   </ centerRect's origin is (2.5, 2.5) and its size is (3.0, 3.0)
   ```
-}
+-->
 
 > Note: If you provide a new initializer with an extension,
 > you are still responsible for making sure that each instance is fully initialized
@@ -392,7 +392,7 @@ extension Int {
 ```
 
 
-@Comment {
+<!--
   - test: `extensionsInstanceMethods`
   
   ```swifttest
@@ -404,7 +404,7 @@ extension Int {
         }
      }
   ```
-}
+-->
 
 The `repetitions(task:)` method takes a single argument of type `() -> Void`,
 which indicates a function that has no parameters and doesn't return a value.
@@ -423,7 +423,7 @@ to perform a task that many number of times:
 ```
 
 
-@Comment {
+<!--
   - test: `extensionsInstanceMethods`
   
   ```swifttest
@@ -434,7 +434,7 @@ to perform a task that many number of times:
   </ Hello!
   </ Hello!
   ```
-}
+-->
 
 ### Mutating Instance Methods
 
@@ -458,7 +458,7 @@ someInt.square()
 ```
 
 
-@Comment {
+<!--
   - test: `extensionsInstanceMethods`
   
   ```swifttest
@@ -472,7 +472,7 @@ someInt.square()
   /> someInt is now \(someInt)
   </ someInt is now 9
   ```
-}
+-->
 
 ## Subscripts
 
@@ -507,7 +507,7 @@ extension Int {
 ```
 
 
-@Comment {
+<!--
   - test: `extensionsSubscripts`
   
   ```swifttest
@@ -537,18 +537,18 @@ extension Int {
   /> returns \(r3)
   </ returns 7
   ```
-}
+-->
 
-@Comment {
+<!--
   Rewrite the above to avoid bare expressions.
   Tracking bug is <rdar://problem/35301593>
-}
+-->
 
-@Comment {
+<!--
   TODO: Replace the for loop above with an exponent,
   if/when integer exponents land in the stdlib.
   Darwin's pow() function is only for floating point.
-}
+-->
 
 If the `Int` value doesn't have enough digits for the requested index,
 the subscript implementation returns `0`,
@@ -561,7 +561,7 @@ as if the number had been padded with zeros to the left:
 ```
 
 
-@Comment {
+<!--
   - test: `extensionsSubscripts`
   
   ```swifttest
@@ -572,16 +572,16 @@ as if the number had been padded with zeros to the left:
   >> let r5 =
   -> 0746381295[9]
   ```
-}
+-->
 
-@Comment {
+<!--
   TODO: provide an explanation of this example
-}
+-->
 
-@Comment {
+<!--
   Rewrite the above to avoid bare expressions.
   Tracking bug is <rdar://problem/35301593>
-}
+-->
 
 ## Nested Types
 
@@ -606,7 +606,7 @@ extension Int {
 ```
 
 
-@Comment {
+<!--
   - test: `extensionsNestedTypes`
   
   ```swifttest
@@ -626,7 +626,7 @@ extension Int {
         }
      }
   ```
-}
+-->
 
 This example adds a new nested enumeration to `Int`.
 This enumeration, called `Kind`,
@@ -659,7 +659,7 @@ printIntegerKinds([3, 19, -27, 0, -6, 0, 7])
 ```
 
 
-@Comment {
+<!--
   - test: `extensionsNestedTypes`
   
   ```swifttest
@@ -680,11 +680,11 @@ printIntegerKinds([3, 19, -27, 0, -6, 0, 7])
   << + + - 0 - 0 +
   // Prints "+ + - 0 - 0 + "
   ```
-}
+-->
 
-@Comment {
+<!--
   Workaround for rdar://26016325
-}
+-->
 
 This function, `printIntegerKinds(_:)`,
 takes an input array of `Int` values and iterates over those values in turn.
@@ -698,7 +698,7 @@ and prints an appropriate description.
 > such as `.negative` rather than `Int.Kind.negative`.
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -706,4 +706,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Functions.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Functions.md
@@ -55,7 +55,7 @@ func greet(person: String) -> String {
 ```
 
 
-@Comment {
+<!--
   - test: `definingAndCalling`
   
   ```swifttest
@@ -64,7 +64,7 @@ func greet(person: String) -> String {
         return greeting
      }
   ```
-}
+-->
 
 All of this information is rolled up into the function's *definition*,
 which is prefixed with the `func` keyword.
@@ -86,7 +86,7 @@ print(greet(person: "Brian"))
 ```
 
 
-@Comment {
+<!--
   - test: `definingAndCalling`
   
   ```swifttest
@@ -95,7 +95,7 @@ print(greet(person: "Brian"))
   -> print(greet(person: "Brian"))
   <- Hello, Brian!
   ```
-}
+-->
 
 You call the `greet(person:)` function
 by passing it a `String` value after the `person` argument label,
@@ -135,7 +135,7 @@ print(greetAgain(person: "Anna"))
 ```
 
 
-@Comment {
+<!--
   - test: `definingAndCalling`
   
   ```swifttest
@@ -145,7 +145,7 @@ print(greetAgain(person: "Anna"))
   -> print(greetAgain(person: "Anna"))
   <- Hello again, Anna!
   ```
-}
+-->
 
 ## Function Parameters and Return Values
 
@@ -168,7 +168,7 @@ print(sayHelloWorld())
 ```
 
 
-@Comment {
+<!--
   - test: `functionsWithoutParameters`
   
   ```swifttest
@@ -178,7 +178,7 @@ print(sayHelloWorld())
   -> print(sayHelloWorld())
   <- hello, world
   ```
-}
+-->
 
 The function definition still needs parentheses after the function's name,
 even though it doesn't take any parameters.
@@ -207,7 +207,7 @@ print(greet(person: "Tim", alreadyGreeted: true))
 ```
 
 
-@Comment {
+<!--
   - test: `definingAndCalling`
   
   ```swifttest
@@ -221,7 +221,7 @@ print(greet(person: "Tim", alreadyGreeted: true))
   -> print(greet(person: "Tim", alreadyGreeted: true))
   <- Hello again, Tim!
   ```
-}
+-->
 
 You call the `greet(person:alreadyGreeted:)` function
 by passing it both a `String` argument value labeled `person`
@@ -248,7 +248,7 @@ greet(person: "Dave")
 ```
 
 
-@Comment {
+<!--
   - test: `functionsWithoutReturnValues`
   
   ```swifttest
@@ -258,7 +258,7 @@ greet(person: "Dave")
   -> greet(person: "Dave")
   <- Hello, Dave!
   ```
-}
+-->
 
 Because it doesn't need to return a value,
 the function's definition doesn't include the return arrow (`->`)
@@ -287,7 +287,7 @@ printWithoutCounting(string: "hello, world")
 ```
 
 
-@Comment {
+<!--
   - test: `functionsWithoutReturnValues`
   
   ```swifttest
@@ -307,12 +307,12 @@ printWithoutCounting(string: "hello, world")
   << hello, world
   // prints "hello, world" but doesn't return a value
   ```
-}
+-->
 
-@Comment {
+<!--
   Rewrite the above to avoid bare expressions.
   Tracking bug is <rdar://problem/35301593>
-}
+-->
 
 The first function, `printAndCount(string:)`,
 prints a string, and then returns its character count as an `Int`.
@@ -329,10 +329,10 @@ but the returned value isn't used.
 > without returning a value,
 > and attempting to do so will result in a compile-time error.
 
-@Comment {
+<!--
   FIXME Unless the function is marked @discardableResult,
   ignoring its return value triggers a compile-time warning.
-}
+-->
 
 ### Functions with Multiple Return Values
 
@@ -358,7 +358,7 @@ func minMax(array: [Int]) -> (min: Int, max: Int) {
 ```
 
 
-@Comment {
+<!--
   - test: `tupleTypesAsReturnTypes`
   
   ```swifttest
@@ -375,7 +375,7 @@ func minMax(array: [Int]) -> (min: Int, max: Int) {
         return (currentMin, currentMax)
      }
   ```
-}
+-->
 
 The `minMax(array:)` function returns a tuple containing two `Int` values.
 These values are labeled `min` and `max`
@@ -400,7 +400,7 @@ print("min is \(bounds.min) and max is \(bounds.max)")
 ```
 
 
-@Comment {
+<!--
   - test: `tupleTypesAsReturnTypes`
   
   ```swifttest
@@ -408,7 +408,7 @@ print("min is \(bounds.min) and max is \(bounds.max)")
   -> print("min is \(bounds.min) and max is \(bounds.max)")
   <- min is -6 and max is 109
   ```
-}
+-->
 
 Note that the tuple's members don't need to be named
 at the point that the tuple is returned from the function,
@@ -457,7 +457,7 @@ func minMax(array: [Int]) -> (min: Int, max: Int)? {
 ```
 
 
-@Comment {
+<!--
   - test: `tupleTypesAsReturnTypes2`
   
   ```swifttest
@@ -475,7 +475,7 @@ func minMax(array: [Int]) -> (min: Int, max: Int)? {
         return (currentMin, currentMax)
      }
   ```
-}
+-->
 
 You can use optional binding to check whether this version of the `minMax(array:)` function
 returns an actual tuple value or `nil`:
@@ -488,7 +488,7 @@ if let bounds = minMax(array: [8, -6, 2, 109, 3, 71]) {
 ```
 
 
-@Comment {
+<!--
   - test: `tupleTypesAsReturnTypes2`
   
   ```swifttest
@@ -497,7 +497,7 @@ if let bounds = minMax(array: [8, -6, 2, 109, 3, 71]) {
      }
   <- min is -6 and max is 109
   ```
-}
+-->
 
 ### Functions With an Implicit Return
 
@@ -521,7 +521,7 @@ print(anotherGreeting(for: "Dave"))
 ```
 
 
-@Comment {
+<!--
   - test: `implicit-func-return`
   
   ```swifttest
@@ -537,7 +537,7 @@ print(anotherGreeting(for: "Dave"))
   -> print(anotherGreeting(for: "Dave"))
   <- Hello, Dave!
   ```
-}
+-->
 
 The entire definition of the `greeting(for:)` function
 is the greeting message that it returns,
@@ -559,7 +559,7 @@ property getters can also use an implicit return.
 > as an implicit return value,
 > because Swift knows that the implicit return doesn't happen.
 
-@Comment {
+<!--
   - test: `implicit-return-print-instead`
   
   ```swifttest
@@ -576,7 +576,7 @@ property getters can also use an implicit return.
   !! print(13)
   !! ^~~~~~~~~
   ```
-}
+-->
 
 ## Function Argument Labels and Parameter Names
 
@@ -597,7 +597,7 @@ someFunction(firstParameterName: 1, secondParameterName: 2)
 ```
 
 
-@Comment {
+<!--
   - test: `functionParameterNames`
   
   ```swifttest
@@ -607,21 +607,21 @@ someFunction(firstParameterName: 1, secondParameterName: 2)
      }
   -> someFunction(firstParameterName: 1, secondParameterName: 2)
   ```
-}
+-->
 
 All parameters must have unique names.
 Although it's possible for multiple parameters
 to have the same argument label,
 unique argument labels help make your code more readable.
 
-@Comment {
+<!--
   - test: `non-unique-external-name`
   
   ```swifttest
   -> func foo(external a: Int, external b: Int) {}
   -> foo(external: 7, external: 12)
   ```
-}
+-->
 
 ### Specifying Argument Labels
 
@@ -636,7 +636,7 @@ func someFunction(argumentLabel parameterName: Int) {
 ```
 
 
-@Comment {
+<!--
   - test: `externalParameterNames`
   
   ```swifttest
@@ -645,7 +645,7 @@ func someFunction(argumentLabel parameterName: Int) {
         // for that parameter.
      }
   ```
-}
+-->
 
 Here's a variation of the `greet(person:)` function
 that takes a person's name and hometown
@@ -660,7 +660,7 @@ print(greet(person: "Bill", from: "Cupertino"))
 ```
 
 
-@Comment {
+<!--
   - test: `externalParameterNames`
   
   ```swifttest
@@ -670,7 +670,7 @@ print(greet(person: "Bill", from: "Cupertino"))
   -> print(greet(person: "Bill", from: "Cupertino"))
   <- Hello Bill!  Glad you could visit from Cupertino.
   ```
-}
+-->
 
 The use of argument labels can allow a function
 to be called in an expressive, sentence-like manner,
@@ -690,7 +690,7 @@ someFunction(1, secondParameterName: 2)
 ```
 
 
-@Comment {
+<!--
   - test: `omittedExternalParameterNames`
   
   ```swifttest
@@ -700,7 +700,7 @@ someFunction(1, secondParameterName: 2)
      }
   -> someFunction(1, secondParameterName: 2)
   ```
-}
+-->
 
 If a parameter has an argument label,
 the argument *must* be labeled when you call the function.
@@ -721,7 +721,7 @@ someFunction(parameterWithoutDefault: 4) // parameterWithDefault is 12
 ```
 
 
-@Comment {
+<!--
   - test: `omittedExternalParameterNames`
   
   ```swifttest
@@ -732,7 +732,7 @@ someFunction(parameterWithoutDefault: 4) // parameterWithDefault is 12
   -> someFunction(parameterWithoutDefault: 3, parameterWithDefault: 6) // parameterWithDefault is 6
   -> someFunction(parameterWithoutDefault: 4) // parameterWithDefault is 12
   ```
-}
+-->
 
 Place parameters that don't have default values
 at the beginning of a function's parameter list,
@@ -775,7 +775,7 @@ arithmeticMean(3, 8.25, 18.75)
 ```
 
 
-@Comment {
+<!--
   - test: `variadicParameters`
   
   ```swifttest
@@ -795,12 +795,12 @@ arithmeticMean(3, 8.25, 18.75)
   /> returns \(r1), which is the arithmetic mean of these three numbers
   </ returns 10.0, which is the arithmetic mean of these three numbers
   ```
-}
+-->
 
-@Comment {
+<!--
   Rewrite the above to avoid bare expressions.
   Tracking bug is <rdar://problem/35301593>
-}
+-->
 
 A function can have multiple variadic parameters.
 The first parameter that comes after a variadic parameter
@@ -810,7 +810,7 @@ which arguments are passed to the variadic parameter
 and which arguments are passed to the parameters
 that come after the variadic parameter.
 
-@Comment {
+<!--
   - test: `variadic-parameters-and-labels`
   
   ```swifttest
@@ -823,9 +823,9 @@ that come after the variadic parameter.
   // Multiple
   >> func h(_a: Int..., b: String, _ c: Int..., d: String) {}
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `variadic-parameters-and-labels-failure`
   
   ```swifttest
@@ -835,7 +835,7 @@ that come after the variadic parameter.
   !! func f(_ a: Int..., _ b: String) {}
   !! ^
   ```
-}
+-->
 
 ### In-Out Parameters
 
@@ -878,7 +878,7 @@ func swapTwoInts(_ a: inout Int, _ b: inout Int) {
 ```
 
 
-@Comment {
+<!--
   - test: `inoutParameters`
   
   ```swifttest
@@ -888,7 +888,7 @@ func swapTwoInts(_ a: inout Int, _ b: inout Int) {
         b = temporaryA
      }
   ```
-}
+-->
 
 The `swapTwoInts(_:_:)` function simply swaps the value of `b` into `a`,
 and the value of `a` into `b`.
@@ -910,7 +910,7 @@ print("someInt is now \(someInt), and anotherInt is now \(anotherInt)")
 ```
 
 
-@Comment {
+<!--
   - test: `inoutParameters`
   
   ```swifttest
@@ -920,7 +920,7 @@ print("someInt is now \(someInt), and anotherInt is now \(anotherInt)")
   -> print("someInt is now \(someInt), and anotherInt is now \(anotherInt)")
   <- someInt is now 107, and anotherInt is now 3
   ```
-}
+-->
 
 The example above shows that
 the original values of `someInt` and `anotherInt`
@@ -933,10 +933,10 @@ even though they were originally defined outside of the function.
 > In-out parameters are an alternative way for a function to have an effect
 > outside of the scope of its function body.
 
-@Comment {
+<!--
   TODO: you can pass a subproperty of something as an inout reference.
   Would be great to show an example of this as a way to avoid temporary variables.
-}
+-->
 
 ## Function Types
 
@@ -955,7 +955,7 @@ func multiplyTwoInts(_ a: Int, _ b: Int) -> Int {
 ```
 
 
-@Comment {
+<!--
   - test: `functionTypes`
   
   ```swifttest
@@ -970,7 +970,7 @@ func multiplyTwoInts(_ a: Int, _ b: Int) -> Int {
   >> print(type(of: multiplyTwoInts))
   << (Int, Int) -> Int
   ```
-}
+-->
 
 This example defines two simple mathematical functions
 called `addTwoInts` and `multiplyTwoInts`.
@@ -993,7 +993,7 @@ func printHelloWorld() {
 ```
 
 
-@Comment {
+<!--
   - test: `functionTypes`
   
   ```swifttest
@@ -1003,7 +1003,7 @@ func printHelloWorld() {
   >> print(type(of: printHelloWorld))
   << () -> ()
   ```
-}
+-->
 
 The type of this function is `() -> Void`,
 or “a function that has no parameters, and returns `Void`.”
@@ -1019,13 +1019,13 @@ var mathFunction: (Int, Int) -> Int = addTwoInts
 ```
 
 
-@Comment {
+<!--
   - test: `functionTypes`
   
   ```swifttest
   -> var mathFunction: (Int, Int) -> Int = addTwoInts
   ```
-}
+-->
 
 This can be read as:
 
@@ -1045,14 +1045,14 @@ print("Result: \(mathFunction(2, 3))")
 ```
 
 
-@Comment {
+<!--
   - test: `functionTypes`
   
   ```swifttest
   -> print("Result: \(mathFunction(2, 3))")
   <- Result: 5
   ```
-}
+-->
 
 A different function with the same matching type can be assigned to the same variable,
 in the same way as for nonfunction types:
@@ -1064,7 +1064,7 @@ print("Result: \(mathFunction(2, 3))")
 ```
 
 
-@Comment {
+<!--
   - test: `functionTypes`
   
   ```swifttest
@@ -1072,7 +1072,7 @@ print("Result: \(mathFunction(2, 3))")
   -> print("Result: \(mathFunction(2, 3))")
   <- Result: 6
   ```
-}
+-->
 
 As with any other type,
 you can leave it to Swift to infer the function type
@@ -1084,7 +1084,7 @@ let anotherMathFunction = addTwoInts
 ```
 
 
-@Comment {
+<!--
   - test: `functionTypes`
   
   ```swifttest
@@ -1093,11 +1093,11 @@ let anotherMathFunction = addTwoInts
   << (Int, Int) -> Int
   // anotherMathFunction is inferred to be of type (Int, Int) -> Int
   ```
-}
+-->
 
-@Comment {
+<!--
   TODO: talk about defining typealiases for function types somewhere?
-}
+-->
 
 ### Function Types as Parameter Types
 
@@ -1117,7 +1117,7 @@ printMathResult(addTwoInts, 3, 5)
 ```
 
 
-@Comment {
+<!--
   - test: `functionTypes`
   
   ```swifttest
@@ -1127,7 +1127,7 @@ printMathResult(addTwoInts, 3, 5)
   -> printMathResult(addTwoInts, 3, 5)
   <- Result: 8
   ```
-}
+-->
 
 This example defines a function called `printMathResult(_:_:_:)`, which has three parameters.
 The first parameter is called `mathFunction`, and is of type `(Int, Int) -> Int`.
@@ -1167,7 +1167,7 @@ func stepBackward(_ input: Int) -> Int {
 ```
 
 
-@Comment {
+<!--
   - test: `functionTypes`
   
   ```swifttest
@@ -1178,7 +1178,7 @@ func stepBackward(_ input: Int) -> Int {
         return input - 1
      }
   ```
-}
+-->
 
 Here's a function called `chooseStepFunction(backward:)`,
 whose return type is `(Int) -> Int`.
@@ -1192,7 +1192,7 @@ func chooseStepFunction(backward: Bool) -> (Int) -> Int {
 ```
 
 
-@Comment {
+<!--
   - test: `functionTypes`
   
   ```swifttest
@@ -1200,7 +1200,7 @@ func chooseStepFunction(backward: Bool) -> (Int) -> Int {
         return backward ? stepBackward : stepForward
      }
   ```
-}
+-->
 
 You can now use `chooseStepFunction(backward:)` to obtain a function
 that will step in one direction or the other:
@@ -1212,7 +1212,7 @@ let moveNearerToZero = chooseStepFunction(backward: currentValue > 0)
 ```
 
 
-@Comment {
+<!--
   - test: `functionTypes`
   
   ```swifttest
@@ -1222,7 +1222,7 @@ let moveNearerToZero = chooseStepFunction(backward: currentValue > 0)
   << (Int) -> Int
   // moveNearerToZero now refers to the stepBackward() function
   ```
-}
+-->
 
 The example above determines whether a positive or negative step is needed
 to move a variable called `currentValue` progressively closer to zero.
@@ -1249,7 +1249,7 @@ print("zero!")
 ```
 
 
-@Comment {
+<!--
   - test: `functionTypes`
   
   ```swifttest
@@ -1265,7 +1265,7 @@ print("zero!")
   </ 1...
   </ zero!
   ```
-}
+-->
 
 ## Nested Functions
 
@@ -1304,7 +1304,7 @@ print("zero!")
 ```
 
 
-@Comment {
+<!--
   - test: `nestedFunctions`
   
   ```swifttest
@@ -1329,10 +1329,10 @@ print("zero!")
   </ -1...
   </ zero!
   ```
-}
+-->
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -1340,4 +1340,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Generics.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Generics.md
@@ -33,7 +33,7 @@ func swapTwoInts(_ a: inout Int, _ b: inout Int) {
 ```
 
 
-@Comment {
+<!--
   - test: `whyGenerics`
   
   ```swifttest
@@ -43,7 +43,7 @@ func swapTwoInts(_ a: inout Int, _ b: inout Int) {
         b = temporaryA
      }
   ```
-}
+-->
 
 This function makes use of in-out parameters to swap the values of `a` and `b`,
 as described in <doc:Functions#In-Out-Parameters>.
@@ -61,7 +61,7 @@ print("someInt is now \(someInt), and anotherInt is now \(anotherInt)")
 ```
 
 
-@Comment {
+<!--
   - test: `whyGenerics`
   
   ```swifttest
@@ -71,7 +71,7 @@ print("someInt is now \(someInt), and anotherInt is now \(anotherInt)")
   -> print("someInt is now \(someInt), and anotherInt is now \(anotherInt)")
   <- someInt is now 107, and anotherInt is now 3
   ```
-}
+-->
 
 The `swapTwoInts(_:_:)` function is useful, but it can only be used with `Int` values.
 If you want to swap two `String` values,
@@ -94,7 +94,7 @@ func swapTwoDoubles(_ a: inout Double, _ b: inout Double) {
 ```
 
 
-@Comment {
+<!--
   - test: `whyGenerics`
   
   ```swifttest
@@ -110,7 +110,7 @@ func swapTwoDoubles(_ a: inout Double, _ b: inout Double) {
         b = temporaryA
      }
   ```
-}
+-->
 
 You may have noticed that the bodies of
 the `swapTwoInts(_:_:)`, `swapTwoStrings(_:_:)`, and `swapTwoDoubles(_:_:)` functions are identical.
@@ -147,7 +147,7 @@ func swapTwoValues<T>(_ a: inout T, _ b: inout T) {
 ```
 
 
-@Comment {
+<!--
   - test: `genericFunctions`
   
   ```swifttest
@@ -157,14 +157,14 @@ func swapTwoValues<T>(_ a: inout T, _ b: inout T) {
         b = temporaryA
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   This could be done in one line using a tuple pattern: (a, b) = (b, a)
   That's probably not as approachable here, and the novel syntax to avoid an
   explicit placeholder variable might distract from the discussion of
   generics.
-}
+-->
 
 The body of the `swapTwoValues(_:_:)` function
 is identical to the body of the `swapTwoInts(_:_:)` function.
@@ -178,7 +178,7 @@ func swapTwoValues<T>(_ a: inout T, _ b: inout T)
 ```
 
 
-@Comment {
+<!--
   - test: `genericFunctionsComparison`
   
   ```swifttest
@@ -195,7 +195,7 @@ func swapTwoValues<T>(_ a: inout T, _ b: inout T)
   >>    b = temporaryA
   >> }
   ```
-}
+-->
 
 The generic version of the function
 uses a *placeholder* type name (called `T`, in this case)
@@ -234,7 +234,7 @@ swapTwoValues(&someString, &anotherString)
 ```
 
 
-@Comment {
+<!--
   - test: `genericFunctions`
   
   ```swifttest
@@ -250,7 +250,7 @@ swapTwoValues(&someString, &anotherString)
   /> someString is now \"\(someString)\", and anotherString is now \"\(anotherString)\"
   </ someString is now "world", and anotherString is now "hello"
   ```
-}
+-->
 
 > Note: The `swapTwoValues(_:_:)` function defined above is inspired by
 > a generic function called `swap`, which is part of the Swift standard library,
@@ -349,7 +349,7 @@ struct IntStack {
 ```
 
 
-@Comment {
+<!--
   - test: `genericStack`
   
   ```swifttest
@@ -370,7 +370,7 @@ struct IntStack {
   >> print("the stack now contains \(intStack.items.count) integers")
   << the stack now contains 4 integers
   ```
-}
+-->
 
 This structure uses an `Array` property called `items` to store the values in the stack.
 `Stack` provides two methods, `push` and `pop`,
@@ -397,7 +397,7 @@ struct Stack<Element> {
 ```
 
 
-@Comment {
+<!--
   - test: `genericStack`
   
   ```swifttest
@@ -411,7 +411,7 @@ struct Stack<Element> {
         }
      }
   ```
-}
+-->
 
 Note how the generic version of `Stack`
 is essentially the same as the nongeneric version,
@@ -452,7 +452,7 @@ stackOfStrings.push("cuatro")
 ```
 
 
-@Comment {
+<!--
   - test: `genericStack`
   
   ```swifttest
@@ -464,7 +464,7 @@ stackOfStrings.push("cuatro")
   /> the stack now contains \(stackOfStrings.items.count) strings
   </ the stack now contains 4 strings
   ```
-}
+-->
 
 Here's how `stackOfStrings` looks after pushing these four values on to the stack:
 
@@ -479,7 +479,7 @@ let fromTheTop = stackOfStrings.pop()
 ```
 
 
-@Comment {
+<!--
   - test: `genericStack`
   
   ```swifttest
@@ -487,7 +487,7 @@ let fromTheTop = stackOfStrings.pop()
   /> fromTheTop is equal to \"\(fromTheTop)\", and the stack now contains \(stackOfStrings.items.count) strings
   </ fromTheTop is equal to "cuatro", and the stack now contains 3 strings
   ```
-}
+-->
 
 Here's how the stack looks after popping its top value:
 
@@ -516,7 +516,7 @@ extension Stack {
 ```
 
 
-@Comment {
+<!--
   - test: `genericStack`
   
   ```swifttest
@@ -526,7 +526,7 @@ extension Stack {
         }
      }
   ```
-}
+-->
 
 The `topItem` property returns an optional value of type `Element`.
 If the stack is empty, `topItem` returns `nil`;
@@ -548,7 +548,7 @@ if let topItem = stackOfStrings.topItem {
 ```
 
 
-@Comment {
+<!--
   - test: `genericStack`
   
   ```swifttest
@@ -557,7 +557,7 @@ if let topItem = stackOfStrings.topItem {
      }
   <- The top item on the stack is tres.
   ```
-}
+-->
 
 Extensions of a generic type can also include requirements
 that instances of the extended type must satisfy
@@ -616,7 +616,7 @@ func someFunction<T: SomeClass, U: SomeProtocol>(someT: T, someU: U) {
 ```
 
 
-@Comment {
+<!--
   - test: `typeConstraints`
   
   ```swifttest
@@ -626,7 +626,7 @@ func someFunction<T: SomeClass, U: SomeProtocol>(someT: T, someU: U) {
         // function body goes here
      }
   ```
-}
+-->
 
 The hypothetical function above has two type parameters.
 The first type parameter, `T`, has a type constraint
@@ -655,7 +655,7 @@ func findIndex(ofString valueToFind: String, in array: [String]) -> Int? {
 ```
 
 
-@Comment {
+<!--
   - test: `typeConstraints`
   
   ```swifttest
@@ -668,7 +668,7 @@ func findIndex(ofString valueToFind: String, in array: [String]) -> Int? {
         return nil
      }
   ```
-}
+-->
 
 The `findIndex(ofString:in:)` function can be used to find a string value in an array of strings:
 
@@ -681,7 +681,7 @@ if let foundIndex = findIndex(ofString: "llama", in: strings) {
 ```
 
 
-@Comment {
+<!--
   - test: `typeConstraints`
   
   ```swifttest
@@ -691,7 +691,7 @@ if let foundIndex = findIndex(ofString: "llama", in: strings) {
      }
   <- The index of llama is 2
   ```
-}
+-->
 
 The principle of finding the index of a value in an array isn't useful only for strings, however.
 You can write the same functionality as a generic function
@@ -717,7 +717,7 @@ func findIndex<T>(of valueToFind: T, in array:[T]) -> Int? {
 ```
 
 
-@Comment {
+<!--
   - test: `typeConstraints-err`
   
   ```swifttest
@@ -733,7 +733,7 @@ func findIndex<T>(of valueToFind: T, in array:[T]) -> Int? {
   !!       if value == valueToFind {
   !!          ~~~~~ ^  ~~~~~~~~~~~
   ```
-}
+-->
 
 This function doesn't compile as written above.
 The problem lies with the equality check, “`if value == valueToFind`”.

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Inheritance.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Inheritance.md
@@ -54,7 +54,7 @@ class Vehicle {
 ```
 
 
-@Comment {
+<!--
   - test: `inheritance`
   
   ```swifttest
@@ -68,7 +68,7 @@ class Vehicle {
         }
      }
   ```
-}
+-->
 
 You create a new instance of `Vehicle` with *initializer syntax*,
 which is written as a type name followed by empty parentheses:
@@ -78,13 +78,13 @@ let someVehicle = Vehicle()
 ```
 
 
-@Comment {
+<!--
   - test: `inheritance`
   
   ```swifttest
   -> let someVehicle = Vehicle()
   ```
-}
+-->
 
 Having created a new `Vehicle` instance,
 you can access its `description` property to print
@@ -96,14 +96,14 @@ print("Vehicle: \(someVehicle.description)")
 ```
 
 
-@Comment {
+<!--
   - test: `inheritance`
   
   ```swifttest
   -> print("Vehicle: \(someVehicle.description)")
   </ Vehicle: traveling at 0.0 miles per hour
   ```
-}
+-->
 
 The `Vehicle` class defines common characteristics for an arbitrary vehicle,
 but isn't much use in itself.
@@ -127,7 +127,7 @@ class SomeSubclass: SomeSuperclass {
 ```
 
 
-@Comment {
+<!--
   - test: `protocolSyntax`
   
   ```swifttest
@@ -136,7 +136,7 @@ class SomeSubclass: SomeSuperclass {
         // subclass definition goes here
      }
   ```
-}
+-->
 
 The following example defines a subclass called `Bicycle`,
 with a superclass of `Vehicle`:
@@ -148,7 +148,7 @@ class Bicycle: Vehicle {
 ```
 
 
-@Comment {
+<!--
   - test: `inheritance`
   
   ```swifttest
@@ -156,7 +156,7 @@ class Bicycle: Vehicle {
         var hasBasket = false
      }
   ```
-}
+-->
 
 The new `Bicycle` class automatically gains all of the characteristics of `Vehicle`,
 such as its `currentSpeed` and `description` properties and its `makeNoise()` method.
@@ -176,14 +176,14 @@ bicycle.hasBasket = true
 ```
 
 
-@Comment {
+<!--
   - test: `inheritance`
   
   ```swifttest
   -> let bicycle = Bicycle()
   -> bicycle.hasBasket = true
   ```
-}
+-->
 
 You can also modify the inherited `currentSpeed` property of a `Bicycle` instance,
 and query the instance's inherited `description` property:
@@ -195,7 +195,7 @@ print("Bicycle: \(bicycle.description)")
 ```
 
 
-@Comment {
+<!--
   - test: `inheritance`
   
   ```swifttest
@@ -203,7 +203,7 @@ print("Bicycle: \(bicycle.description)")
   -> print("Bicycle: \(bicycle.description)")
   </ Bicycle: traveling at 15.0 miles per hour
   ```
-}
+-->
 
 Subclasses can themselves be subclassed.
 The next example creates a subclass of `Bicycle` for a two-seater bicycle
@@ -216,7 +216,7 @@ class Tandem: Bicycle {
 ```
 
 
-@Comment {
+<!--
   - test: `inheritance`
   
   ```swifttest
@@ -224,7 +224,7 @@ class Tandem: Bicycle {
         var currentNumberOfPassengers = 0
      }
   ```
-}
+-->
 
 `Tandem` inherits all of the properties and methods from `Bicycle`,
 which in turn inherits all of the properties and methods from `Vehicle`.
@@ -245,7 +245,7 @@ print("Tandem: \(tandem.description)")
 ```
 
 
-@Comment {
+<!--
   - test: `inheritance`
   
   ```swifttest
@@ -256,7 +256,7 @@ print("Tandem: \(tandem.description)")
   -> print("Tandem: \(tandem.description)")
   </ Tandem: traveling at 22.0 miles per hour
   ```
-}
+-->
 
 ## Overriding
 
@@ -314,7 +314,7 @@ class Train: Vehicle {
 ```
 
 
-@Comment {
+<!--
   - test: `inheritance`
   
   ```swifttest
@@ -324,7 +324,7 @@ class Train: Vehicle {
         }
      }
   ```
-}
+-->
 
 If you create a new instance of `Train` and call its `makeNoise()` method,
 you can see that the `Train` subclass version of the method is called:
@@ -336,7 +336,7 @@ train.makeNoise()
 ```
 
 
-@Comment {
+<!--
   - test: `inheritance`
   
   ```swifttest
@@ -344,7 +344,7 @@ train.makeNoise()
   -> train.makeNoise()
   <- Choo Choo
   ```
-}
+-->
 
 ### Overriding Properties
 
@@ -393,7 +393,7 @@ class Car: Vehicle {
 ```
 
 
-@Comment {
+<!--
   - test: `inheritance`
   
   ```swifttest
@@ -404,7 +404,7 @@ class Car: Vehicle {
         }
      }
   ```
-}
+-->
 
 The override of the `description` property starts by calling `super.description`,
 which returns the `Vehicle` class's `description` property.
@@ -425,7 +425,7 @@ print("Car: \(car.description)")
 ```
 
 
-@Comment {
+<!--
   - test: `inheritance`
   
   ```swifttest
@@ -435,7 +435,7 @@ print("Car: \(car.description)")
   -> print("Car: \(car.description)")
   </ Car: traveling at 25.0 miles per hour in gear 3
   ```
-}
+-->
 
 #### Overriding Property Observers
 
@@ -470,7 +470,7 @@ class AutomaticCar: Car {
 ```
 
 
-@Comment {
+<!--
   - test: `inheritance`
   
   ```swifttest
@@ -482,7 +482,7 @@ class AutomaticCar: Car {
         }
      }
   ```
-}
+-->
 
 Whenever you set the `currentSpeed` property of an `AutomaticCar` instance,
 the property's `didSet` observer sets the instance's `gear` property to
@@ -500,7 +500,7 @@ print("AutomaticCar: \(automatic.description)")
 ```
 
 
-@Comment {
+<!--
   - test: `inheritance`
   
   ```swifttest
@@ -509,7 +509,7 @@ print("AutomaticCar: \(automatic.description)")
   -> print("AutomaticCar: \(automatic.description)")
   </ AutomaticCar: traveling at 35.0 miles per hour in gear 4
   ```
-}
+-->
 
 ## Preventing Overrides
 
@@ -524,7 +524,7 @@ is reported as a compile-time error.
 Methods, properties, or subscripts that you add to a class in an extension
 can also be marked as final within the extension's definition.
 
-@Comment {
+<!--
   - test: `finalPreventsOverriding`
   
   ```swifttest
@@ -556,13 +556,13 @@ can also be marked as final within the extension's definition.
   !! final func someFunction() {
   !! ^
   ```
-}
+-->
 
 You can mark an entire class as final by writing the `final` modifier
 before the `class` keyword in its class definition (`final class`).
 Any attempt to subclass a final class is reported as a compile-time error.
 
-@Comment {
+<!--
   - test: `finalClassPreventsOverriding`
   
   ```swifttest
@@ -597,30 +597,30 @@ Any attempt to subclass a final class is reported as a compile-time error.
   !! class D : C {
   !!       ^
   ```
-}
+-->
 
-@Comment {
+<!--
   TODO: I should probably provide an example here.
-}
+-->
 
-@Comment {
+<!--
   TODO: provide more information about function signatures,
   and what does / doesn't make them unique.
   For example, the parameter names don't have to match
   in order for a function to override a similar signature in its parent.
   (This is true for both of the function declaration syntaxes.)
-}
+-->
 
-@Comment {
+<!--
   TODO: Mention that you can return more-specific types, and take less-specific types,
   when overriding methods that use optionals / unchecked optionals.
   
   TODO: Overriding Type Methods
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-}
+-->
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -628,4 +628,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Initialization.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Initialization.md
@@ -2719,7 +2719,7 @@ class SomeClass {
         init() {}
      }
   !$ error: 'required' initializer 'init(i:)' must be provided by subclass of 'C'
-  !! -->
+  !! }
   !! ^
   !$ note: 'required' initializer is declared in superclass here
   !!    required init(i: Int) {}
@@ -2741,7 +2741,7 @@ class SomeClass {
         init(s: String) {}
      }
   !$ error: 'required' initializer 'init(i:)' must be provided by subclass of 'C'
-  !! -->
+  !! }
   !! ^
   !$ note: 'required' initializer is declared in superclass here
   !!    required convenience init(i: Int) {

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Initialization.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Initialization.md
@@ -48,7 +48,7 @@ init() {
 ```
 
 
-@Comment {
+<!--
   - test: `initializerSyntax`
   
   ```swifttest
@@ -58,7 +58,7 @@ init() {
      }
   >> }
   ```
-}
+-->
 
 The example below defines a new structure called `Fahrenheit`
 to store temperatures expressed in the Fahrenheit scale.
@@ -78,7 +78,7 @@ print("The default temperature is \(f.temperature)° Fahrenheit")
 ```
 
 
-@Comment {
+<!--
   - test: `fahrenheitInit`
   
   ```swifttest
@@ -92,7 +92,7 @@ print("The default temperature is \(f.temperature)° Fahrenheit")
   -> print("The default temperature is \(f.temperature)° Fahrenheit")
   <- The default temperature is 32.0° Fahrenheit
   ```
-}
+-->
 
 The structure defines a single initializer, `init`, with no parameters,
 which initializes the stored temperature with a value of `32.0`
@@ -128,7 +128,7 @@ struct Fahrenheit {
 ```
 
 
-@Comment {
+<!--
   - test: `fahrenheitDefault`
   
   ```swifttest
@@ -136,7 +136,7 @@ struct Fahrenheit {
         var temperature = 32.0
      }
   ```
-}
+-->
 
 ## Customizing Initialization
 
@@ -176,7 +176,7 @@ let freezingPointOfWater = Celsius(fromKelvin: 273.15)
 ```
 
 
-@Comment {
+<!--
   - test: `initialization`
   
   ```swifttest
@@ -196,7 +196,7 @@ let freezingPointOfWater = Celsius(fromKelvin: 273.15)
   /> freezingPointOfWater.temperatureInCelsius is \(freezingPointOfWater.temperatureInCelsius)
   </ freezingPointOfWater.temperatureInCelsius is 0.0
   ```
-}
+-->
 
 The first initializer has a single initialization parameter
 with an argument label of `fromFahrenheit` and a parameter name of `fahrenheit`.
@@ -206,10 +206,10 @@ Both initializers convert their single argument into
 the corresponding Celsius value
 and store this value in a property called `temperatureInCelsius`.
 
-@Comment {
+<!--
   TODO: I need to provide an example of default values for initializer parameters,
   to show they can help you to get multiple initializers "for free" (after a fashion).
-}
+-->
 
 ### Parameter Names and Argument Labels
 
@@ -253,7 +253,7 @@ struct Color {
 ```
 
 
-@Comment {
+<!--
   - test: `externalParameterNames, externalParameterNames-err`
   
   ```swifttest
@@ -271,7 +271,7 @@ struct Color {
         }
      }
   ```
-}
+-->
 
 Both initializers can be used to create a new `Color` instance,
 by providing named values for each initializer parameter:
@@ -282,7 +282,7 @@ let halfGray = Color(white: 0.5)
 ```
 
 
-@Comment {
+<!--
   - test: `externalParameterNames`
   
   ```swifttest
@@ -292,7 +292,7 @@ let halfGray = Color(white: 0.5)
   >> assert(halfGray.green == 0.5)
   >> assert(halfGray.blue == 0.5)
   ```
-}
+-->
 
 Note that it isn't possible to call these initializers
 without using argument labels.
@@ -305,7 +305,7 @@ let veryGreen = Color(0.0, 1.0, 0.0)
 ```
 
 
-@Comment {
+<!--
   - test: `externalParameterNames-err`
   
   ```swifttest
@@ -316,7 +316,7 @@ let veryGreen = Color(0.0, 1.0, 0.0)
   !! ^
   !! red: green:  blue:
   ```
-}
+-->
 
 ### Initializer Parameters Without Argument Labels
 
@@ -347,7 +347,7 @@ let bodyTemperature = Celsius(37.0)
 ```
 
 
-@Comment {
+<!--
   - test: `initializersWithoutExternalParameterNames`
   
   ```swifttest
@@ -367,7 +367,7 @@ let bodyTemperature = Celsius(37.0)
   /> bodyTemperature.temperatureInCelsius is \(bodyTemperature.temperatureInCelsius)
   </ bodyTemperature.temperatureInCelsius is 37.0
   ```
-}
+-->
 
 The initializer call `Celsius(37.0)` is clear in its intent
 without the need for an argument label.
@@ -405,7 +405,7 @@ cheeseQuestion.response = "Yes, I do like cheese."
 ```
 
 
-@Comment {
+<!--
   - test: `surveyQuestionVariable`
   
   ```swifttest
@@ -424,7 +424,7 @@ cheeseQuestion.response = "Yes, I do like cheese."
   <- Do you like cheese?
   -> cheeseQuestion.response = "Yes, I do like cheese."
   ```
-}
+-->
 
 The response to a survey question can't be known until it's asked,
 and so the `response` property is declared with a type of `String?`,
@@ -440,7 +440,7 @@ as long as it's set to a definite value by the time initialization finishes.
 Once a constant property is assigned a value,
 it can't be further modified.
 
-@Comment {
+<!--
   - test: `constantPropertyAssignment`
   
   ```swifttest
@@ -459,9 +459,9 @@ it can't be further modified.
   !! ^~~
   !! var
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `constantPropertyAssignmentWithInitialValue`
   
   ```swifttest
@@ -482,7 +482,7 @@ it can't be further modified.
   !! ^~~
   !! var
   ```
-}
+-->
 
 > Note: For class instances,
 > a constant property can be modified during initialization
@@ -513,7 +513,7 @@ beetsQuestion.response = "I also like beets. (But not with cheese.)"
 ```
 
 
-@Comment {
+<!--
   - test: `surveyQuestionConstant`
   
   ```swifttest
@@ -532,7 +532,7 @@ beetsQuestion.response = "I also like beets. (But not with cheese.)"
   <- How about beets?
   -> beetsQuestion.response = "I also like beets. (But not with cheese.)"
   ```
-}
+-->
 
 ## Default Initializers
 
@@ -543,7 +543,7 @@ and doesn't provide at least one initializer itself.
 The default initializer simply creates a new instance
 with all of its properties set to their default values.
 
-@Comment {
+<!--
   - test: `defaultInitializersForStructAndClass`
   
   ```swifttest
@@ -555,7 +555,7 @@ with all of its properties set to their default values.
   -> assert(B().a == "a")
   -> assert(B().b ==  "b")
   ```
-}
+-->
 
 This example defines a class called `ShoppingListItem`,
 which encapsulates the name, quantity, and purchase state
@@ -571,7 +571,7 @@ var item = ShoppingListItem()
 ```
 
 
-@Comment {
+<!--
   - test: `initialization`
   
   ```swifttest
@@ -582,7 +582,7 @@ var item = ShoppingListItem()
      }
   -> var item = ShoppingListItem()
   ```
-}
+-->
 
 Because all properties of the `ShoppingListItem` class have default values,
 and because it's a base class with no superclass,
@@ -604,7 +604,7 @@ Unlike a default initializer,
 the structure receives a memberwise initializer
 even if it has stored properties that don't have default values.
 
-@Comment {
+<!--
   - test: `memberwiseInitializersDontRequireDefaultStoredPropertyValues`
   
   ```swifttest
@@ -614,7 +614,7 @@ even if it has stored properties that don't have default values.
   -> struct SS { var int = 10; var string: String }
   -> let ss = SS(int: 42, string: "hello")
   ```
-}
+-->
 
 The memberwise initializer is a shorthand way
 to initialize the member properties of new structure instances.
@@ -638,7 +638,7 @@ let twoByTwo = Size(width: 2.0, height: 2.0)
 ```
 
 
-@Comment {
+<!--
   - test: `initialization`
   
   ```swifttest
@@ -647,7 +647,7 @@ let twoByTwo = Size(width: 2.0, height: 2.0)
      }
   -> let twoByTwo = Size(width: 2.0, height: 2.0)
   ```
-}
+-->
 
 When you call a memberwise initializer,
 you can omit values for any properties
@@ -670,7 +670,7 @@ print(zeroByZero.width, zeroByZero.height)
 ```
 
 
-@Comment {
+<!--
   - test: `initialization`
   
   ```swifttest
@@ -682,7 +682,7 @@ print(zeroByZero.width, zeroByZero.height)
   -> print(zeroByZero.width, zeroByZero.height)
   <- 0.0 0.0
   ```
-}
+-->
 
 ## Initializer Delegation for Value Types
 
@@ -735,7 +735,7 @@ struct Point {
 ```
 
 
-@Comment {
+<!--
   - test: `valueDelegation`
   
   ```swifttest
@@ -746,7 +746,7 @@ struct Point {
         var x = 0.0, y = 0.0
      }
   ```
-}
+-->
 
 You can initialize the `Rect` structure below in one of three ways ---
 by using its default zero-initialized `origin` and `size` property values,
@@ -773,7 +773,7 @@ struct Rect {
 ```
 
 
-@Comment {
+<!--
   - test: `valueDelegation`
   
   ```swifttest
@@ -792,7 +792,7 @@ struct Rect {
         }
      }
   ```
-}
+-->
 
 The first `Rect` initializer, `init()`,
 is functionally the same as the default initializer that the structure would have received
@@ -811,7 +811,7 @@ let basicRect = Rect()
 ```
 
 
-@Comment {
+<!--
   - test: `valueDelegation`
   
   ```swifttest
@@ -819,7 +819,7 @@ let basicRect = Rect()
   /> basicRect's origin is (\(basicRect.origin.x), \(basicRect.origin.y)) and its size is (\(basicRect.size.width), \(basicRect.size.height))
   </ basicRect's origin is (0.0, 0.0) and its size is (0.0, 0.0)
   ```
-}
+-->
 
 The second `Rect` initializer, `init(origin:size:)`,
 is functionally the same as the memberwise initializer that the structure would have received
@@ -834,7 +834,7 @@ let originRect = Rect(origin: Point(x: 2.0, y: 2.0),
 ```
 
 
-@Comment {
+<!--
   - test: `valueDelegation`
   
   ```swifttest
@@ -843,7 +843,7 @@ let originRect = Rect(origin: Point(x: 2.0, y: 2.0),
   /> originRect's origin is (\(originRect.origin.x), \(originRect.origin.y)) and its size is (\(originRect.size.width), \(originRect.size.height))
   </ originRect's origin is (2.0, 2.0) and its size is (5.0, 5.0)
   ```
-}
+-->
 
 The third `Rect` initializer, `init(center:size:)`, is slightly more complex.
 It starts by calculating an appropriate origin point based on
@@ -858,7 +858,7 @@ let centerRect = Rect(center: Point(x: 4.0, y: 4.0),
 ```
 
 
-@Comment {
+<!--
   - test: `valueDelegation`
   
   ```swifttest
@@ -867,7 +867,7 @@ let centerRect = Rect(center: Point(x: 4.0, y: 4.0),
   /> centerRect's origin is (\(centerRect.origin.x), \(centerRect.origin.y)) and its size is (\(centerRect.size.width), \(centerRect.size.height))
   </ centerRect's origin is (2.5, 2.5) and its size is (3.0, 3.0)
   ```
-}
+-->
 
 The `init(center:size:)` initializer could have assigned
 the new values of `origin` and `size` to the appropriate properties itself.
@@ -1135,7 +1135,7 @@ and validates that the parameters for your overriding initializer have been spec
 > Note: You always write the `override` modifier when overriding a superclass designated initializer,
 > even if your subclass's implementation of the initializer is a convenience initializer.
 
-@Comment {
+<!--
   - test: `youHaveToWriteOverrideWhenOverridingADesignatedInitializer`
   
   ```swifttest
@@ -1158,9 +1158,9 @@ and validates that the parameters for your overriding initializer have been spec
   !! init() {}
   !! ^
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `youHaveToWriteOverrideEvenWhenOverridingADefaultInitializer`
   
   ```swifttest
@@ -1183,7 +1183,7 @@ and validates that the parameters for your overriding initializer have been spec
   !! class C {
   !! ^
   ```
-}
+-->
 
 Conversely, if you write a subclass initializer that matches a superclass *convenience* initializer,
 that superclass convenience initializer can never be called directly by your subclass,
@@ -1192,7 +1192,7 @@ Therefore, your subclass is not (strictly speaking) providing an override of the
 As a result, you don't write the `override` modifier when providing
 a matching implementation of a superclass convenience initializer.
 
-@Comment {
+<!--
   - test: `youDoNotAndCannotWriteOverrideWhenOverridingAConvenienceInitializer`
   
   ```swifttest
@@ -1232,7 +1232,7 @@ a matching implementation of a superclass convenience initializer.
   !! convenience init() {
   !! ^
   ```
-}
+-->
 
 The example below defines a base class called `Vehicle`.
 This base class declares a stored property called `numberOfWheels`,
@@ -1250,7 +1250,7 @@ class Vehicle {
 ```
 
 
-@Comment {
+<!--
   - test: `initializerInheritance`
   
   ```swifttest
@@ -1261,7 +1261,7 @@ class Vehicle {
         }
      }
   ```
-}
+-->
 
 The `Vehicle` class provides a default value for its only stored property,
 and doesn't provide any custom initializers itself.
@@ -1277,7 +1277,7 @@ print("Vehicle: \(vehicle.description)")
 ```
 
 
-@Comment {
+<!--
   - test: `initializerInheritance`
   
   ```swifttest
@@ -1285,7 +1285,7 @@ print("Vehicle: \(vehicle.description)")
   -> print("Vehicle: \(vehicle.description)")
   </ Vehicle: 0 wheel(s)
   ```
-}
+-->
 
 The next example defines a subclass of `Vehicle` called `Bicycle`:
 
@@ -1299,7 +1299,7 @@ class Bicycle: Vehicle {
 ```
 
 
-@Comment {
+<!--
   - test: `initializerInheritance`
   
   ```swifttest
@@ -1310,7 +1310,7 @@ class Bicycle: Vehicle {
         }
      }
   ```
-}
+-->
 
 The `Bicycle` subclass defines a custom designated initializer, `init()`.
 This designated initializer matches a designated initializer from the superclass of `Bicycle`,
@@ -1334,7 +1334,7 @@ print("Bicycle: \(bicycle.description)")
 ```
 
 
-@Comment {
+<!--
   - test: `initializerInheritance`
   
   ```swifttest
@@ -1342,7 +1342,7 @@ print("Bicycle: \(bicycle.description)")
   -> print("Bicycle: \(bicycle.description)")
   </ Bicycle: 2 wheel(s)
   ```
-}
+-->
 
 If a subclass initializer performs no customization
 in phase 2 of the initialization process,
@@ -1372,7 +1372,7 @@ class Hoverboard: Vehicle {
 ```
 
 
-@Comment {
+<!--
   - test: `initializerInheritance`
   
   ```swifttest
@@ -1387,7 +1387,7 @@ class Hoverboard: Vehicle {
          }
      }
   ```
-}
+-->
 
 An instance of `Hoverboard` uses the default number of wheels
 supplied by the `Vehicle` initializer.
@@ -1399,7 +1399,7 @@ print("Hoverboard: \(hoverboard.description)")
 ```
 
 
-@Comment {
+<!--
   - test: `initializerInheritance`
   
   ```swifttest
@@ -1407,12 +1407,12 @@ print("Hoverboard: \(hoverboard.description)")
   -> print("Hoverboard: \(hoverboard.description)")
   </ Hoverboard: 0 wheel(s) in a beautiful silver
   ```
-}
+-->
 
 > Note: Subclasses can modify inherited variable properties during initialization,
 > but can't modify inherited constant properties.
 
-@Comment {
+<!--
   - test: `youCantModifyInheritedConstantPropertiesFromASuperclass`
   
   ```swifttest
@@ -1447,7 +1447,7 @@ print("Hoverboard: \(hoverboard.description)")
   !! ^~~
   !! var
   ```
-}
+-->
 
 ### Automatic Initializer Inheritance
 
@@ -1474,16 +1474,16 @@ These rules apply even if your subclass adds further convenience initializers.
 > Note: A subclass can implement a superclass designated initializer
 > as a subclass convenience initializer as part of satisfying rule 2.
 
-@Comment {
+<!--
   TODO: feedback from Beto is that this note is a little hard to parse.
   Perhaps this point should be left until the later "in action" example,
   where this principle is demonstrated?
-}
+-->
 
-@Comment {
+<!--
   TODO: There are rare cases in which we automatically insert a call to super.init() for you.
   When is this? Either way, I need to mention it in here.
-}
+-->
 
 ### Designated and Convenience Initializers in Action
 
@@ -1511,7 +1511,7 @@ class Food {
 ```
 
 
-@Comment {
+<!--
   - test: `designatedConvenience`
   
   ```swifttest
@@ -1525,7 +1525,7 @@ class Food {
         }
      }
   ```
-}
+-->
 
 The figure below shows the initializer chain for the `Food` class:
 
@@ -1543,7 +1543,7 @@ let namedMeat = Food(name: "Bacon")
 ```
 
 
-@Comment {
+<!--
   - test: `designatedConvenience`
   
   ```swifttest
@@ -1551,7 +1551,7 @@ let namedMeat = Food(name: "Bacon")
   /> namedMeat's name is \"\(namedMeat.name)\"
   </ namedMeat's name is "Bacon"
   ```
-}
+-->
 
 The `init(name: String)` initializer from the `Food` class
 is provided as a *designated* initializer,
@@ -1572,7 +1572,7 @@ let mysteryMeat = Food()
 ```
 
 
-@Comment {
+<!--
   - test: `designatedConvenience`
   
   ```swifttest
@@ -1580,7 +1580,7 @@ let mysteryMeat = Food()
   /> mysteryMeat's name is \"\(mysteryMeat.name)\"
   </ mysteryMeat's name is "[Unnamed]"
   ```
-}
+-->
 
 The second class in the hierarchy is a subclass of `Food` called `RecipeIngredient`.
 The `RecipeIngredient` class models an ingredient in a cooking recipe.
@@ -1602,7 +1602,7 @@ class RecipeIngredient: Food {
 ```
 
 
-@Comment {
+<!--
   - test: `designatedConvenience`
   
   ```swifttest
@@ -1617,7 +1617,7 @@ class RecipeIngredient: Food {
         }
      }
   ```
-}
+-->
 
 The figure below shows the initializer chain for the `RecipeIngredient` class:
 
@@ -1675,7 +1675,7 @@ let sixEggs = RecipeIngredient(name: "Eggs", quantity: 6)
 ```
 
 
-@Comment {
+<!--
   - test: `designatedConvenience`
   
   ```swifttest
@@ -1683,7 +1683,7 @@ let sixEggs = RecipeIngredient(name: "Eggs", quantity: 6)
   -> let oneBacon = RecipeIngredient(name: "Bacon")
   -> let sixEggs = RecipeIngredient(name: "Eggs", quantity: 6)
   ```
-}
+-->
 
 The third and final class in the hierarchy is
 a subclass of `RecipeIngredient` called `ShoppingListItem`.
@@ -1708,7 +1708,7 @@ class ShoppingListItem: RecipeIngredient {
 ```
 
 
-@Comment {
+<!--
   - test: `designatedConvenience`
   
   ```swifttest
@@ -1721,7 +1721,7 @@ class ShoppingListItem: RecipeIngredient {
         }
      }
   ```
-}
+-->
 
 > Note: `ShoppingListItem` doesn't define an initializer to provide
 > an initial value for `purchased`,
@@ -1757,7 +1757,7 @@ for item in breakfastList {
 ```
 
 
-@Comment {
+<!--
   - test: `designatedConvenience`
   
   ```swifttest
@@ -1775,7 +1775,7 @@ for item in breakfastList {
   </ 1 x Bacon ✘
   </ 6 x Eggs ✘
   ```
-}
+-->
 
 Here, a new array called `breakfastList` is created from
 an array literal containing three new `ShoppingListItem` instances.
@@ -1787,22 +1787,22 @@ and it's marked as having been purchased.
 Printing the description of each item in the array
 shows that their default states have been set as expected.
 
-@Comment {
+<!--
   TODO: talk about the general factory initializer pattern,
   and how Swift's approach to initialization removes the need for most factories.
-}
+-->
 
-@Comment {
+<!--
   NOTE: We import some Obj-C-imported factory initializers as init() -> MyType,
   but you can't currently write these in Swift yourself.
   After conferring with Doug, I've decided not to include these in the Guide
   if you can't write them yourself in pure Swift.
-}
+-->
 
-@Comment {
+<!--
   TODO: Feedback from Beto is that it would be useful to indicate the flow
   through these inherited initializers.
-}
+-->
 
 ## Failable Initializers
 
@@ -1821,7 +1821,7 @@ by placing a question mark after the `init` keyword (`init?`).
 > Note: You can't define a failable and a nonfailable initializer
 > with the same parameter types and names.
 
-@Comment {
+<!--
   - test: `failableAndNonFailableInitializersCannotMatch`
   
   ```swifttest
@@ -1837,7 +1837,7 @@ by placing a question mark after the `init` keyword (`init?`).
   !!            init(s: String) { self.s = s }
   !!            ^
   ```
-}
+-->
 
 A failable initializer creates an *optional* value of the type it initializes.
 You write `return nil` within a failable initializer
@@ -1874,7 +1874,7 @@ if valueChanged == nil {
 ```
 
 
-@Comment {
+<!--
   - test: `failableInitializers`
   
   ```swifttest
@@ -1894,7 +1894,7 @@ if valueChanged == nil {
      }
   <- 3.14159 conversion to Int doesn't maintain value
   ```
-}
+-->
 
 The example below defines a structure called `Animal`,
 with a constant `String` property called `species`.
@@ -1915,7 +1915,7 @@ struct Animal {
 ```
 
 
-@Comment {
+<!--
   - test: `failableInitializers`
   
   ```swifttest
@@ -1927,7 +1927,7 @@ struct Animal {
         }
      }
   ```
-}
+-->
 
 You can use this failable initializer to try to initialize a new `Animal` instance
 and to check if initialization succeeded:
@@ -1943,7 +1943,7 @@ if let giraffe = someCreature {
 ```
 
 
-@Comment {
+<!--
   - test: `failableInitializers`
   
   ```swifttest
@@ -1955,7 +1955,7 @@ if let giraffe = someCreature {
      }
   <- An animal was initialized with a species of Giraffe
   ```
-}
+-->
 
 If you pass an empty string value to the failable initializer's `species` parameter,
 the initializer triggers an initialization failure:
@@ -1971,7 +1971,7 @@ if anonymousCreature == nil {
 ```
 
 
-@Comment {
+<!--
   - test: `failableInitializers`
   
   ```swifttest
@@ -1983,7 +1983,7 @@ if anonymousCreature == nil {
      }
   <- The anonymous creature couldn't be initialized
   ```
-}
+-->
 
 > Note: Checking for an empty string value (such as `""` rather than `"Giraffe"`)
 > isn't the same as checking for `nil` to indicate the absence of an *optional* `String` value.
@@ -2024,7 +2024,7 @@ enum TemperatureUnit {
 ```
 
 
-@Comment {
+<!--
   - test: `failableInitializers`
   
   ```swifttest
@@ -2044,7 +2044,7 @@ enum TemperatureUnit {
         }
      }
   ```
-}
+-->
 
 You can use this failable initializer to choose
 an appropriate enumeration case for the three possible states
@@ -2066,7 +2066,7 @@ if unknownUnit == nil {
 ```
 
 
-@Comment {
+<!--
   - test: `failableInitializers`
   
   ```swifttest
@@ -2082,7 +2082,7 @@ if unknownUnit == nil {
      }
   <- This isn't a defined temperature unit, so initialization failed.
   ```
-}
+-->
 
 ### Failable Initializers for Enumerations with Raw Values
 
@@ -2115,7 +2115,7 @@ if unknownUnit == nil {
 ```
 
 
-@Comment {
+<!--
   - test: `failableInitializersForEnumerations`
   
   ```swifttest
@@ -2135,7 +2135,7 @@ if unknownUnit == nil {
      }
   <- This isn't a defined temperature unit, so initialization failed.
   ```
-}
+-->
 
 ### Propagation of Initialization Failure
 
@@ -2147,7 +2147,7 @@ In either case, if you delegate to another initializer that causes initializatio
 the entire initialization process fails immediately,
 and no further initialization code is executed.
 
-@Comment {
+<!--
   - test: `delegatingAcrossInAStructurePropagatesInitializationFailureImmediately`
   
   ```swifttest
@@ -2161,9 +2161,9 @@ and no further initialization code is executed.
   -> let s = S(string1: "bing")
   -> assert(s == nil)
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `delegatingAcrossInAClassPropagatesInitializationFailureImmediately`
   
   ```swifttest
@@ -2177,9 +2177,9 @@ and no further initialization code is executed.
   -> let c = C(string1: "bing")
   -> assert(c == nil)
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `delegatingUpInAClassPropagatesInitializationFailureImmediately`
   
   ```swifttest
@@ -2195,7 +2195,7 @@ and no further initialization code is executed.
   -> let d = D(string2: "bing")
   -> assert(d == nil)
   ```
-}
+-->
 
 > Note: A failable initializer can also delegate to a nonfailable initializer.
 > Use this approach if you need to add a potential failure state
@@ -2226,7 +2226,7 @@ class CartItem: Product {
 ```
 
 
-@Comment {
+<!--
   - test: `failableInitializers`
   
   ```swifttest
@@ -2248,7 +2248,7 @@ class CartItem: Product {
         }
      }
   ```
-}
+-->
 
 The failable initializer for `CartItem` starts by
 validating that it has received a `quantity` value of `1` or more.
@@ -2271,7 +2271,7 @@ if let twoSocks = CartItem(name: "sock", quantity: 2) {
 ```
 
 
-@Comment {
+<!--
   - test: `failableInitializers`
   
   ```swifttest
@@ -2280,7 +2280,7 @@ if let twoSocks = CartItem(name: "sock", quantity: 2) {
      }
   <- Item: sock, quantity: 2
   ```
-}
+-->
 
 If you try to create a `CartItem` instance with a `quantity` value of `0`,
 the `CartItem` initializer causes initialization to fail:
@@ -2295,7 +2295,7 @@ if let zeroShirts = CartItem(name: "shirt", quantity: 0) {
 ```
 
 
-@Comment {
+<!--
   - test: `failableInitializers`
   
   ```swifttest
@@ -2306,7 +2306,7 @@ if let zeroShirts = CartItem(name: "shirt", quantity: 0) {
      }
   <- Unable to initialize zero shirts
   ```
-}
+-->
 
 Similarly, if you try to create a `CartItem` instance with an empty `name` value,
 the superclass `Product` initializer causes initialization to fail:
@@ -2321,7 +2321,7 @@ if let oneUnnamed = CartItem(name: "", quantity: 1) {
 ```
 
 
-@Comment {
+<!--
   - test: `failableInitializers`
   
   ```swifttest
@@ -2332,7 +2332,7 @@ if let oneUnnamed = CartItem(name: "", quantity: 1) {
      }
   <- Unable to initialize one unnamed product
   ```
-}
+-->
 
 ### Overriding a Failable Initializer
 
@@ -2350,7 +2350,7 @@ is to force-unwrap the result of the failable superclass initializer.
 > Note: You can override a failable initializer with a nonfailable initializer
 > but not the other way around.
 
-@Comment {
+<!--
   - test: `youCannotOverrideANonFailableInitializerWithAFailableInitializer`
   
   ```swifttest
@@ -2367,7 +2367,7 @@ is to force-unwrap the result of the failable superclass initializer.
   !!            init() {}
   !!            ^
   ```
-}
+-->
 
 The example below defines a class called `Document`.
 This class models a document that can be initialized with
@@ -2388,7 +2388,7 @@ class Document {
 ```
 
 
-@Comment {
+<!--
   - test: `failableInitializers`
   
   ```swifttest
@@ -2403,7 +2403,7 @@ class Document {
         }
      }
   ```
-}
+-->
 
 The next example defines a subclass of `Document` called `AutomaticallyNamedDocument`.
 The `AutomaticallyNamedDocument` subclass overrides
@@ -2431,7 +2431,7 @@ class AutomaticallyNamedDocument: Document {
 ```
 
 
-@Comment {
+<!--
   - test: `failableInitializers`
   
   ```swifttest
@@ -2450,7 +2450,7 @@ class AutomaticallyNamedDocument: Document {
         }
      }
   ```
-}
+-->
 
 The `AutomaticallyNamedDocument` overrides its superclass's
 failable `init?(name:)` initializer with a nonfailable `init(name:)` initializer.
@@ -2475,7 +2475,7 @@ class UntitledDocument: Document {
 ```
 
 
-@Comment {
+<!--
   - test: `failableInitializers`
   
   ```swifttest
@@ -2485,7 +2485,7 @@ class UntitledDocument: Document {
         }
      }
   ```
-}
+-->
 
 In this case, if the `init(name:)` initializer of the superclass
 were ever called with an empty string as the name,
@@ -2510,7 +2510,7 @@ You can also delegate from `init` to `init!`,
 although doing so will trigger an assertion
 if the `init!` initializer causes initialization to fail.
 
-@Comment {
+<!--
   - test: `structuresCanDelegateAcrossFromOptionalToIUO`
   
   ```swifttest
@@ -2519,9 +2519,9 @@ if the `init!` initializer causes initialization to fail.
         init!(iuo: Int) {}
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `structuresCanDelegateAcrossFromIUOToOptional`
   
   ```swifttest
@@ -2530,9 +2530,9 @@ if the `init!` initializer causes initialization to fail.
         init?(optional: Int) {}
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `classesCanDelegateAcrossFromOptionalToIUO`
   
   ```swifttest
@@ -2541,9 +2541,9 @@ if the `init!` initializer causes initialization to fail.
         init!(iuo: Int) {}
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `classesCanDelegateAcrossFromIUOToOptional`
   
   ```swifttest
@@ -2552,9 +2552,9 @@ if the `init!` initializer causes initialization to fail.
         init?(optional: Int) {}
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `classesCanDelegateUpFromOptionalToIUO`
   
   ```swifttest
@@ -2565,9 +2565,9 @@ if the `init!` initializer causes initialization to fail.
         init?(optional: Int) { super.init(iuo: optional) }
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `classesCanDelegateUpFromIUOToOptional`
   
   ```swifttest
@@ -2578,9 +2578,9 @@ if the `init!` initializer causes initialization to fail.
         init!(iuo: Int) { super.init(optional: iuo) }
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `classesCanOverrideOptionalWithIUO`
   
   ```swifttest
@@ -2591,9 +2591,9 @@ if the `init!` initializer causes initialization to fail.
         override init!(i: Int) { super.init(i: i) }
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `classesCanOverrideIUOWithOptional`
   
   ```swifttest
@@ -2604,9 +2604,9 @@ if the `init!` initializer causes initialization to fail.
         override init?(i: Int) { super.init(i: i) }
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `structuresCanDelegateAcrossFromNonFailingToIUO`
   
   ```swifttest
@@ -2615,9 +2615,9 @@ if the `init!` initializer causes initialization to fail.
         init!(iuo: Int) {}
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `classesCanDelegateAcrossFromNonFailingToIUO`
   
   ```swifttest
@@ -2626,9 +2626,9 @@ if the `init!` initializer causes initialization to fail.
         init!(iuo: Int) {}
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `classesCanDelegateUpFromNonFailingToIUO`
   
   ```swifttest
@@ -2639,9 +2639,9 @@ if the `init!` initializer causes initialization to fail.
         init(nonFailing: Int) { super.init(iuo: nonFailing) }
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `structuresAssertWhenDelegatingAcrossFromNonFailingToNilIUO`
   
   ```swifttest
@@ -2652,9 +2652,9 @@ if the `init!` initializer causes initialization to fail.
   -> let s = S(nonFailing: 42)
   xx assertion
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `classesAssertWhenDelegatingAcrossFromNonFailingToNilIUO`
   
   ```swifttest
@@ -2665,9 +2665,9 @@ if the `init!` initializer causes initialization to fail.
   -> let c = C(nonFailing: 42)
   xx assertion
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `classesAssertWhenDelegatingUpFromNonFailingToNilIUO`
   
   ```swifttest
@@ -2680,7 +2680,7 @@ if the `init!` initializer causes initialization to fail.
   -> let d = D(nonFailing: 42)
   xx assertion
   ```
-}
+-->
 
 ## Required Initializers
 
@@ -2696,7 +2696,7 @@ class SomeClass {
 ```
 
 
-@Comment {
+<!--
   - test: `requiredInitializers`
   
   ```swifttest
@@ -2706,9 +2706,9 @@ class SomeClass {
         }
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `requiredDesignatedInitializersMustBeImplementedBySubclasses`
   
   ```swifttest
@@ -2719,15 +2719,15 @@ class SomeClass {
         init() {}
      }
   !$ error: 'required' initializer 'init(i:)' must be provided by subclass of 'C'
-  !! }
+  !! -->
   !! ^
   !$ note: 'required' initializer is declared in superclass here
   !!    required init(i: Int) {}
   !!             ^
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `requiredConvenienceInitializersMustBeImplementedBySubclasses`
   
   ```swifttest
@@ -2741,13 +2741,13 @@ class SomeClass {
         init(s: String) {}
      }
   !$ error: 'required' initializer 'init(i:)' must be provided by subclass of 'C'
-  !! }
+  !! -->
   !! ^
   !$ note: 'required' initializer is declared in superclass here
   !!    required convenience init(i: Int) {
   !!                         ^
   ```
-}
+-->
 
 You must also write the `required` modifier before
 every subclass implementation of a required initializer,
@@ -2763,7 +2763,7 @@ class SomeSubclass: SomeClass {
 ```
 
 
-@Comment {
+<!--
   - test: `requiredInitializers`
   
   ```swifttest
@@ -2773,9 +2773,9 @@ class SomeSubclass: SomeClass {
         }
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `youCannotWriteOverrideWhenOverridingARequiredDesignatedInitializer`
   
   ```swifttest
@@ -2793,12 +2793,12 @@ class SomeSubclass: SomeClass {
   !!    required init() {}
   !!             ^
   ```
-}
+-->
 
 > Note: You don't have to provide an explicit implementation of a required initializer
 > if you can satisfy the requirement with an inherited initializer.
 
-@Comment {
+<!--
   - test: `youCanSatisfyARequiredDesignatedInitializerWithAnInheritedInitializer`
   
   ```swifttest
@@ -2810,9 +2810,9 @@ class SomeSubclass: SomeClass {
         var y = 0
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `youCanSatisfyARequiredConvenienceInitializerWithAnInheritedInitializer`
   
   ```swifttest
@@ -2827,9 +2827,9 @@ class SomeSubclass: SomeClass {
         var y = 0
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   FIXME: This section still doesn't describe why required initializers are useful.
   This is because the reason for their usefulness -
   construction through a metatype of some protocol type with an initializer requirement -
@@ -2837,7 +2837,7 @@ class SomeSubclass: SomeClass {
   <rdar://problem/13695680> Constructor requirements in protocols (needed for NSCoding).
   As of early 2015 that bug has been fixed.
   See the corresponding FIXME in the Protocols chapter introduction too.
-}
+-->
 
 ## Setting a Default Property Value with a Closure or Function
 
@@ -2867,7 +2867,7 @@ class SomeClass {
 ```
 
 
-@Comment {
+<!--
   - test: `defaultPropertyWithClosure`
   
   ```swifttest
@@ -2881,7 +2881,7 @@ class SomeClass {
         }()
      }
   ```
-}
+-->
 
 Note that the closure's end curly brace is followed by an empty pair of parentheses.
 This tells Swift to execute the closure immediately.
@@ -2889,13 +2889,13 @@ If you omit these parentheses,
 you are trying to assign the closure itself to the property,
 and not the return value of the closure.
 
-@Comment {
+<!--
   TODO: feedback from Peter is that this is very close to the syntax for
   a computed property that doesn't define a separate getter.
   He's right, and it would be good to provide an additional example -
   perhaps with a stored property that's assigned the result of a function -
   to make the difference more explicit.
-}
+-->
 
 > Note: If you use a closure to initialize a property,
 > remember that the rest of the instance hasn't yet been initialized
@@ -2944,7 +2944,7 @@ struct Chessboard {
 ```
 
 
-@Comment {
+<!--
   - test: `chessboard`
   
   ```swifttest
@@ -2966,7 +2966,7 @@ struct Chessboard {
         }
      }
   ```
-}
+-->
 
 Whenever a new `Chessboard` instance is created, the closure is executed,
 and the default value of `boardColors` is calculated and returned.
@@ -2987,7 +2987,7 @@ print(board.squareIsBlackAt(row: 7, column: 7))
 ```
 
 
-@Comment {
+<!--
   - test: `chessboard`
   
   ```swifttest
@@ -2998,10 +2998,10 @@ print(board.squareIsBlackAt(row: 7, column: 7))
   -> print(board.squareIsBlackAt(row: 7, column: 7))
   <- false
   ```
-}
+-->
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -3009,4 +3009,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/MemorySafety.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/MemorySafety.md
@@ -20,13 +20,13 @@ so you can avoid writing code that has conflicting access to memory.
 If your code does contain conflicts,
 you'll get a compile-time or runtime error.
 
-@Comment {
+<!--
   TODO: maybe re-introduce this text...
   
   Memory safety refers to...
   The term *safety* usually refers to :newTerm:`memory safety`...
   Unsafe access to memory is available, if you ask for it explicitly...
-}
+-->
 
 ## Understanding Conflicting Access to Memory
 
@@ -45,7 +45,7 @@ print("We're number \(one)!")
 ```
 
 
-@Comment {
+<!--
   - test: `memory-read-write`
   
   ```swifttest
@@ -56,12 +56,12 @@ print("We're number \(one)!")
   -> print("We're number \(one)!")
   << We're number 1!
   ```
-}
+-->
 
-@Comment {
+<!--
   Might be worth a different example,
   or else I'm going to keep getting "We are Number One" stuck in my head.
-}
+-->
 
 A conflicting access to memory can occur
 when different parts of your code are trying
@@ -122,10 +122,10 @@ you have to determine what it was intended to do.
 > use [Thread Sanitizer](https://developer.apple.com/documentation/xcode/diagnosing_memory_thread_and_crash_issues_early)
 > to help detect conflicting access across threads.
 
-@Comment {
+<!--
   TODO: The xref above doesn't seem to give enough information.
   What should I be looking for when I get to the linked page?
-}
+-->
 
 ### Characteristics of Memory Access
 
@@ -157,10 +157,10 @@ if it uses only C atomic operations;
 otherwise it's nonatomic.
 For a list of those functions, see the `stdatomic(3)` man page.
 
-@Comment {
+<!--
   Using these functions from Swift requires some shimming -- for example:
   https://github.com/apple/swift-se-0282-experimental/tree/master/Sources/_AtomicsShims
-}
+-->
 
 An access is *instantaneous*
 if it's not possible for other code to run
@@ -182,7 +182,7 @@ print(myNumber)
 ```
 
 
-@Comment {
+<!--
   - test: `memory-instantaneous`
   
   ```swifttest
@@ -195,7 +195,7 @@ print(myNumber)
   -> print(myNumber)
   <- 2
   ```
-}
+-->
 
 However,
 there are several ways to access memory,
@@ -243,7 +243,7 @@ increment(&stepSize)
 ```
 
 
-@Comment {
+<!--
   - test: `memory-increment`
   
   ```swifttest
@@ -259,7 +259,7 @@ increment(&stepSize)
   xx Previous access (a modification) started at  (0x10e86b032).
   xx Current access (a read) started at:
   ```
-}
+-->
 
 In the code above,
 `stepSize` is a global variable,
@@ -290,7 +290,7 @@ stepSize = copyOfStepSize
 ```
 
 
-@Comment {
+<!--
   - test: `memory-increment-copy`
   
   ```swifttest
@@ -307,7 +307,7 @@ stepSize = copyOfStepSize
   /> stepSize is now \(stepSize)
   </ stepSize is now 2
   ```
-}
+-->
 
 When you make a copy of `stepSize` before calling `increment(_:)`,
 it's clear that the value of `copyOfStepSize` is incremented
@@ -337,7 +337,7 @@ balance(&playerOneScore, &playerOneScore)
 ```
 
 
-@Comment {
+<!--
   - test: `memory-balance`
   
   ```swifttest
@@ -364,7 +364,7 @@ balance(&playerOneScore, &playerOneScore)
   !! balance(&playerOneScore, &playerOneScore)
   !!         ^~~~~~~~~~~~~~~
   ```
-}
+-->
 
 The `balance(_:_:)` function above
 modifies its two parameters
@@ -388,18 +388,18 @@ to the same location in memory at the same time.
 
 ## Conflicting Access to self in Methods
 
-@Comment {
+<!--
   This (probably?) applies to all value types,
   but structures are the only place you can observe it.
   Enumerations can have mutating methods
   but you can't mutate their associated values in place,
   and tuples can't have methods.
-}
+-->
 
-@Comment {
+<!--
   Methods behave like self is passed to the method as inout
   because, under the hood, that's exactly what happens.
-}
+-->
 
 A mutating method on a structure has write access to `self`
 for the duration of the method call.
@@ -421,7 +421,7 @@ struct Player {
 ```
 
 
-@Comment {
+<!--
   - test: `memory-player-share-with-self`
   
   ```swifttest
@@ -441,7 +441,7 @@ struct Player {
          }
      }
   ```
-}
+-->
 
 In the `restoreHealth()` method above,
 a write access to `self` starts at the beginning of the method
@@ -466,7 +466,7 @@ oscar.shareHealth(with: &maria)  // OK
 ```
 
 
-@Comment {
+<!--
   - test: `memory-player-share-with-self`
   
   ```swifttest
@@ -480,7 +480,7 @@ oscar.shareHealth(with: &maria)  // OK
   -> var maria = Player(name: "Maria", health: 5, energy: 10)
   -> oscar.shareHealth(with: &maria)  // OK
   ```
-}
+-->
 
 In the example above,
 calling the `shareHealth(with:)` method
@@ -509,7 +509,7 @@ oscar.shareHealth(with: &oscar)
 ```
 
 
-@Comment {
+<!--
   - test: `memory-player-share-with-self`
   
   ```swifttest
@@ -528,7 +528,7 @@ oscar.shareHealth(with: &oscar)
   !! oscar.shareHealth(with: &oscar)
   !! ^~~~~~
   ```
-}
+-->
 
 The mutating method needs write access to `self`
 for the duration of the method,
@@ -565,7 +565,7 @@ balance(&playerInformation.health, &playerInformation.energy)
 ```
 
 
-@Comment {
+<!--
   - test: `memory-tuple`
   
   ```swifttest
@@ -581,7 +581,7 @@ balance(&playerInformation.health, &playerInformation.energy)
   xx Previous access (a modification) started at  (0x107952037).
   xx Current access (a modification) started at:
   ```
-}
+-->
 
 In the example above,
 calling `balance(_:_:)` on the elements of a tuple
@@ -608,7 +608,7 @@ balance(&holly.health, &holly.energy)  // Error
 ```
 
 
-@Comment {
+<!--
   - test: `memory-share-health-global`
   
   ```swifttest
@@ -628,7 +628,7 @@ balance(&holly.health, &holly.energy)  // Error
   xx Previous access (a modification) started at  (0x107952037).
   xx Current access (a modification) started at:
   ```
-}
+-->
 
 In practice,
 most access to the properties of a structure
@@ -647,7 +647,7 @@ func someFunction() {
 ```
 
 
-@Comment {
+<!--
   - test: `memory-share-health-local`
   
   ```swifttest
@@ -667,7 +667,7 @@ func someFunction() {
      }
   >> someFunction()
   ```
-}
+-->
 
 In the example above,
 Oscar's health and energy are passed
@@ -698,7 +698,7 @@ if the following conditions apply:
 If the compiler can't prove the access is safe,
 it doesn't allow the access.
 
-@Comment {
+<!--
   Because there's no syntax
   to mutate an enum's associated value in place,
   we can't show that overlapping mutations
@@ -707,13 +707,13 @@ it doesn't allow the access.
   Otherwise, we'd want an example of that
   in this section too --
   it's the moral equivalent of property access.
-}
+-->
 
-@Comment {
+<!--
   .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. ..
-}
+-->
 
-@Comment {
+<!--
   In Swift 4, the only way to create a long-term read
   is to use implicit pointer conversion
   when passing a value as a nonmutating unsafe pointer parameter,
@@ -742,9 +742,9 @@ it doesn't allow the access.
       // 2    temp2                              0x000000010675e3c0 main + 102
       // 3    libdyld.dylib                      0x00007fff69c75144 start + 1
       // Fatal access conflict detected.
-}
+-->
 
-@Comment {
+<!--
   TEXT FOR THE FUTURE
   
   Versions of Swift before Swift 5 ensure memory safety
@@ -753,10 +753,10 @@ it doesn't allow the access.
   The copy is no longer shared, preventing the possibility of conflicts.
   However, the copying approach has a negative impact
   on performance and memory usage.
-}
+-->
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -764,4 +764,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Methods.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Methods.md
@@ -49,7 +49,7 @@ class Counter {
 ```
 
 
-@Comment {
+<!--
   - test: `instanceMethods`
   
   ```swifttest
@@ -66,7 +66,7 @@ class Counter {
         }
      }
   ```
-}
+-->
 
 The `Counter` class defines three instance methods:
 
@@ -91,7 +91,7 @@ counter.reset()
 ```
 
 
-@Comment {
+<!--
   - test: `instanceMethods`
   
   ```swifttest
@@ -108,7 +108,7 @@ counter.reset()
   /> the counter's value is now \(counter.count)
   </ the counter's value is now 0
   ```
-}
+-->
 
 Function parameters can have both a name (for use within the function's body)
 and an argument label (for use when calling the function),
@@ -132,7 +132,7 @@ func increment() {
 ```
 
 
-@Comment {
+<!--
   - test: `instanceMethodsIncrement`
   
   ```swifttest
@@ -143,11 +143,11 @@ func increment() {
      }
   >> }
   ```
-}
+-->
 
-@Comment {
+<!--
   NOTE: I'm slightly cheating with my testing of this excerpt, but it works!
-}
+-->
 
 In practice, you don't need to write `self` in your code very often.
 If you don't explicitly write `self`,
@@ -181,7 +181,7 @@ if somePoint.isToTheRightOf(x: 1.0) {
 ```
 
 
-@Comment {
+<!--
   - test: `self`
   
   ```swifttest
@@ -197,7 +197,7 @@ if somePoint.isToTheRightOf(x: 1.0) {
      }
   <- This point is to the right of the line where x == 1.0
   ```
-}
+-->
 
 Without the `self` prefix,
 Swift would assume that both uses of `x` referred to the method parameter called `x`.
@@ -207,9 +207,9 @@ Swift would assume that both uses of `x` referred to the method parameter called
 Structures and enumerations are *value types*.
 By default, the properties of a value type can't be modified from within its instance methods.
 
-@Comment {
+<!--
   TODO: find out why.  once I actually know why, explain it.
-}
+-->
 
 However, if you need to modify the properties of your structure or enumeration
 within a particular method,
@@ -238,7 +238,7 @@ print("The point is now at (\(somePoint.x), \(somePoint.y))")
 ```
 
 
-@Comment {
+<!--
   - test: `selfStructures`
   
   ```swifttest
@@ -254,7 +254,7 @@ print("The point is now at (\(somePoint.x), \(somePoint.y))")
   -> print("The point is now at (\(somePoint.x), \(somePoint.y))")
   <- The point is now at (3.0, 4.0)
   ```
-}
+-->
 
 The `Point` structure above defines a mutating `moveBy(x:y:)` method,
 which moves a `Point` instance by a certain amount.
@@ -274,7 +274,7 @@ fixedPoint.moveBy(x: 2.0, y: 3.0)
 ```
 
 
-@Comment {
+<!--
   - test: `selfStructures-err`
   
   ```swifttest
@@ -296,14 +296,14 @@ fixedPoint.moveBy(x: 2.0, y: 3.0)
   !! var
   // this will report an error
   ```
-}
+-->
 
-@Comment {
+<!--
   TODO: talk about nonmutating as well.
   Struct setters are implicitly 'mutating' by default and thus don't work on 'let's.
   However, JoeG says that this ought to work
   if the setter for the computed property is explicitly defined as @!mutating.
-}
+-->
 
 ### Assigning to self Within a Mutating Method
 
@@ -320,7 +320,7 @@ struct Point {
 ```
 
 
-@Comment {
+<!--
   - test: `selfStructuresAssign`
   
   ```swifttest
@@ -335,7 +335,7 @@ struct Point {
   >> print("The point is now at (\(somePoint.x), \(somePoint.y))")
   << The point is now at (3.0, 4.0)
   ```
-}
+-->
 
 This version of the mutating `moveBy(x:y:)` method creates a new structure
 whose `x` and `y` values are set to the target location.
@@ -367,7 +367,7 @@ ovenLight.next()
 ```
 
 
-@Comment {
+<!--
   - test: `selfEnumerations`
   
   ```swifttest
@@ -390,7 +390,7 @@ ovenLight.next()
   -> ovenLight.next()
   // ovenLight is now equal to .off
   ```
-}
+-->
 
 This example defines an enumeration for a three-state switch.
 The switch cycles between three different power states
@@ -426,7 +426,7 @@ SomeClass.someTypeMethod()
 ```
 
 
-@Comment {
+<!--
   - test: `typeMethods`
   
   ```swifttest
@@ -437,7 +437,7 @@ SomeClass.someTypeMethod()
      }
   -> SomeClass.someTypeMethod()
   ```
-}
+-->
 
 Within the body of a type method,
 the implicit `self` property refers to the type itself,
@@ -491,7 +491,7 @@ struct LevelTracker {
 ```
 
 
-@Comment {
+<!--
   - test: `typeMethods`
   
   ```swifttest
@@ -518,7 +518,7 @@ struct LevelTracker {
         }
      }
   ```
-}
+-->
 
 The `LevelTracker` structure keeps track of the highest level that any player has unlocked.
 This value is stored in a type property called `highestUnlockedLevel`.
@@ -568,7 +568,7 @@ class Player {
 ```
 
 
-@Comment {
+<!--
   - test: `typeMethods`
   
   ```swifttest
@@ -584,7 +584,7 @@ class Player {
         }
      }
   ```
-}
+-->
 
 The `Player` class creates a new instance of `LevelTracker`
 to track that player's progress.
@@ -607,7 +607,7 @@ print("highest unlocked level is now \(LevelTracker.highestUnlockedLevel)")
 ```
 
 
-@Comment {
+<!--
   - test: `typeMethods`
   
   ```swifttest
@@ -616,7 +616,7 @@ print("highest unlocked level is now \(LevelTracker.highestUnlockedLevel)")
   -> print("highest unlocked level is now \(LevelTracker.highestUnlockedLevel)")
   <- highest unlocked level is now 2
   ```
-}
+-->
 
 If you create a second player, whom you try to move to a level
 that's not yet unlocked by any player in the game,
@@ -633,7 +633,7 @@ if player.tracker.advance(to: 6) {
 ```
 
 
-@Comment {
+<!--
   - test: `typeMethods`
   
   ```swifttest
@@ -645,14 +645,12 @@ if player.tracker.advance(to: 6) {
      }
   <- level 6 hasn't yet been unlocked
   ```
-}
+-->
 
-@Comment {
+<!--
   TODO: Method Binding
   --------------------
-}
 
-@Comment {
   TODO: you can get a function that refers to a method, either with or without the 'self' argument already being bound:
   class C {
      func foo(x: Int) -> Float { ... }
@@ -660,15 +658,13 @@ if player.tracker.advance(to: 6) {
   var c = C()
   var boundFunc = c.foo   // a function with type (Int) -> Float
   var unboundFunc = C.foo // a function with type (C) -> (Int) -> Float
-}
 
-@Comment {
   TODO: selector-style methods can be referenced as foo.bar:bas:
   (see Doug's comments from the 2014-03-12 release notes)
-}
+-->
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -676,4 +672,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/NestedTypes.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/NestedTypes.md
@@ -65,7 +65,7 @@ struct BlackjackCard {
 ```
 
 
-@Comment {
+<!--
   - test: `nestedTypes`
   
   ```swifttest
@@ -107,7 +107,7 @@ struct BlackjackCard {
         }
      }
   ```
-}
+-->
 
 The `Suit` enumeration describes the four common playing card suits,
 together with a raw `Character` value to represent their symbol.
@@ -152,7 +152,7 @@ print("theAceOfSpades: \(theAceOfSpades.description)")
 ```
 
 
-@Comment {
+<!--
   - test: `nestedTypes`
   
   ```swifttest
@@ -160,7 +160,7 @@ print("theAceOfSpades: \(theAceOfSpades.description)")
   -> print("theAceOfSpades: \(theAceOfSpades.description)")
   <- theAceOfSpades: suit is ♠, value is 1 or 11
   ```
-}
+-->
 
 Even though `Rank` and `Suit` are nested within `BlackjackCard`,
 their type can be inferred from context,
@@ -180,7 +180,7 @@ let heartsSymbol = BlackjackCard.Suit.hearts.rawValue
 ```
 
 
-@Comment {
+<!--
   - test: `nestedTypes`
   
   ```swifttest
@@ -188,14 +188,14 @@ let heartsSymbol = BlackjackCard.Suit.hearts.rawValue
   /> heartsSymbol is \"\(heartsSymbol)\"
   </ heartsSymbol is "♡"
   ```
-}
+-->
 
 For the example above,
 this enables the names of `Suit`, `Rank`, and `Values` to be kept deliberately short,
 because their names are naturally qualified by the context in which they're defined.
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -203,4 +203,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/OpaqueTypes.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/OpaqueTypes.md
@@ -46,7 +46,7 @@ print(smallTriangle.draw())
 ```
 
 
-@Comment {
+<!--
   - test: `opaque-result`
   
   ```swifttest
@@ -70,7 +70,7 @@ print(smallTriangle.draw())
   </ **
   </ ***
   ```
-}
+-->
 
 You could use generics to implement operations like flipping a shape vertically,
 as shown in the code below.
@@ -94,7 +94,7 @@ print(flippedTriangle.draw())
 ```
 
 
-@Comment {
+<!--
   - test: `opaque-result`
   
   ```swifttest
@@ -111,7 +111,7 @@ print(flippedTriangle.draw())
   </ **
   </ *
   ```
-}
+-->
 
 This approach to defining a `JoinedShape<T: Shape, U: Shape>` structure
 that joins two shapes together vertically, like the code below shows,
@@ -137,7 +137,7 @@ print(joinedTriangles.draw())
 ```
 
 
-@Comment {
+<!--
   - test: `opaque-result`
   
   ```swifttest
@@ -157,7 +157,7 @@ print(joinedTriangles.draw())
   </ **
   </ *
   ```
-}
+-->
 
 Exposing detailed information about the creation of a shape
 allows types that aren't meant to be
@@ -189,11 +189,11 @@ func max<T>(_ x: T, _ y: T) -> T where T: Comparable { ... }
 ```
 
 
-@Comment {
+<!--
   From https://developer.apple.com/documentation/swift/1538951-max
   Not test code because it won't actually compile
   and there's nothing to meaningfully test.
-}
+-->
 
 The code that calls `max(_:_:)` chooses the values for `x` and `y`,
 and the type of those values determines the concrete type of `T`.
@@ -242,7 +242,7 @@ print(trapezoid.draw())
 ```
 
 
-@Comment {
+<!--
   - test: `opaque-result`
   
   ```swifttest
@@ -274,7 +274,7 @@ print(trapezoid.draw())
   </ **
   </ *
   ```
-}
+-->
 
 The `makeTrapezoid()` function in this example
 declares its return type as `some Shape`;
@@ -324,7 +324,7 @@ print(opaqueJoinedTriangles.draw())
 ```
 
 
-@Comment {
+<!--
   - test: `opaque-result`
   
   ```swifttest
@@ -344,7 +344,7 @@ print(opaqueJoinedTriangles.draw())
   </ **
   </ *
   ```
-}
+-->
 
 The value of `opaqueJoinedTriangles` in this example
 is the same as `joinedTriangles` in the generics example
@@ -378,7 +378,7 @@ func invalidFlip<T: Shape>(_ shape: T) -> some Shape {
 ```
 
 
-@Comment {
+<!--
   - test: `opaque-result-err`
   
   ```swifttest
@@ -408,7 +408,7 @@ func invalidFlip<T: Shape>(_ shape: T) -> some Shape {
   !! return FlippedShape(shape: shape) // Error: return types don't match
   !! ^
   ```
-}
+-->
 
 If you call this function with a `Square`, it returns a `Square`;
 otherwise, it returns a `FlippedShape`.
@@ -432,7 +432,7 @@ struct FlippedShape<T: Shape>: Shape {
 ```
 
 
-@Comment {
+<!--
   - test: `opaque-result-special-flip`
   
   ```swifttest
@@ -451,15 +451,15 @@ struct FlippedShape<T: Shape>: Shape {
          }
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   Another way to fix it is with type erasure.
   Define a wrapper called AnyShape,
   and wrap whatever shape you created inside invalidFlip(_:)
   before returning it.
   That example is long enough that it breaks the flow here.
-}
+-->
 
 The requirement to always return a single type
 doesn't prevent you from using generics in an opaque return type.
@@ -473,7 +473,7 @@ func `repeat`<T: Shape>(shape: T, count: Int) -> some Collection {
 ```
 
 
-@Comment {
+<!--
   - test: `opaque-result`
   
   ```swifttest
@@ -481,7 +481,7 @@ func `repeat`<T: Shape>(shape: T, count: Int) -> some Collection {
          return Array<T>(repeating: shape, count: count)
      }
   ```
-}
+-->
 
 In this case,
 the underlying type of the return value
@@ -520,7 +520,7 @@ func protoFlip<T: Shape>(_ shape: T) -> Shape {
 ```
 
 
-@Comment {
+<!--
   - test: `opaque-result-existential-error`
   
   ```swifttest
@@ -543,7 +543,7 @@ func protoFlip<T: Shape>(_ shape: T) -> Shape {
         return FlippedShape(shape: shape)
      }
   ```
-}
+-->
 
 This version of `protoFlip(_:)`
 has the same body as `flip(_:)`,
@@ -568,7 +568,7 @@ func protoFlip<T: Shape>(_ shape: T) -> Shape {
 ```
 
 
-@Comment {
+<!--
   - test: `opaque-result-existential-error`
   
   ```swifttest
@@ -586,7 +586,7 @@ func protoFlip<T: Shape>(_ shape: T) -> Shape {
   !! func protoFlip<T: Shape>(_ shape: T) -> Shape {
   !!      ^
   ```
-}
+-->
 
 The revised version of the code returns
 an instance of `Square` or an instance of `FlippedShape`,
@@ -608,7 +608,7 @@ protoFlippedTriangle == sameThing  // Error
 ```
 
 
-@Comment {
+<!--
   - test: `opaque-result-existential-error`
   
   ```swifttest
@@ -620,7 +620,7 @@ protoFlippedTriangle == sameThing  // Error
   !! protoFlippedTriangle == sameThing  // Error
   !! ~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~
   ```
-}
+-->
 
 The error on the last line of the example occurs for several reasons.
 The immediate issue is that the `Shape` doesn't include an `==` operator
@@ -670,7 +670,7 @@ extension Array: Container { }
 ```
 
 
-@Comment {
+<!--
   - test: `opaque-result, opaque-result-existential-error`
   
   ```swifttest
@@ -681,7 +681,7 @@ extension Array: Container { }
      }
   -> extension Array: Container { }
   ```
-}
+-->
 
 You can't use `Container` as the return type of a function
 because that protocol has an associated type.
@@ -702,7 +702,7 @@ func makeProtocolContainer<T, C: Container>(item: T) -> C {
 ```
 
 
-@Comment {
+<!--
   - test: `opaque-result-existential-error`
   
   ```swifttest
@@ -724,7 +724,7 @@ func makeProtocolContainer<T, C: Container>(item: T) -> C {
   !! ^~~~~~
   !! as! C
   ```
-}
+-->
 
 Using the opaque type `some Container` as a return type
 expresses the desired API contract --- the function returns a container,
@@ -741,7 +741,7 @@ print(type(of: twelve))
 ```
 
 
-@Comment {
+<!--
   - test: `opaque-result`
   
   ```swifttest
@@ -753,7 +753,7 @@ print(type(of: twelve))
   -> print(type(of: twelve))
   <- Int
   ```
-}
+-->
 
 The type of `twelve` is inferred to be `Int`,
 which illustrates the fact that type inference works with opaque types.
@@ -765,7 +765,7 @@ and the `Item` associated type is inferred to be `Int`.
 The subscript on `Container` returns `Item`,
 which means that the type of `twelve` is also inferred to be `Int`.
 
-@Comment {
+<!--
   TODO: Expansion for the future
   
   You can combine the flexibility of returning a value of protocol type
@@ -797,10 +797,10 @@ which means that the type of `twelve` is also inferred to be `Int`.
       }
       return AnyP(p: result)
   }
-}
+-->
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -808,4 +808,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/OptionalChaining.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/OptionalChaining.md
@@ -54,7 +54,7 @@ class Residence {
 ```
 
 
-@Comment {
+<!--
   - test: `optionalChainingIntro, optionalChainingIntroAssert`
   
   ```swifttest
@@ -66,7 +66,7 @@ class Residence {
         var numberOfRooms = 1
      }
   ```
-}
+-->
 
 `Residence` instances have a single `Int` property called `numberOfRooms`,
 with a default value of `1`.
@@ -82,13 +82,13 @@ let john = Person()
 ```
 
 
-@Comment {
+<!--
   - test: `optionalChainingIntro, optionalChainingIntroAssert`
   
   ```swifttest
   -> let john = Person()
   ```
-}
+-->
 
 If you try to access the `numberOfRooms` property of this person's `residence`,
 by placing an exclamation point after `residence` to force the unwrapping of its value,
@@ -101,7 +101,7 @@ let roomCount = john.residence!.numberOfRooms
 ```
 
 
-@Comment {
+<!--
   - test: `optionalChainingIntroAssert`
   
   ```swifttest
@@ -109,7 +109,7 @@ let roomCount = john.residence!.numberOfRooms
   xx assert
   // this triggers a runtime error
   ```
-}
+-->
 
 The code above succeeds when `john.residence` has a non-`nil` value
 and will set `roomCount` to an `Int` value containing the appropriate number of rooms.
@@ -129,7 +129,7 @@ if let roomCount = john.residence?.numberOfRooms {
 ```
 
 
-@Comment {
+<!--
   - test: `optionalChainingIntro`
   
   ```swifttest
@@ -140,7 +140,7 @@ if let roomCount = john.residence?.numberOfRooms {
      }
   <- Unable to retrieve the number of rooms.
   ```
-}
+-->
 
 This tells Swift to “chain” on the optional `residence` property
 and to retrieve the value of `numberOfRooms` if `residence` exists.
@@ -167,13 +167,13 @@ john.residence = Residence()
 ```
 
 
-@Comment {
+<!--
   - test: `optionalChainingIntro`
   
   ```swifttest
   -> john.residence = Residence()
   ```
-}
+-->
 
 `john.residence` now contains an actual `Residence` instance, rather than `nil`.
 If you try to access `numberOfRooms` with the same optional chaining as before,
@@ -190,7 +190,7 @@ if let roomCount = john.residence?.numberOfRooms {
 ```
 
 
-@Comment {
+<!--
   - test: `optionalChainingIntro`
   
   ```swifttest
@@ -201,7 +201,7 @@ if let roomCount = john.residence?.numberOfRooms {
      }
   <- John's residence has 1 room(s).
   ```
-}
+-->
 
 ## Defining Model Classes for Optional Chaining
 
@@ -228,7 +228,7 @@ class Person {
 ```
 
 
-@Comment {
+<!--
   - test: `optionalChaining`
   
   ```swifttest
@@ -236,7 +236,7 @@ class Person {
         var residence: Residence?
      }
   ```
-}
+-->
 
 The `Residence` class is more complex than before.
 This time, the `Residence` class defines a variable property called `rooms`,
@@ -264,7 +264,7 @@ class Residence {
 ```
 
 
-@Comment {
+<!--
   - test: `optionalChaining`
   
   ```swifttest
@@ -287,7 +287,7 @@ class Residence {
         var address: Address?
      }
   ```
-}
+-->
 
 Because this version of `Residence` stores an array of `Room` instances,
 its `numberOfRooms` property is implemented as a computed property,
@@ -318,7 +318,7 @@ class Room {
 ```
 
 
-@Comment {
+<!--
   - test: `optionalChaining`
   
   ```swifttest
@@ -327,7 +327,7 @@ class Room {
         init(name: String) { self.name = name }
      }
   ```
-}
+-->
 
 The final class in this model is called `Address`.
 This class has three optional properties of type `String?`.
@@ -353,7 +353,7 @@ class Address {
 ```
 
 
-@Comment {
+<!--
   - test: `optionalChaining`
   
   ```swifttest
@@ -372,7 +372,7 @@ class Address {
         }
      }
   ```
-}
+-->
 
 The `Address` class also provides a method called `buildingIdentifier()`,
 which has a return type of `String?`.
@@ -401,7 +401,7 @@ if let roomCount = john.residence?.numberOfRooms {
 ```
 
 
-@Comment {
+<!--
   - test: `optionalChaining`
   
   ```swifttest
@@ -413,7 +413,7 @@ if let roomCount = john.residence?.numberOfRooms {
      }
   <- Unable to retrieve the number of rooms.
   ```
-}
+-->
 
 Because `john.residence` is `nil`,
 this optional chaining call fails in the same way as before.
@@ -428,7 +428,7 @@ john.residence?.address = someAddress
 ```
 
 
-@Comment {
+<!--
   - test: `optionalChaining`
   
   ```swifttest
@@ -437,7 +437,7 @@ john.residence?.address = someAddress
   -> someAddress.street = "Acacia Road"
   -> john.residence?.address = someAddress
   ```
-}
+-->
 
 In this example,
 the attempt to set the `address` property of `john.residence` will fail,
@@ -469,7 +469,7 @@ john.residence?.address = createAddress()
 ```
 
 
-@Comment {
+<!--
   - test: `optionalChaining`
   
   ```swifttest
@@ -486,7 +486,7 @@ john.residence?.address = createAddress()
   >> let _ = createAddress()
   << Function was called.
   ```
-}
+-->
 
 You can tell that the `createAddress()` function isn't called,
 because nothing is printed.
@@ -508,7 +508,7 @@ func printNumberOfRooms() {
 ```
 
 
-@Comment {
+<!--
   - test: `optionalChainingCallouts`
   
   ```swifttest
@@ -517,7 +517,7 @@ func printNumberOfRooms() {
         print("The number of rooms is \(numberOfRooms)")
      }
   ```
-}
+-->
 
 This method doesn't specify a return type.
 However, functions and methods with no return type have an implicit return type of `Void`,
@@ -543,7 +543,7 @@ if john.residence?.printNumberOfRooms() != nil {
 ```
 
 
-@Comment {
+<!--
   - test: `optionalChaining`
   
   ```swifttest
@@ -554,7 +554,7 @@ if john.residence?.printNumberOfRooms() != nil {
      }
   <- It was not possible to print the number of rooms.
   ```
-}
+-->
 
 The same is true if you attempt to set a property through optional chaining.
 The example above in <doc:OptionalChaining#Accessing-Properties-Through-Optional-Chaining>
@@ -573,7 +573,7 @@ if (john.residence?.address = someAddress) != nil {
 ```
 
 
-@Comment {
+<!--
   - test: `optionalChaining`
   
   ```swifttest
@@ -584,7 +584,7 @@ if (john.residence?.address = someAddress) != nil {
      }
   <- It was not possible to set the address.
   ```
-}
+-->
 
 ## Accessing Subscripts Through Optional Chaining
 
@@ -613,7 +613,7 @@ if let firstRoomName = john.residence?[0].name {
 ```
 
 
-@Comment {
+<!--
   - test: `optionalChaining`
   
   ```swifttest
@@ -624,7 +624,7 @@ if let firstRoomName = john.residence?[0].name {
      }
   <- Unable to retrieve the first room name.
   ```
-}
+-->
 
 The optional chaining question mark in this subscript call
 is placed immediately after `john.residence`, before the subscript brackets,
@@ -638,13 +638,13 @@ john.residence?[0] = Room(name: "Bathroom")
 ```
 
 
-@Comment {
+<!--
   - test: `optionalChaining`
   
   ```swifttest
   -> john.residence?[0] = Room(name: "Bathroom")
   ```
-}
+-->
 
 This subscript setting attempt also fails, because `residence` is currently `nil`.
 
@@ -668,7 +668,7 @@ if let firstRoomName = john.residence?[0].name {
 ```
 
 
-@Comment {
+<!--
   - test: `optionalChaining`
   
   ```swifttest
@@ -684,7 +684,7 @@ if let firstRoomName = john.residence?[0].name {
      }
   <- The first room name is Living Room.
   ```
-}
+-->
 
 ### Accessing Subscripts of Optional Type
 
@@ -702,7 +702,7 @@ testScores["Brian"]?[0] = 72
 ```
 
 
-@Comment {
+<!--
   - test: `optionalChaining`
   
   ```swifttest
@@ -715,7 +715,7 @@ testScores["Brian"]?[0] = 72
   /> the \"Dave\" array is now [\(testScores[dave]![0]), \(testScores[dave]![1]), \(testScores[dave]![2])] and the \"Bev\" array is now [\(testScores[bev]![0]), \(testScores[bev]![1]), \(testScores[bev]![2])]
   </ the "Dave" array is now [91, 82, 84] and the "Bev" array is now [80, 94, 81]
   ```
-}
+-->
 
 The example above defines a dictionary called `testScores`,
 which contains two key-value pairs that map a `String` key to an array of `Int` values.
@@ -766,7 +766,7 @@ if let johnsStreet = john.residence?.address?.street {
 ```
 
 
-@Comment {
+<!--
   - test: `optionalChaining`
   
   ```swifttest
@@ -777,7 +777,7 @@ if let johnsStreet = john.residence?.address?.street {
      }
   <- Unable to retrieve the address.
   ```
-}
+-->
 
 The value of `john.residence` currently contains a valid `Residence` instance.
 However, the value of `john.residence.address` is currently `nil`.
@@ -809,7 +809,7 @@ if let johnsStreet = john.residence?.address?.street {
 ```
 
 
-@Comment {
+<!--
   - test: `optionalChaining`
   
   ```swifttest
@@ -825,7 +825,7 @@ if let johnsStreet = john.residence?.address?.street {
      }
   <- John's street name is Laurel Street.
   ```
-}
+-->
 
 In this example,
 the attempt to set the `address` property of `john.residence` will succeed,
@@ -852,7 +852,7 @@ if let buildingIdentifier = john.residence?.address?.buildingIdentifier() {
 ```
 
 
-@Comment {
+<!--
   - test: `optionalChaining`
   
   ```swifttest
@@ -861,7 +861,7 @@ if let buildingIdentifier = john.residence?.address?.buildingIdentifier() {
      }
   <- John's building identifier is The Larches.
   ```
-}
+-->
 
 If you want to perform further optional chaining on this method's return value,
 place the optional chaining question mark *after* the method's parentheses:
@@ -879,7 +879,7 @@ if let beginsWithThe =
 ```
 
 
-@Comment {
+<!--
   - test: `optionalChaining`
   
   ```swifttest
@@ -893,7 +893,7 @@ if let beginsWithThe =
      }
   <- John's building identifier begins with "The".
   ```
-}
+-->
 
 > Note: In the example above,
 > you place the optional chaining question mark *after* the parentheses,
@@ -901,14 +901,14 @@ if let beginsWithThe =
 > the `buildingIdentifier()` method's return value,
 > and not the `buildingIdentifier()` method itself.
 
-@Comment {
+<!--
   TODO: add an example of chaining on a property of optional function type.
   This can then be tied in to a revised description of how
   the sugar for optional protocol requirements works.
-}
+-->
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -916,4 +916,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Properties.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Properties.md
@@ -305,8 +305,7 @@ print(manager.importer.filename)
 > there's no guarantee that the property will be initialized only once.
 
 <!--
-  6/19/14, 10:54 PM [Contributor 7746]:
-  @lazy isn't thread safe.  Global variables (and static struct/enum fields) *are*.
+  6/19/14, 10:54 PM [Contributor 7746]: @lazy isn't thread safe.  Global variables (and static struct/enum fields) *are*.
 -->
 
 ### Stored Properties and Instance Variables
@@ -1035,9 +1034,9 @@ print(rectangle.height)
   
   ```swifttest
   -> struct SmallRectangle {
-         @TwelveOrLess var height: Int
-         @TwelveOrLess var width: Int
-     }
+  ->     @TwelveOrLess var height: Int
+  ->     @TwelveOrLess var width: Int
+  -> }
   ---
   -> var rectangle = SmallRectangle()
   -> print(rectangle.height)
@@ -1226,9 +1225,9 @@ print(zeroRectangle.height, zeroRectangle.width)
   
   ```swifttest
   -> struct ZeroRectangle {
-         @SmallNumber var height: Int
-         @SmallNumber var width: Int
-     }
+  ->     @SmallNumber var height: Int
+  ->     @SmallNumber var width: Int
+  -> }
   ---
   -> var zeroRectangle = ZeroRectangle()
   -> print(zeroRectangle.height, zeroRectangle.width)
@@ -1290,9 +1289,9 @@ print(unitRectangle.height, unitRectangle.width)
   
   ```swifttest
   -> struct UnitRectangle {
-         @SmallNumber var height: Int = 1
-         @SmallNumber var width: Int = 1
-     }
+  ->     @SmallNumber var height: Int = 1
+  ->     @SmallNumber var width: Int = 1
+  -> }
   ---
   -> var unitRectangle = UnitRectangle()
   -> print(unitRectangle.height, unitRectangle.width)
@@ -1356,9 +1355,9 @@ print(narrowRectangle.height, narrowRectangle.width)
   
   ```swifttest
   -> struct NarrowRectangle {
-         @SmallNumber(wrappedValue: 2, maximum: 5) var height: Int
-         @SmallNumber(wrappedValue: 3, maximum: 4) var width: Int
-     }
+  ->     @SmallNumber(wrappedValue: 2, maximum: 5) var height: Int
+  ->     @SmallNumber(wrappedValue: 3, maximum: 4) var width: Int
+  -> }
   ---
   -> var narrowRectangle = NarrowRectangle()
   -> print(narrowRectangle.height, narrowRectangle.width)
@@ -1436,9 +1435,9 @@ print(mixedRectangle.height)
   
   ```swifttest
   -> struct MixedRectangle {
-         @SmallNumber var height: Int = 1
-         @SmallNumber(maximum: 9) var width: Int = 2
-     }
+  ->     @SmallNumber var height: Int = 1
+  ->     @SmallNumber(maximum: 9) var width: Int = 2
+  -> }
   ---
   -> var mixedRectangle = MixedRectangle()
   -> print(mixedRectangle.height)
@@ -1542,8 +1541,8 @@ print(someStructure.$someNumber)
          }
      }
   -> struct SomeStructure {
-         @SmallNumber var someNumber: Int
-     }
+  ->     @SmallNumber var someNumber: Int
+  -> }
   -> var someStructure = SomeStructure()
   ---
   -> someStructure.someNumber = 4
@@ -1613,8 +1612,8 @@ struct SizedRectangle {
      }
   ---
   -> struct SizedRectangle {
-         @SmallNumber var height: Int
-         @SmallNumber var width: Int
+  ->     @SmallNumber var height: Int
+  ->     @SmallNumber var width: Int
   ---
          mutating func resize(to size: Size) -> Bool {
              switch size {
@@ -1726,7 +1725,7 @@ func someFunction() {
   
   ```swifttest
   -> func someFunction() {
-         @SmallNumber var myNumber: Int = 0
+  ->     @SmallNumber var myNumber: Int = 0
   ---
          myNumber = 10
          // now myNumber is 10

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Properties.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Properties.md
@@ -8,7 +8,7 @@ whereas computed properties calculate (rather than store) a value.
 Computed properties are provided by classes, structures, and enumerations.
 Stored properties are provided only by classes and structures.
 
-@Comment {
+<!--
   - test: `enumerationsCantProvideStoredProperties`
   
   ```swifttest
@@ -17,7 +17,7 @@ Stored properties are provided only by classes and structures.
   !! enum E { case a, b; var x = 0 }
   !! ^
   ```
-}
+-->
 
 Stored and computed properties are usually associated with instances of a particular type.
 However, properties can also be associated with the type itself.
@@ -28,7 +28,7 @@ which you can respond to with custom actions.
 Property observers can be added to stored properties you define yourself,
 and also to properties that a subclass inherits from its superclass.
 
-@Comment {
+<!--
   - test: `propertyObserverIntroClaims`
   
   ```swifttest
@@ -53,7 +53,7 @@ and also to properties that a subclass inherits from its superclass.
   <- C didSet x from 0
   <- D didSet x from 0
   ```
-}
+-->
 
 You can also use a property wrapper
 to reuse code in the getter and setter of multiple properties.
@@ -88,7 +88,7 @@ rangeOfThreeItems.firstValue = 6
 ```
 
 
-@Comment {
+<!--
   - test: `storedProperties, storedProperties-err`
   
   ```swifttest
@@ -101,7 +101,7 @@ rangeOfThreeItems.firstValue = 6
   -> rangeOfThreeItems.firstValue = 6
   // the range now represents integer values 6, 7, and 8
   ```
-}
+-->
 
 Instances of `FixedLengthRange` have
 a variable stored property called `firstValue`
@@ -124,7 +124,7 @@ rangeOfFourItems.firstValue = 6
 ```
 
 
-@Comment {
+<!--
   - test: `storedProperties-err`
   
   ```swifttest
@@ -140,7 +140,7 @@ rangeOfFourItems.firstValue = 6
   !! var
   // this will report an error, even though firstValue is a variable property
   ```
-}
+-->
 
 Because `rangeOfFourItems` is declared as a constant (with the `let` keyword),
 it isn't possible to change its `firstValue` property,
@@ -154,16 +154,16 @@ The same isn't true for classes, which are *reference types*.
 If you assign an instance of a reference type to a constant,
 you can still change that instance's variable properties.
 
-@Comment {
+<!--
   TODO: this explanation could still do to be improved.
-}
+-->
 
 ### Lazy Stored Properties
 
-@Comment {
+<!--
   QUESTION: is this section too complex for this point in the book?
   Should it go in the Default Property Values section of Initialization instead?
-}
+-->
 
 A *lazy stored property* is a property whose initial value isn't calculated
 until the first time it's used.
@@ -176,7 +176,7 @@ the `lazy` modifier before its declaration.
 > Constant properties must always have a value *before* initialization completes,
 > and therefore can't be declared as lazy.
 
-@Comment {
+<!--
   - test: `lazyPropertiesMustAlwaysBeVariables`
   
   ```swifttest
@@ -186,7 +186,7 @@ the `lazy` modifier before its declaration.
   !! ^~~~~
   !!-
   ```
-}
+-->
 
 Lazy properties are useful when the initial value for a property
 is dependent on outside factors whose values aren't known
@@ -195,10 +195,10 @@ Lazy properties are also useful when the initial value for a property requires
 complex or computationally expensive setup that shouldn't be performed
 unless or until it's needed.
 
-@Comment {
+<!--
   TODO: add a note that if you assign a value to a lazy property before first access,
   the initial value you give in your code will be ignored.
-}
+-->
 
 The example below uses a lazy stored property to avoid
 unnecessary initialization of a complex class.
@@ -228,7 +228,7 @@ manager.data.append("Some more data")
 ```
 
 
-@Comment {
+<!--
   - test: `lazyProperties`
   
   ```swifttest
@@ -255,7 +255,7 @@ manager.data.append("Some more data")
   -> manager.data.append("Some more data")
   // the DataImporter instance for the importer property hasn't yet been created
   ```
-}
+-->
 
 The `DataManager` class has a stored property called `data`,
 which is initialized with a new, empty array of `String` values.
@@ -289,7 +289,7 @@ print(manager.importer.filename)
 ```
 
 
-@Comment {
+<!--
   - test: `lazyProperties`
   
   ```swifttest
@@ -297,17 +297,17 @@ print(manager.importer.filename)
   </ the DataImporter instance for the importer property has now been created
   <- data.txt
   ```
-}
+-->
 
 > Note: If a property marked with the `lazy` modifier
 > is accessed by multiple threads simultaneously
 > and the property hasn't yet been initialized,
 > there's no guarantee that the property will be initialized only once.
 
-@Comment {
+<!--
   6/19/14, 10:54 PM [Contributor 7746]:
   @lazy isn't thread safe.  Global variables (and static struct/enum fields) *are*.
-}
+-->
 
 ### Stored Properties and Instance Variables
 
@@ -326,9 +326,9 @@ All information about the property ---
 including its name, type, and memory management characteristics ---
 is defined in a single location as part of the type's definition.
 
-@Comment {
+<!--
   TODO: what happens if one property of a constant structure is an object reference?
-}
+-->
 
 ## Computed Properties
 
@@ -370,7 +370,7 @@ print("square.origin is now at (\(square.origin.x), \(square.origin.y))")
 ```
 
 
-@Comment {
+<!--
   - test: `computedProperties`
   
   ```swifttest
@@ -404,7 +404,7 @@ print("square.origin is now at (\(square.origin.x), \(square.origin.y))")
   -> print("square.origin is now at (\(square.origin.x), \(square.origin.y))")
   <- square.origin is now at (10.0, 10.0)
   ```
-}
+-->
 
 This example defines three structures for working with geometric shapes:
 
@@ -437,9 +437,9 @@ Setting the `center` property calls the setter for `center`,
 which modifies the `x` and `y` values of the stored `origin` property,
 and moves the square to its new position.
 
-@Comment {
+<!--
   iBooks Store screenshot begins here.
-}
+-->
 
 ![](computedProperties)
 
@@ -470,7 +470,7 @@ struct AlternativeRect {
 ```
 
 
-@Comment {
+<!--
   - test: `computedProperties`
   
   ```swifttest
@@ -490,11 +490,11 @@ struct AlternativeRect {
         }
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   iBooks Store screenshot ends here.
-}
+-->
 
 ### Shorthand Getter Declaration
 
@@ -522,7 +522,7 @@ struct CompactRect {
 ```
 
 
-@Comment {
+<!--
   - test: `computedProperties`
   
   ```swifttest
@@ -541,7 +541,7 @@ struct CompactRect {
         }
      }
   ```
-}
+-->
 
 Omitting the `return` from a getter
 follows the same rules as omitting `return` from a function,
@@ -559,7 +559,7 @@ and can be accessed through dot syntax, but can't be set to a different value.
 > to indicate that their values can't be changed once they're set
 > as part of instance initialization.
 
-@Comment {
+<!--
   - test: `readOnlyComputedPropertiesMustBeVariables`
   
   ```swifttest
@@ -576,7 +576,7 @@ and can be accessed through dot syntax, but can't be set to a different value.
   !! ~~~        ^
   !! var
   ```
-}
+-->
 
 You can simplify the declaration of a read-only computed property
 by removing the `get` keyword and its braces:
@@ -594,7 +594,7 @@ print("the volume of fourByFiveByTwo is \(fourByFiveByTwo.volume)")
 ```
 
 
-@Comment {
+<!--
   - test: `computedProperties`
   
   ```swifttest
@@ -608,7 +608,7 @@ print("the volume of fourByFiveByTwo is \(fourByFiveByTwo.volume)")
   -> print("the volume of fourByFiveByTwo is \(fourByFiveByTwo.volume)")
   <- the volume of fourByFiveByTwo is 40.0
   ```
-}
+-->
 
 This example defines a new structure called `Cuboid`,
 which represents a 3D rectangular box with `width`, `height`, and `depth` properties.
@@ -620,20 +620,20 @@ should be used for a particular `volume` value.
 Nonetheless, it's useful for a `Cuboid` to provide a read-only computed property
 to enable external users to discover its current calculated volume.
 
-@Comment {
+<!--
   NOTE: getters and setters are also allowed for constants and variables
   that aren't associated with a particular class or struct.
   Where should this be mentioned?
-}
+-->
 
-@Comment {
+<!--
   TODO: Anything else from https://[Internal Staging Server]/docs/StoredAndComputedVariables.html
-}
+-->
 
-@Comment {
+<!--
   TODO: Add an example of a computed property for an enumeration
   (now that the Enumerations chapter no longer has an example of this itself).
-}
+-->
 
 ## Property Observers
 
@@ -641,7 +641,7 @@ Property observers observe and respond to changes in a property's value.
 Property observers are called every time a property's value is set,
 even if the new value is the same as the property's current value.
 
-@Comment {
+<!--
   - test: `observersAreCalledEvenIfNewValueIsTheSameAsOldValue`
   
   ```swifttest
@@ -654,7 +654,7 @@ even if the new value is the same as the property's current value.
   <- willSet
   <- didSet
   ```
-}
+-->
 
 You can add property observers in the following places:
 
@@ -669,7 +669,7 @@ use the property's setter to observe and respond to value changes,
 instead of trying to create an observer.
 Overriding properties is described in <doc:Inheritance#Overriding>.
 
-@Comment {
+<!--
   - test: `lazyPropertiesCanHaveObservers`
   
   ```swifttest
@@ -688,9 +688,9 @@ Overriding properties is described in <doc:Inheritance#Overriding>.
   >> print(c.x)
   << 12
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `storedAndComputedInheritedPropertiesCanBeObserved`
   
   ```swifttest
@@ -716,7 +716,7 @@ Overriding properties is described in <doc:Inheritance#Overriding>.
   <- D willSet y to 42
   <- D didSet y from 42
   ```
-}
+-->
 
 You have the option to define either or both of these observers on a property:
 
@@ -735,7 +735,7 @@ You can name the parameter or use the default parameter name of `oldValue`.
 If you assign a value to a property within its own `didSet` observer,
 the new value that you assign replaces the one that was just set.
 
-@Comment {
+<!--
   - test: `assigningANewValueInADidSetReplacesTheNewValue`
   
   ```swifttest
@@ -745,7 +745,7 @@ the new value that you assign replaces the one that was just set.
   -> print(c.x)
   <- -273
   ```
-}
+-->
 
 > Note: The `willSet` and `didSet` observers of superclass properties
 > are called when a property is set in a subclass initializer,
@@ -755,7 +755,7 @@ the new value that you assign replaces the one that was just set.
 > see <doc:Initialization#Initializer-Delegation-for-Value-Types>
 > and <doc:Initialization#Initializer-Delegation-for-Class-Types>.
 
-@Comment {
+<!--
   - test: `observersDuringInitialization`
   
   ```swifttest
@@ -781,7 +781,7 @@ the new value that you assign replaces the one that was just set.
   <- willSet x
   <- didSet x
   ```
-}
+-->
 
 Here's an example of `willSet` and `didSet` in action.
 The example below defines a new class called `StepCounter`,
@@ -815,7 +815,7 @@ stepCounter.totalSteps = 896
 ```
 
 
-@Comment {
+<!--
   - test: `storedProperties`
   
   ```swifttest
@@ -842,7 +842,7 @@ stepCounter.totalSteps = 896
   </ About to set totalSteps to 896
   </ Added 536 steps
   ```
-}
+-->
 
 The `StepCounter` class declares a `totalSteps` property of type `Int`.
 This is a stored property with `willSet` and `didSet` observers.
@@ -870,7 +870,7 @@ and the default name of `oldValue` is used instead.
 > For a detailed discussion of the behavior of in-out parameters,
 > see <doc:Declarations#In-Out-Parameters>.
 
-@Comment {
+<!--
   - test: `observersCalledAfterInout`
   
   ```swifttest
@@ -884,14 +884,14 @@ and the default name of `oldValue` is used instead.
   << willSet
   << didSet
   ```
-}
+-->
 
-@Comment {
+<!--
   TODO: If you add a property observer to a stored property of structure type,
   that property observer is fired whenever any of the subproperties
   of that structure instance are set. This is cool, but nonobvious.
   Provide an example of it here.
-}
+-->
 
 ## Property Wrappers
 
@@ -927,7 +927,7 @@ struct TwelveOrLess {
 ```
 
 
-@Comment {
+<!--
   - test: `small-number-wrapper, property-wrapper-expansion`
   
   ```swifttest
@@ -940,12 +940,12 @@ struct TwelveOrLess {
          }
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   No init(wrappedValue:) in this example -- that's in a later example.
   Always initializing the wrapped value is a simpler starting point.
-}
+-->
 
 The setter ensures that new values are less than or equal to 12,
 and the getter returns the stored value.
@@ -959,7 +959,7 @@ and the getter returns the stored value.
 > and can't use `number` directly.
 > For information about `private`, see <doc:AccessControl>.
 
-@Comment {
+<!--
   In this example,
   the number is stored in the wrapper's private ``number`` property,
   but you could write a version of ``EvenNumber``
@@ -972,9 +972,9 @@ and the getter returns the stored value.
   so I'm not highlighting that fact here.
   The order of operations for willSet, set, and didSet is well defined,
   but might be something you have to pay attention to.
-}
+-->
 
-@Comment {
+<!--
   - test: `stored-property-wrappedValue`
   
   ```swifttest
@@ -1001,7 +1001,7 @@ and the getter returns the stored value.
   >> print(s.someNumber)
   << 12
   ```
-}
+-->
 
 You apply a wrapper to a property
 by writing the wrapper's name before the property
@@ -1030,7 +1030,7 @@ print(rectangle.height)
 ```
 
 
-@Comment {
+<!--
   - test: `small-number-wrapper`
   
   ```swifttest
@@ -1051,7 +1051,7 @@ print(rectangle.height)
   -> print(rectangle.height)
   <- 12
   ```
-}
+-->
 
 The `height` and `width` properties get their initial values
 from the definition of `TwelveOrLess`,
@@ -1091,7 +1091,7 @@ struct SmallRectangle {
 ```
 
 
-@Comment {
+<!--
   - test: `property-wrapper-expansion`
   
   ```swifttest
@@ -1108,7 +1108,7 @@ struct SmallRectangle {
          }
      }
   ```
-}
+-->
 
 The `_height` and `_width` properties
 store an instance of the property wrapper, `TwelveOrLess`.
@@ -1158,7 +1158,7 @@ struct SmallNumber {
 ```
 
 
-@Comment {
+<!--
   - test: `property-wrapper-init, property-wrapper-mixed-init`
   
   ```swifttest
@@ -1186,9 +1186,9 @@ struct SmallNumber {
          }
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   The initializers above could be written to use
   init(wrappedValue:maximum:) as the designated initializer,
   with the other two calling it instead of doing initialization.
@@ -1196,7 +1196,7 @@ struct SmallNumber {
   that the risk of bugs isn't significant,
   and the reader hasn't seen init syntax/rules in detail yet
   so it's clearer to make each init stand on its own.
-}
+-->
 
 The definition of `SmallNumber` includes three initializers ---
 `init()`, `init(wrappedValue:)`, and `init(wrappedValue:maximum:)` ---
@@ -1221,7 +1221,7 @@ print(zeroRectangle.height, zeroRectangle.width)
 ```
 
 
-@Comment {
+<!--
   - test: `property-wrapper-init`
   
   ```swifttest
@@ -1234,9 +1234,9 @@ print(zeroRectangle.height, zeroRectangle.width)
   -> print(zeroRectangle.height, zeroRectangle.width)
   <- 0 0
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `property-wrapper-init`
   
   ```swifttest
@@ -1256,7 +1256,7 @@ print(zeroRectangle.height, zeroRectangle.width)
   -> print(zeroRectangle_equiv.height, zeroRectangle_equiv.width)
   <- 0 0
   ```
-}
+-->
 
 The instances of `SmallNumber` that wrap `height` and `width`
 are created by calling `SmallNumber()`.
@@ -1285,7 +1285,7 @@ print(unitRectangle.height, unitRectangle.width)
 ```
 
 
-@Comment {
+<!--
   - test: `property-wrapper-init`
   
   ```swifttest
@@ -1298,9 +1298,9 @@ print(unitRectangle.height, unitRectangle.width)
   -> print(unitRectangle.height, unitRectangle.width)
   <- 1 1
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `property-wrapper-init`
   
   ```swifttest
@@ -1320,7 +1320,7 @@ print(unitRectangle.height, unitRectangle.width)
   -> print(unitRectangle_equiv.height, unitRectangle_equiv.width)
   <- 1 1
   ```
-}
+-->
 
 When you write `= 1` on a property with a wrapper,
 that's translated into a call to the `init(wrappedValue:)` initializer.
@@ -1351,7 +1351,7 @@ print(narrowRectangle.height, narrowRectangle.width)
 ```
 
 
-@Comment {
+<!--
   - test: `property-wrapper-init`
   
   ```swifttest
@@ -1369,9 +1369,9 @@ print(narrowRectangle.height, narrowRectangle.width)
   -> print(narrowRectangle.height, narrowRectangle.width)
   <- 5 4
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `property-wrapper-init`
   
   ```swifttest
@@ -1395,7 +1395,7 @@ print(narrowRectangle.height, narrowRectangle.width)
   -> print(narrowRectangle_equiv.height, narrowRectangle_equiv.width)
   <- 5 4
   ```
-}
+-->
 
 The instance of `SmallNumber` that wraps `height`
 is created by calling `SmallNumber(wrappedValue: 2, maximum: 5)`,
@@ -1431,7 +1431,7 @@ print(mixedRectangle.height)
 ```
 
 
-@Comment {
+<!--
   - test: `property-wrapper-mixed-init`
   
   ```swifttest
@@ -1448,7 +1448,7 @@ print(mixedRectangle.height)
   -> print(mixedRectangle.height)
   <- 12
   ```
-}
+-->
 
 The instance of `SmallNumber` that wraps `height`
 is created by calling `SmallNumber(wrappedValue: 1)`,
@@ -1514,7 +1514,7 @@ print(someStructure.$someNumber)
 ```
 
 
-@Comment {
+<!--
   - test: `small-number-wrapper-projection`
   
   ```swifttest
@@ -1554,7 +1554,7 @@ print(someStructure.$someNumber)
   -> print(someStructure.$someNumber)
   <- true
   ```
-}
+-->
 
 Writing `someStructure.$someNumber` accesses the wrapper's projected value.
 After storing a small number like four,
@@ -1604,7 +1604,7 @@ struct SizedRectangle {
 ```
 
 
-@Comment {
+<!--
   - test: `small-number-wrapper-projection`
   
   ```swifttest
@@ -1635,7 +1635,7 @@ struct SizedRectangle {
   >> print(adj, r.height, r.width)
   << true 12 12
   ```
-}
+-->
 
 Because property wrapper syntax is just syntactic sugar
 for a property with a getter and a setter,
@@ -1675,7 +1675,7 @@ in either a global or local scope.
 Computed variables calculate their value, rather than storing it,
 and they're written in the same way as computed properties.
 
-@Comment {
+<!--
   - test: `computedVariables`
   
   ```swifttest
@@ -1685,9 +1685,9 @@ and they're written in the same way as computed properties.
   -> print(a)
   <- 42
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `observersForStoredVariables`
   
   ```swifttest
@@ -1696,7 +1696,7 @@ and they're written in the same way as computed properties.
   <- willSet
   <- didSet
   ```
-}
+-->
 
 > Note: Global constants and variables are always computed lazily,
 > in a similar manner to <doc:Properties#Lazy-Stored-Properties>.
@@ -1721,7 +1721,7 @@ func someFunction() {
 ```
 
 
-@Comment {
+<!--
   - test: `property-wrapper-init`
   
   ```swifttest
@@ -1740,28 +1740,28 @@ func someFunction() {
   << 10
   << 12
   ```
-}
+-->
 
 Like when you apply `SmallNumber` to a property,
 setting the value of `myNumber` to 10 is valid.
 Because the property wrapper doesn't allow values higher than 12,
 it sets `myNumber` to 12 instead of 24.
 
-@Comment {
+<!--
   The discussion of local variables with property wrappers
   has to come later, because we need to use init(wrappedValue:)
   to work around <rdar://problem/74616133>.
-}
+-->
 
-@Comment {
+<!--
   TODO: clarify what we mean by "global variables" here.
   According to [Contributor 6004], anything defined in a playground, REPL, or in main.swift
   is a local variable in top-level code, not a global variable.
-}
+-->
 
-@Comment {
+<!--
   TODO: this also makes it impossible (at present) to test the "always lazy" assertion.
-}
+-->
 
 ## Type Properties
 
@@ -1833,7 +1833,7 @@ class SomeClass {
 ```
 
 
-@Comment {
+<!--
   - test: `typePropertySyntax`
   
   ```swifttest
@@ -1859,9 +1859,9 @@ class SomeClass {
         }
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `classComputedTypePropertiesAreOverrideable`
   
   ```swifttest
@@ -1870,9 +1870,9 @@ class SomeClass {
   -> assert(A.cp == "A")
   -> assert(B.cp == "B")
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `staticComputedTypePropertiesAreFinal`
   
   ```swifttest
@@ -1885,7 +1885,7 @@ class SomeClass {
   !! class A { static var cp: String { return "A" } }
   !!                      ^
   ```
-}
+-->
 
 > Note: The computed type property examples above are for read-only computed type properties,
 > but you can also define read-write computed type properties
@@ -1910,7 +1910,7 @@ print(SomeClass.computedTypeProperty)
 ```
 
 
-@Comment {
+<!--
   - test: `typePropertySyntax`
   
   ```swifttest
@@ -1924,7 +1924,7 @@ print(SomeClass.computedTypeProperty)
   -> print(SomeClass.computedTypeProperty)
   <- 27
   ```
-}
+-->
 
 The examples that follow use two stored type properties as part of a structure
 that models an audio level meter for a number of audio channels.
@@ -1963,7 +1963,7 @@ struct AudioChannel {
 ```
 
 
-@Comment {
+<!--
   - test: `staticProperties`
   
   ```swifttest
@@ -1984,7 +1984,7 @@ struct AudioChannel {
         }
      }
   ```
-}
+-->
 
 The `AudioChannel` structure defines two stored type properties to support its functionality.
 The first, `thresholdLevel`, defines the maximum threshold value an audio level can take.
@@ -2027,14 +2027,14 @@ var rightChannel = AudioChannel()
 ```
 
 
-@Comment {
+<!--
   - test: `staticProperties`
   
   ```swifttest
   -> var leftChannel = AudioChannel()
   -> var rightChannel = AudioChannel()
   ```
-}
+-->
 
 If you set the `currentLevel` of the *left* channel to `7`,
 you can see that the `maxInputLevelForAllChannels` type property
@@ -2049,7 +2049,7 @@ print(AudioChannel.maxInputLevelForAllChannels)
 ```
 
 
-@Comment {
+<!--
   - test: `staticProperties`
   
   ```swifttest
@@ -2059,7 +2059,7 @@ print(AudioChannel.maxInputLevelForAllChannels)
   -> print(AudioChannel.maxInputLevelForAllChannels)
   <- 7
   ```
-}
+-->
 
 If you try to set the `currentLevel` of the *right* channel to `11`,
 you can see that the right channel's `currentLevel` property
@@ -2075,7 +2075,7 @@ print(AudioChannel.maxInputLevelForAllChannels)
 ```
 
 
-@Comment {
+<!--
   - test: `staticProperties`
   
   ```swifttest
@@ -2085,10 +2085,10 @@ print(AudioChannel.maxInputLevelForAllChannels)
   -> print(AudioChannel.maxInputLevelForAllChannels)
   <- 10
   ```
-}
+-->
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -2096,4 +2096,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Protocols.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Protocols.md
@@ -2229,9 +2229,9 @@ which has two optional requirements:
   ```swifttest
   >> import Foundation
   -> @objc protocol CounterDataSource {
-        @objc optional func increment(forCount count: Int) -> Int
-        @objc optional var fixedIncrement: Int { get }
-     }
+  ->    @objc optional func increment(forCount count: Int) -> Int
+  ->    @objc optional var fixedIncrement: Int { get }
+  -> }
   ```
 -->
 
@@ -2718,7 +2718,7 @@ print(differentNumbers.allEqual())
   TODO: Other things to be included
   ---------------------------------
   Class-only protocols
-  @obj-c protocols
+  Protocols marked @objc
   Standard-library protocols such as Sequence, Equatable etc.?
   Show how to make a custom type conform to Boolean or some other protocol
   Show a protocol being used by an enumeration

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Protocols.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Protocols.md
@@ -14,7 +14,7 @@ In addition to specifying requirements that conforming types must implement,
 you can extend a protocol to implement some of these requirements
 or to implement additional functionality that conforming types can take advantage of.
 
-@Comment {
+<!--
   FIXME: Protocols should also be able to support initializers,
   and indeed you can currently write them,
   but they don't work due to
@@ -23,7 +23,7 @@ or to implement additional functionality that conforming types can take advantag
   UPDATE: actually, they *can* be used right now,
   but only in a generic function, and not more generally with the protocol type.
   I'm not sure I should mention them in this chapter until they work more generally.
-}
+-->
 
 ## Protocol Syntax
 
@@ -36,7 +36,7 @@ protocol SomeProtocol {
 ```
 
 
-@Comment {
+<!--
   - test: `protocolSyntax`
   
   ```swifttest
@@ -44,7 +44,7 @@ protocol SomeProtocol {
         // protocol definition goes here
      }
   ```
-}
+-->
 
 Custom types state that they adopt a particular protocol
 by placing the protocol's name after the type's name,
@@ -58,7 +58,7 @@ struct SomeStructure: FirstProtocol, AnotherProtocol {
 ```
 
 
-@Comment {
+<!--
   - test: `protocolSyntax`
   
   ```swifttest
@@ -68,7 +68,7 @@ struct SomeStructure: FirstProtocol, AnotherProtocol {
         // structure definition goes here
      }
   ```
-}
+-->
 
 If a class has a superclass, list the superclass name
 before any protocols it adopts, followed by a comma:
@@ -80,7 +80,7 @@ class SomeClass: SomeSuperclass, FirstProtocol, AnotherProtocol {
 ```
 
 
-@Comment {
+<!--
   - test: `protocolSyntax`
   
   ```swifttest
@@ -89,7 +89,7 @@ class SomeClass: SomeSuperclass, FirstProtocol, AnotherProtocol {
         // class definition goes here
      }
   ```
-}
+-->
 
 ## Property Requirements
 
@@ -123,7 +123,7 @@ protocol SomeProtocol {
 ```
 
 
-@Comment {
+<!--
   - test: `instanceProperties`
   
   ```swifttest
@@ -132,7 +132,7 @@ protocol SomeProtocol {
         var doesNotNeedToBeSettable: Int { get }
      }
   ```
-}
+-->
 
 Always prefix type property requirements with the `static` keyword
 when you define them in a protocol.
@@ -146,7 +146,7 @@ protocol AnotherProtocol {
 ```
 
 
-@Comment {
+<!--
   - test: `instanceProperties`
   
   ```swifttest
@@ -154,7 +154,7 @@ protocol AnotherProtocol {
         static var someTypeProperty: Int { get set }
      }
   ```
-}
+-->
 
 Here's an example of a protocol with a single instance property requirement:
 
@@ -165,7 +165,7 @@ protocol FullyNamed {
 ```
 
 
-@Comment {
+<!--
   - test: `instanceProperties`
   
   ```swifttest
@@ -173,7 +173,7 @@ protocol FullyNamed {
         var fullName: String { get }
      }
   ```
-}
+-->
 
 The `FullyNamed` protocol requires a conforming type to provide a fully qualified name.
 The protocol doesn't specify anything else about the nature of the conforming type ---
@@ -193,7 +193,7 @@ let john = Person(fullName: "John Appleseed")
 ```
 
 
-@Comment {
+<!--
   - test: `instanceProperties`
   
   ```swifttest
@@ -204,7 +204,7 @@ let john = Person(fullName: "John Appleseed")
   /> john.fullName is \"\(john.fullName)\"
   </ john.fullName is "John Appleseed"
   ```
-}
+-->
 
 This example defines a structure called `Person`,
 which represents a specific named person.
@@ -236,7 +236,7 @@ var ncc1701 = Starship(name: "Enterprise", prefix: "USS")
 ```
 
 
-@Comment {
+<!--
   - test: `instanceProperties`
   
   ```swifttest
@@ -255,7 +255,7 @@ var ncc1701 = Starship(name: "Enterprise", prefix: "USS")
   /> ncc1701.fullName is \"\(ncc1701.fullName)\"
   </ ncc1701.fullName is "USS Enterprise"
   ```
-}
+-->
 
 This class implements the `fullName` property requirement as
 a computed read-only property for a starship.
@@ -263,9 +263,9 @@ Each `Starship` class instance stores a mandatory `name` and an optional `prefix
 The `fullName` property uses the `prefix` value if it exists,
 and prepends it to the beginning of `name` to create a full name for the starship.
 
-@Comment {
+<!--
   TODO: add some advice on how protocols should be named
-}
+-->
 
 ## Method Requirements
 
@@ -290,7 +290,7 @@ protocol SomeProtocol {
 ```
 
 
-@Comment {
+<!--
   - test: `typeMethods`
   
   ```swifttest
@@ -298,7 +298,7 @@ protocol SomeProtocol {
         static func someTypeMethod()
      }
   ```
-}
+-->
 
 The following example defines a protocol with a single instance method requirement:
 
@@ -309,7 +309,7 @@ protocol RandomNumberGenerator {
 ```
 
 
-@Comment {
+<!--
   - test: `protocols`
   
   ```swifttest
@@ -317,7 +317,7 @@ protocol RandomNumberGenerator {
         func random() -> Double
      }
   ```
-}
+-->
 
 This protocol, `RandomNumberGenerator`, requires any conforming type
 to have an instance method called `random`,
@@ -356,7 +356,7 @@ print("And another one: \(generator.random())")
 ```
 
 
-@Comment {
+<!--
   - test: `protocols`
   
   ```swifttest
@@ -377,7 +377,7 @@ print("And another one: \(generator.random())")
   -> print("And another one: \(generator.random())")
   <- And another one: 0.729023776863283
   ```
-}
+-->
 
 ## Mutating Method Requirements
 
@@ -418,7 +418,7 @@ protocol Togglable {
 ```
 
 
-@Comment {
+<!--
   - test: `mutatingRequirements`
   
   ```swifttest
@@ -426,7 +426,7 @@ protocol Togglable {
         mutating func toggle()
      }
   ```
-}
+-->
 
 If you implement the `Togglable` protocol for a structure or enumeration,
 that structure or enumeration can conform to the protocol
@@ -457,7 +457,7 @@ lightSwitch.toggle()
 ```
 
 
-@Comment {
+<!--
   - test: `mutatingRequirements`
   
   ```swifttest
@@ -476,7 +476,7 @@ lightSwitch.toggle()
   -> lightSwitch.toggle()
   // lightSwitch is now equal to .on
   ```
-}
+-->
 
 ## Initializer Requirements
 
@@ -493,7 +493,7 @@ protocol SomeProtocol {
 ```
 
 
-@Comment {
+<!--
   - test: `initializers`
   
   ```swifttest
@@ -501,7 +501,7 @@ protocol SomeProtocol {
         init(someParameter: Int)
      }
   ```
-}
+-->
 
 ### Class Implementations of Protocol Initializer Requirements
 
@@ -519,7 +519,7 @@ class SomeClass: SomeProtocol {
 ```
 
 
-@Comment {
+<!--
   - test: `initializers`
   
   ```swifttest
@@ -529,9 +529,9 @@ class SomeClass: SomeProtocol {
         }
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `protocolInitializerRequirementsCanBeImplementedAsDesignatedOrConvenience`
   
   ```swifttest
@@ -548,7 +548,7 @@ class SomeClass: SomeProtocol {
         }
      }
   ```
-}
+-->
 
 The use of the `required` modifier ensures that
 you provide an explicit or inherited implementation of the initializer requirement
@@ -558,7 +558,7 @@ such that they also conform to the protocol.
 For more information on required initializers,
 see <doc:Initialization#Required-Initializers>.
 
-@Comment {
+<!--
   - test: `protocolInitializerRequirementsRequireTheRequiredModifierOnTheImplementingClass`
   
   ```swifttest
@@ -576,9 +576,9 @@ see <doc:Initialization#Required-Initializers>.
   !! ^
   !! required
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `protocolInitializerRequirementsRequireTheRequiredModifierOnSubclasses`
   
   ```swifttest
@@ -602,14 +602,14 @@ see <doc:Initialization#Required-Initializers>.
   !! required init(s: String) {}
   !! ^
   ```
-}
+-->
 
 > Note: You don't need to mark protocol initializer implementations with the `required` modifier
 > on classes that are marked with the `final` modifier,
 > because final classes can't subclassed.
 > For more about the `final` modifier, see <doc:Inheritance#Preventing-Overrides>.
 
-@Comment {
+<!--
   - test: `finalClassesDoNotNeedTheRequiredModifierForProtocolInitializerRequirements`
   
   ```swifttest
@@ -623,7 +623,7 @@ see <doc:Initialization#Required-Initializers>.
         init(s: String) {}
      }
   ```
-}
+-->
 
 If a subclass overrides a designated initializer from a superclass,
 and also implements a matching initializer requirement from a protocol,
@@ -649,7 +649,7 @@ class SomeSubClass: SomeSuperClass, SomeProtocol {
 ```
 
 
-@Comment {
+<!--
   - test: `requiredOverrideInitializers`
   
   ```swifttest
@@ -670,7 +670,7 @@ class SomeSubClass: SomeSuperClass, SomeProtocol {
         }
      }
   ```
-}
+-->
 
 ### Failable Initializer Requirements
 
@@ -682,7 +682,7 @@ a failable or nonfailable initializer on a conforming type.
 A nonfailable initializer requirement can be satisfied by
 a nonfailable initializer or an implicitly unwrapped failable initializer.
 
-@Comment {
+<!--
   - test: `failableRequirementCanBeSatisfiedByFailableInitializer`
   
   ```swifttest
@@ -690,9 +690,9 @@ a nonfailable initializer or an implicitly unwrapped failable initializer.
   -> class C: P { required init?(i: Int) {} }
   -> struct S: P { init?(i: Int) {} }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `failableRequirementCanBeSatisfiedByIUOInitializer`
   
   ```swifttest
@@ -700,9 +700,9 @@ a nonfailable initializer or an implicitly unwrapped failable initializer.
   -> class C: P { required init!(i: Int) {} }
   -> struct S: P { init!(i: Int) {} }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `iuoRequirementCanBeSatisfiedByFailableInitializer`
   
   ```swifttest
@@ -710,9 +710,9 @@ a nonfailable initializer or an implicitly unwrapped failable initializer.
   -> class C: P { required init?(i: Int) {} }
   -> struct S: P { init?(i: Int) {} }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `iuoRequirementCanBeSatisfiedByIUOInitializer`
   
   ```swifttest
@@ -720,9 +720,9 @@ a nonfailable initializer or an implicitly unwrapped failable initializer.
   -> class C: P { required init!(i: Int) {} }
   -> struct S: P { init!(i: Int) {} }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `failableRequirementCanBeSatisfiedByNonFailableInitializer`
   
   ```swifttest
@@ -730,9 +730,9 @@ a nonfailable initializer or an implicitly unwrapped failable initializer.
   -> class C: P { required init(i: Int) {} }
   -> struct S: P { init(i: Int) {} }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `iuoRequirementCanBeSatisfiedByNonFailableInitializer`
   
   ```swifttest
@@ -740,9 +740,9 @@ a nonfailable initializer or an implicitly unwrapped failable initializer.
   -> class C: P { required init(i: Int) {} }
   -> struct S: P { init(i: Int) {} }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `nonFailableRequirementCanBeSatisfiedByNonFailableInitializer`
   
   ```swifttest
@@ -750,9 +750,9 @@ a nonfailable initializer or an implicitly unwrapped failable initializer.
   -> class C: P { required init(i: Int) {} }
   -> struct S: P { init(i: Int) {} }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `nonFailableRequirementCanBeSatisfiedByIUOInitializer`
   
   ```swifttest
@@ -760,7 +760,7 @@ a nonfailable initializer or an implicitly unwrapped failable initializer.
   -> class C: P { required init!(i: Int) {} }
   -> struct S: P { init!(i: Int) {} }
   ```
-}
+-->
 
 ## Protocols as Types
 
@@ -800,7 +800,7 @@ class Dice {
 ```
 
 
-@Comment {
+<!--
   - test: `protocols`
   
   ```swifttest
@@ -816,7 +816,7 @@ class Dice {
         }
      }
   ```
-}
+-->
 
 This example defines a new class called `Dice`,
 which represents an *n*-sided dice for use in a board game.
@@ -870,7 +870,7 @@ for _ in 1...5 {
 ```
 
 
-@Comment {
+<!--
   - test: `protocols`
   
   ```swifttest
@@ -884,7 +884,7 @@ for _ in 1...5 {
   </ Random dice roll is 5
   </ Random dice roll is 4
   ```
-}
+-->
 
 ## Delegation
 
@@ -914,7 +914,7 @@ protocol DiceGameDelegate: AnyObject {
 ```
 
 
-@Comment {
+<!--
   - test: `protocols`
   
   ```swifttest
@@ -928,7 +928,7 @@ protocol DiceGameDelegate: AnyObject {
         func gameDidEnd(_ game: DiceGame)
      }
   ```
-}
+-->
 
 The `DiceGame` protocol is a protocol that can be adopted
 by any game that involves dice.
@@ -985,7 +985,7 @@ class SnakesAndLadders: DiceGame {
 ```
 
 
-@Comment {
+<!--
   - test: `protocols`
   
   ```swifttest
@@ -1020,7 +1020,7 @@ class SnakesAndLadders: DiceGame {
         }
      }
   ```
-}
+-->
 
 For a description of the *Snakes and Ladders* gameplay,
 see <doc:ControlFlow#Break>.
@@ -1059,9 +1059,9 @@ If the `delegate` property is non-nil,
 the delegate methods are called,
 and are passed the `SnakesAndLadders` instance as a parameter.
 
-@Comment {
+<!--
   TODO: add a cross-reference to optional chaining here.
-}
+-->
 
 This next example shows a class called `DiceGameTracker`,
 which adopts the `DiceGameDelegate` protocol:
@@ -1087,7 +1087,7 @@ class DiceGameTracker: DiceGameDelegate {
 ```
 
 
-@Comment {
+<!--
   - test: `protocols`
   
   ```swifttest
@@ -1109,7 +1109,7 @@ class DiceGameTracker: DiceGameDelegate {
         }
      }
   ```
-}
+-->
 
 `DiceGameTracker` implements all three methods required by `DiceGameDelegate`.
 It uses these methods to keep track of the number of turns a game has taken.
@@ -1151,7 +1151,7 @@ game.play()
 ```
 
 
-@Comment {
+<!--
   - test: `protocols`
   
   ```swifttest
@@ -1167,7 +1167,7 @@ game.play()
   </ Rolled a 5
   </ The game lasted for 4 turns
   ```
-}
+-->
 
 ## Adding Protocol Conformance with an Extension
 
@@ -1191,7 +1191,7 @@ protocol TextRepresentable {
 ```
 
 
-@Comment {
+<!--
   - test: `protocols`
   
   ```swifttest
@@ -1199,15 +1199,15 @@ protocol TextRepresentable {
         var textualDescription: String { get }
      }
   ```
-}
+-->
 
 The `Dice` class from above can be extended to adopt and conform to `TextRepresentable`:
 
-@Comment {
+<!--
   No "from above" xref because
   even though Dice isn't defined in the section immediately previous
   it's part of a running example and Dice is used in that section.
-}
+-->
 
 ```swift
 extension Dice: TextRepresentable {
@@ -1218,7 +1218,7 @@ extension Dice: TextRepresentable {
 ```
 
 
-@Comment {
+<!--
   - test: `protocols`
   
   ```swifttest
@@ -1228,7 +1228,7 @@ extension Dice: TextRepresentable {
         }
      }
   ```
-}
+-->
 
 This extension adopts the new protocol in exactly the same way
 as if `Dice` had provided it in its original implementation.
@@ -1245,7 +1245,7 @@ print(d12.textualDescription)
 ```
 
 
-@Comment {
+<!--
   - test: `protocols`
   
   ```swifttest
@@ -1253,7 +1253,7 @@ print(d12.textualDescription)
   -> print(d12.textualDescription)
   <- A 12-sided dice
   ```
-}
+-->
 
 Similarly, the `SnakesAndLadders` game class can be extended to
 adopt and conform to the `TextRepresentable` protocol:
@@ -1269,7 +1269,7 @@ print(game.textualDescription)
 ```
 
 
-@Comment {
+<!--
   - test: `protocols`
   
   ```swifttest
@@ -1281,7 +1281,7 @@ print(game.textualDescription)
   -> print(game.textualDescription)
   <- A game of Snakes and Ladders with 25 squares
   ```
-}
+-->
 
 ### Conditionally Conforming to a Protocol
 
@@ -1311,7 +1311,7 @@ print(myDice.textualDescription)
 ```
 
 
-@Comment {
+<!--
   - test: `protocols`
   
   ```swifttest
@@ -1325,7 +1325,7 @@ print(myDice.textualDescription)
   -> print(myDice.textualDescription)
   <- [A 6-sided dice, A 12-sided dice]
   ```
-}
+-->
 
 ### Declaring Protocol Adoption with an Extension
 
@@ -1344,7 +1344,7 @@ extension Hamster: TextRepresentable {}
 ```
 
 
-@Comment {
+<!--
   - test: `protocols`
   
   ```swifttest
@@ -1356,7 +1356,7 @@ extension Hamster: TextRepresentable {}
      }
   -> extension Hamster: TextRepresentable {}
   ```
-}
+-->
 
 Instances of `Hamster` can now be used wherever `TextRepresentable` is the required type:
 
@@ -1368,7 +1368,7 @@ print(somethingTextRepresentable.textualDescription)
 ```
 
 
-@Comment {
+<!--
   - test: `protocols`
   
   ```swifttest
@@ -1377,7 +1377,7 @@ print(somethingTextRepresentable.textualDescription)
   -> print(somethingTextRepresentable.textualDescription)
   <- A hamster named Simon
   ```
-}
+-->
 
 > Note: Types don't automatically adopt a protocol just by satisfying its requirements.
 > They must always explicitly declare their adoption of the protocol.
@@ -1391,7 +1391,7 @@ Using this synthesized implementation
 means you don't have to write repetitive boilerplate code
 to implement the protocol requirements yourself.
 
-@Comment {
+<!--
   Linking directly to a section of an article like the URLs below do
   is expected to be stable --
   as long as the section stays around, that topic ID will be there too.
@@ -1412,7 +1412,7 @@ to implement the protocol requirements yourself.
   is also repeated in the "Conform Automatically to Equatable and Hashable" section
   of the article "Adopting Common Protocols".
   https://developer.apple.com/documentation/swift/adopting_common_protocols#2991123
-}
+-->
 
 Swift provides a synthesized implementation of `Equatable`
 for the following kinds of custom types:
@@ -1448,7 +1448,7 @@ if twoThreeFour == anotherTwoThreeFour {
 ```
 
 
-@Comment {
+<!--
   - test: `equatable_synthesis`
   
   ```swifttest
@@ -1463,16 +1463,16 @@ if twoThreeFour == anotherTwoThreeFour {
      }
   <- These two vectors are also equivalent.
   ```
-}
+-->
 
-@Comment {
+<!--
   Need to cross reference here from "Adopting Common Protocols"
   https://developer.apple.com/documentation/swift/adopting_common_protocols
   
   Discussion in the article calls out that
   enums without associated values are Equatable & Hashable
   even if you don't declare the protocol conformance.
-}
+-->
 
 Swift provides a synthesized implementation of `Hashable`
 for the following kinds of custom types:
@@ -1519,7 +1519,7 @@ for level in levels.sorted() {
 ```
 
 
-@Comment {
+<!--
   - test: `comparable-enum-synthesis`
   
   ```swifttest
@@ -1538,15 +1538,15 @@ for level in levels.sorted() {
   <- expert(stars: 3)
   <- expert(stars: 5)
   ```
-}
+-->
 
-@Comment {
+<!--
   The example above iterates and prints instead of printing the whole array
   because printing an array gives you the debug description of each element,
   which looks like temp123908.SkillLevel.expert(5) -- not nice to read.
-}
+-->
 
-@Comment {
+<!--
   - test: `no-synthesized-comparable-for-raw-value-enum`
   
   ```swifttest
@@ -1582,7 +1582,7 @@ for level in levels.sorted() {
   !! static func < (lhs: Self, rhs: Self) -> Bool
   !!                 ^
   ```
-}
+-->
 
 ## Collections of Protocol Types
 
@@ -1596,13 +1596,13 @@ let things: [TextRepresentable] = [game, d12, simonTheHamster]
 ```
 
 
-@Comment {
+<!--
   - test: `protocols`
   
   ```swifttest
   -> let things: [TextRepresentable] = [game, d12, simonTheHamster]
   ```
-}
+-->
 
 It's now possible to iterate over the items in the array,
 and print each item's textual description:
@@ -1617,7 +1617,7 @@ for thing in things {
 ```
 
 
-@Comment {
+<!--
   - test: `protocols`
   
   ```swifttest
@@ -1628,7 +1628,7 @@ for thing in things {
   </ A 12-sided dice
   </ A hamster named Simon
   ```
-}
+-->
 
 Note that the `thing` constant is of type `TextRepresentable`.
 It's not of type `Dice`, or `DiceGame`, or `Hamster`,
@@ -1651,7 +1651,7 @@ protocol InheritingProtocol: SomeProtocol, AnotherProtocol {
 ```
 
 
-@Comment {
+<!--
   - test: `protocols`
   
   ```swifttest
@@ -1661,7 +1661,7 @@ protocol InheritingProtocol: SomeProtocol, AnotherProtocol {
         // protocol definition goes here
      }
   ```
-}
+-->
 
 Here's an example of a protocol that inherits
 the `TextRepresentable` protocol from above:
@@ -1673,7 +1673,7 @@ protocol PrettyTextRepresentable: TextRepresentable {
 ```
 
 
-@Comment {
+<!--
   - test: `protocols`
   
   ```swifttest
@@ -1681,7 +1681,7 @@ protocol PrettyTextRepresentable: TextRepresentable {
         var prettyTextualDescription: String { get }
      }
   ```
-}
+-->
 
 This example defines a new protocol, `PrettyTextRepresentable`,
 which inherits from `TextRepresentable`.
@@ -1713,7 +1713,7 @@ extension SnakesAndLadders: PrettyTextRepresentable {
 ```
 
 
-@Comment {
+<!--
   - test: `protocols`
   
   ```swifttest
@@ -1734,7 +1734,7 @@ extension SnakesAndLadders: PrettyTextRepresentable {
         }
      }
   ```
-}
+-->
 
 This extension states that it adopts the `PrettyTextRepresentable` protocol
 and provides an implementation of the `prettyTextualDescription` property
@@ -1765,7 +1765,7 @@ print(game.prettyTextualDescription)
 ```
 
 
-@Comment {
+<!--
   - test: `protocols`
   
   ```swifttest
@@ -1773,7 +1773,7 @@ print(game.prettyTextualDescription)
   </ A game of Snakes and Ladders with 25 squares:
   </ ○ ○ ▲ ○ ○ ▲ ○ ○ ▲ ▲ ○ ○ ○ ▼ ○ ○ ○ ○ ▼ ○ ○ ▼ ○ ▼ ○
   ```
-}
+-->
 
 ## Class-Only Protocols
 
@@ -1787,7 +1787,7 @@ protocol SomeClassOnlyProtocol: AnyObject, SomeInheritedProtocol {
 ```
 
 
-@Comment {
+<!--
   - test: `classOnlyProtocols`
   
   ```swifttest
@@ -1796,7 +1796,7 @@ protocol SomeClassOnlyProtocol: AnyObject, SomeInheritedProtocol {
         // class-only protocol definition goes here
      }
   ```
-}
+-->
 
 In the example above, `SomeClassOnlyProtocol` can only be adopted by class types.
 It's a compile-time error to write a structure or enumeration definition
@@ -1809,7 +1809,7 @@ that tries to adopt `SomeClassOnlyProtocol`.
 > see <doc:ClassesAndStructures#Structures-and-Enumerations-Are-Value-Types>
 > and <doc:ClassesAndStructures#Classes-Are-Reference-Types>.
 
-@Comment {
+<!--
   - test: `anyobject-doesn't-have-to-be-first`
   
   ```swifttest
@@ -1818,11 +1818,11 @@ that tries to adopt `SomeClassOnlyProtocol`.
         // class-only protocol definition goes here
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   TODO: a Cacheable protocol might make a good example here?
-}
+-->
 
 ## Protocol Composition
 
@@ -1864,7 +1864,7 @@ wishHappyBirthday(to: birthdayPerson)
 ```
 
 
-@Comment {
+<!--
   - test: `protocolComposition`
   
   ```swifttest
@@ -1885,7 +1885,7 @@ wishHappyBirthday(to: birthdayPerson)
   -> wishHappyBirthday(to: birthdayPerson)
   <- Happy birthday, Malcolm, you're 21!
   ```
-}
+-->
 
 In this example,
 the `Named` protocol
@@ -1935,7 +1935,7 @@ beginConcert(in: seattle)
 ```
 
 
-@Comment {
+<!--
   - test: `protocolComposition`
   
   ```swifttest
@@ -1962,7 +1962,7 @@ beginConcert(in: seattle)
   -> beginConcert(in: seattle)
   <- Hello, Seattle!
   ```
-}
+-->
 
 The `beginConcert(in:)` function takes
 a parameter of type `Location & Named`,
@@ -2003,7 +2003,7 @@ protocol HasArea {
 ```
 
 
-@Comment {
+<!--
   - test: `protocolConformance`
   
   ```swifttest
@@ -2011,7 +2011,7 @@ protocol HasArea {
         var area: Double { get }
      }
   ```
-}
+-->
 
 Here are two classes, `Circle` and `Country`,
 both of which conform to the `HasArea` protocol:
@@ -2030,7 +2030,7 @@ class Country: HasArea {
 ```
 
 
-@Comment {
+<!--
   - test: `protocolConformance`
   
   ```swifttest
@@ -2045,7 +2045,7 @@ class Country: HasArea {
         init(area: Double) { self.area = area }
      }
   ```
-}
+-->
 
 The `Circle` class implements the `area` property requirement
 as a computed property, based on a stored `radius` property.
@@ -2062,7 +2062,7 @@ class Animal {
 ```
 
 
-@Comment {
+<!--
   - test: `protocolConformance`
   
   ```swifttest
@@ -2071,7 +2071,7 @@ class Animal {
         init(legs: Int) { self.legs = legs }
      }
   ```
-}
+-->
 
 The `Circle`, `Country` and `Animal` classes don't have a shared base class.
 Nonetheless, they're all classes, and so instances of all three types
@@ -2086,7 +2086,7 @@ let objects: [AnyObject] = [
 ```
 
 
-@Comment {
+<!--
   - test: `protocolConformance`
   
   ```swifttest
@@ -2096,7 +2096,7 @@ let objects: [AnyObject] = [
         Animal(legs: 4)
      ]
   ```
-}
+-->
 
 The `objects` array is initialized with an array literal containing
 a `Circle` instance with a radius of 2 units;
@@ -2122,7 +2122,7 @@ for object in objects {
 ```
 
 
-@Comment {
+<!--
   - test: `protocolConformance`
   
   ```swifttest
@@ -2137,7 +2137,7 @@ for object in objects {
   </ Area is 243610.0
   </ Something that doesn't have an area
   ```
-}
+-->
 
 Whenever an object in the array conforms to the `HasArea` protocol,
 the optional value returned by the `as?` operator is unwrapped with optional binding
@@ -2151,7 +2151,7 @@ However, at the point that they're stored in the `objectWithArea` constant,
 they're only known to be of type `HasArea`,
 and so only their `area` property can be accessed.
 
-@Comment {
+<!--
   TODO: This is an *extremely* contrived example.
   Also, it's not particularly useful to be able to get the area of these two objects,
   because there's no shared unit system.
@@ -2160,27 +2160,27 @@ and so only their `area` property can be accessed.
   which make the example far less focused than I'd like.
   The problem is, I can't use strings within an @objc protocol
   without also having to import Foundation, so it's numbers or bust, I'm afraid.
-}
+-->
 
-@Comment {
+<!--
   TODO: Since the restrictions on @objc of the previous TODO are now lifted,
   Should the previous examples be revisited?
-}
+-->
 
 ## Optional Protocol Requirements
 
-@Comment {
+<!--
   TODO: split this section into several subsections as per [Contributor 7746]'s feedback,
   and cover the missing alternative approaches that he mentioned.
-}
+-->
 
-@Comment {
+<!--
   TODO: you can specify optional subscripts,
   and the way you check for them / work with them is a bit esoteric.
   You have to try and access a value from the subscript,
   and see if the value you get back (which will be an optional)
   has a value or is nil.
-}
+-->
 
 You can define *optional requirements* for protocols.
 These requirements don't have to be implemented by types that conform to the protocol.
@@ -2223,7 +2223,7 @@ which has two optional requirements:
 ```
 
 
-@Comment {
+<!--
   - test: `protocolConformance`
   
   ```swifttest
@@ -2233,7 +2233,7 @@ which has two optional requirements:
         @objc optional var fixedIncrement: Int { get }
      }
   ```
-}
+-->
 
 The `CounterDataSource` protocol defines
 an optional method requirement called `increment(forCount:)`
@@ -2265,7 +2265,7 @@ class Counter {
 ```
 
 
-@Comment {
+<!--
   - test: `protocolConformance`
   
   ```swifttest
@@ -2281,7 +2281,7 @@ class Counter {
         }
      }
   ```
-}
+-->
 
 The `Counter` class stores its current value in a variable property called `count`.
 The `Counter` class also defines a method called `increment`,
@@ -2345,7 +2345,7 @@ class ThreeSource: NSObject, CounterDataSource {
 ```
 
 
-@Comment {
+<!--
   - test: `protocolConformance`
   
   ```swifttest
@@ -2353,7 +2353,7 @@ class ThreeSource: NSObject, CounterDataSource {
         let fixedIncrement = 3
      }
   ```
-}
+-->
 
 You can use an instance of `ThreeSource` as the data source for a new `Counter` instance:
 
@@ -2371,7 +2371,7 @@ for _ in 1...4 {
 ```
 
 
-@Comment {
+<!--
   - test: `protocolConformance`
   
   ```swifttest
@@ -2386,7 +2386,7 @@ for _ in 1...4 {
   </ 9
   </ 12
   ```
-}
+-->
 
 The code above creates a new `Counter` instance;
 sets its data source to be a new `ThreeSource` instance;
@@ -2413,7 +2413,7 @@ class TowardsZeroSource: NSObject, CounterDataSource {
 ```
 
 
-@Comment {
+<!--
   - test: `protocolConformance`
   
   ```swifttest
@@ -2429,7 +2429,7 @@ class TowardsZeroSource: NSObject, CounterDataSource {
         }
      }
   ```
-}
+-->
 
 The `TowardsZeroSource` class implements
 the optional `increment(forCount:)` method from the `CounterDataSource` protocol
@@ -2456,7 +2456,7 @@ for _ in 1...5 {
 ```
 
 
-@Comment {
+<!--
   - test: `protocolConformance`
   
   ```swifttest
@@ -2472,7 +2472,7 @@ for _ in 1...5 {
   </ 0
   </ 0
   ```
-}
+-->
 
 ## Protocol Extensions
 
@@ -2496,7 +2496,7 @@ extension RandomNumberGenerator {
 ```
 
 
-@Comment {
+<!--
   - test: `protocols`
   
   ```swifttest
@@ -2506,7 +2506,7 @@ extension RandomNumberGenerator {
         }
      }
   ```
-}
+-->
 
 By creating an extension on the protocol,
 all conforming types automatically gain this method implementation
@@ -2521,7 +2521,7 @@ print("And here's a random Boolean: \(generator.randomBool())")
 ```
 
 
-@Comment {
+<!--
   - test: `protocols`
   
   ```swifttest
@@ -2533,12 +2533,12 @@ print("And here's a random Boolean: \(generator.randomBool())")
   <- And here's a random Boolean: true
   >> }
   ```
-}
+-->
 
-@Comment {
+<!--
   The extra scope in the above test code allows this 'generator' variable to shadow
   the variable that already exists from a previous testcode block.
-}
+-->
 
 Protocol extensions can add implementations to conforming types
 but can't make a protocol extend or inherit from another protocol.
@@ -2570,7 +2570,7 @@ extension PrettyTextRepresentable  {
 ```
 
 
-@Comment {
+<!--
   - test: `protocols`
   
   ```swifttest
@@ -2580,36 +2580,36 @@ extension PrettyTextRepresentable  {
         }
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   TODO <rdar://problem/32211512> TSPL: Explain when you can/can't override a protocol default implementation
-}
+-->
 
-@Comment {
+<!--
   If something is a protocol requirement,
   types that conform to the protocol can override the default implementation.
-}
+-->
 
-@Comment {
+<!--
   If something isn't a requirement,
   you get wonky behavior when you try to override the default implementation.
-}
+-->
 
-@Comment {
+<!--
   If the static type is the conforming type,
   your override is used.
-}
+-->
 
-@Comment {
+<!--
   If the static type is the protocol type,
   the default implementation is used.
-}
+-->
 
-@Comment {
+<!--
   You can't write ``final`` on a default implementation
   to prevent someone from overriding it in a conforming type.
-}
+-->
 
 ### Adding Constraints to Protocol Extensions
 
@@ -2642,7 +2642,7 @@ extension Collection where Element: Equatable {
 ```
 
 
-@Comment {
+<!--
   - test: `protocols`
   
   ```swifttest
@@ -2657,7 +2657,7 @@ extension Collection where Element: Equatable {
          }
      }
   ```
-}
+-->
 
 The `allEqual()` method returns `true`
 only if all the elements in the collection are equal.
@@ -2672,14 +2672,14 @@ let differentNumbers = [100, 100, 200, 100, 200]
 ```
 
 
-@Comment {
+<!--
   - test: `protocols`
   
   ```swifttest
   -> let equalNumbers = [100, 100, 100, 100, 100]
   -> let differentNumbers = [100, 100, 200, 100, 200]
   ```
-}
+-->
 
 Because arrays conform to `Collection`
 and integers conform to `Equatable`,
@@ -2693,7 +2693,7 @@ print(differentNumbers.allEqual())
 ```
 
 
-@Comment {
+<!--
   - test: `protocols`
   
   ```swifttest
@@ -2702,19 +2702,19 @@ print(differentNumbers.allEqual())
   -> print(differentNumbers.allEqual())
   <- false
   ```
-}
+-->
 
 > Note: If a conforming type satisfies the requirements for multiple constrained extensions
 > that provide implementations for the same method or property,
 > Swift uses the implementation corresponding to the most specialized constraints.
 > 
-> @Comment {
+> <!--
   > TODO: It would be great to pull this out of a note,
   > but we should wait until we have a better narrative that shows how this
   > works with some examples.
-> }
+> -->
 
-@Comment {
+<!--
   TODO: Other things to be included
   ---------------------------------
   Class-only protocols
@@ -2726,10 +2726,10 @@ print(differentNumbers.allEqual())
   Protocols can't be nested, but nested types can implement protocols
   Protocol requirements can be marked as @unavailable, but this currently only works if they're also marked as @objc.
   Checking for (and calling) optional implementations via optional binding and closures
-}
+-->
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -2737,4 +2737,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Protocols.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Protocols.md
@@ -2707,12 +2707,12 @@ print(differentNumbers.allEqual())
 > Note: If a conforming type satisfies the requirements for multiple constrained extensions
 > that provide implementations for the same method or property,
 > Swift uses the implementation corresponding to the most specialized constraints.
-> 
-> <!--
-  > TODO: It would be great to pull this out of a note,
-  > but we should wait until we have a better narrative that shows how this
-  > works with some examples.
-> -->
+
+<!--
+  TODO: It would be great to pull this out of a note,
+  but we should wait until we have a better narrative that shows how this
+  works with some examples.
+-->
 
 <!--
   TODO: Other things to be included

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/StringsAndCharacters.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/StringsAndCharacters.md
@@ -45,13 +45,13 @@ let someString = "Some string literal value"
 ```
 
 
-@Comment {
+<!--
   - test: `stringLiterals`
   
   ```swifttest
   -> let someString = "Some string literal value"
   ```
-}
+-->
 
 Note that Swift infers a type of `String` for the `someString` constant
 because it's initialized with a string literal value.
@@ -63,10 +63,10 @@ use a multiline string literal ---
 a sequence of characters
 surrounded by three double quotation marks:
 
-@Comment {
+<!--
   Quote comes from "Alice's Adventures in Wonderland",
   which has been public domain as of 1907.
-}
+-->
 
 ```swift
 let quotation = """
@@ -79,7 +79,7 @@ till you come to the end; then stop."
 ```
 
 
-@Comment {
+<!--
   - test: `multiline-string-literals`
   
   ```swifttest
@@ -94,7 +94,7 @@ till you come to the end; then stop."
   >> print(newlines.count)
   << 4
   ```
-}
+-->
 
 A multiline string literal includes all of the lines between
 its opening and closing quotation marks.
@@ -111,7 +111,7 @@ These are the same.
 ```
 
 
-@Comment {
+<!--
   - test: `multiline-string-literals`
   
   ```swifttest
@@ -122,7 +122,7 @@ These are the same.
   >> print(singleLineString == multilineString)
   << true
   ```
-}
+-->
 
 When your source code includes a line break
 inside of a multiline string literal,
@@ -143,7 +143,7 @@ till you come to the end; then stop."
 ```
 
 
-@Comment {
+<!--
   - test: `multiline-string-literals`
   
   ```swifttest
@@ -158,7 +158,7 @@ till you come to the end; then stop."
   >> print(softNewlines.count)
   << 2
   ```
-}
+-->
 
 To make a multiline string literal that begins or ends with a line feed,
 write a blank line as the first or last line.
@@ -174,7 +174,7 @@ It also ends with a line break.
 ```
 
 
-@Comment {
+<!--
   - test: `multiline-string-literals`
   
   ```swifttest
@@ -185,11 +185,11 @@ It also ends with a line break.
   
      """
   ```
-}
+-->
 
-@Comment {
+<!--
   These are well-fed lines!
-}
+-->
 
 A multiline string can be indented to match the surrounding code.
 The whitespace before the closing quotation marks (`"""`)
@@ -201,14 +201,14 @@ that whitespace *is* included.
 ![](multilineStringWhitespace)
 
 
-@Comment {
+<!--
   Using an image here is a little clearer,
   since it can call out which spaces "count",
   but it also works around
   <rdar://problem/32463195> Multiline string literals lose (meaningful) indentation
-}
+-->
 
-@Comment {
+<!--
   - test: `multiline-string-literal-whitespace`
   
   ```swifttest
@@ -218,7 +218,7 @@ that whitespace *is* included.
          This line doesn't begin with whitespace.
          """
   ```
-}
+-->
 
 In the example above,
 even though the entire multiline string literal is indented,
@@ -237,7 +237,7 @@ String literals can include the following special characters:
   where *n* is a 1--8 digit hexadecimal number
   (Unicode is discussed in <doc:StringsAndCharacters#Unicode> below)
 
-@Comment {
+<!--
   - test: `stringLiteralUnicodeScalar`
   
   ```swifttest
@@ -253,7 +253,7 @@ String literals can include the following special characters:
   !! _ = "\u{110000}"
   !!      ^
   ```
-}
+-->
 
 The code below shows four examples of these special characters.
 The `wiseWords` constant contains two escaped double quotation marks.
@@ -269,7 +269,7 @@ let sparklingHeart = "\u{1F496}" // 💖, Unicode scalar U+1F496
 ```
 
 
-@Comment {
+<!--
   - test: `specialCharacters`
   
   ```swifttest
@@ -283,7 +283,7 @@ let sparklingHeart = "\u{1F496}" // 💖, Unicode scalar U+1F496
   -> let sparklingHeart = "\u{1F496}" // 💖, Unicode scalar U+1F496
   >> assert(sparklingHeart == "💖")
   ```
-}
+-->
 
 Because multiline string literals use three double quotation marks instead of just one,
 you can include a double quotation mark (`"`) inside of a multiline string literal
@@ -300,7 +300,7 @@ Escaping all three quotation marks \"\"\"
 ```
 
 
-@Comment {
+<!--
   - test: `multiline-string-literals`
   
   ```swifttest
@@ -312,7 +312,7 @@ Escaping all three quotation marks \"\"\"
   << Escaping the first quotation mark """
   << Escaping all three quotation marks """
   ```
-}
+-->
 
 ### Extended String Delimiters
 
@@ -344,7 +344,7 @@ Here are three more double quotes: """
 ```
 
 
-@Comment {
+<!--
   - test: `extended-string-delimiters`
   
   ```swifttest
@@ -354,7 +354,7 @@ Here are three more double quotes: """
   >> print(threeMoreDoubleQuotationMarks)
   << Here are three more double quotes: """
   ```
-}
+-->
 
 ## Initializing an Empty String
 
@@ -370,7 +370,7 @@ var anotherEmptyString = String()  // initializer syntax
 ```
 
 
-@Comment {
+<!--
   - test: `emptyStrings`
   
   ```swifttest
@@ -379,7 +379,7 @@ var anotherEmptyString = String()  // initializer syntax
   // these two strings are both empty, and are equivalent to each other
   >> assert(emptyString == anotherEmptyString)
   ```
-}
+-->
 
 Find out whether a `String` value is empty
 by checking its Boolean `isEmpty` property:
@@ -392,7 +392,7 @@ if emptyString.isEmpty {
 ```
 
 
-@Comment {
+<!--
   - test: `emptyStrings`
   
   ```swifttest
@@ -401,11 +401,11 @@ if emptyString.isEmpty {
      }
   <- Nothing to see here
   ```
-}
+-->
 
-@Comment {
+<!--
   TODO: init(size, character)
-}
+-->
 
 ## String Mutability
 
@@ -424,7 +424,7 @@ constantString += " and another Highlander"
 ```
 
 
-@Comment {
+<!--
   - test: `stringMutability`
   
   ```swifttest
@@ -443,9 +443,9 @@ constantString += " and another Highlander"
   !! var
   // this reports a compile-time error - a constant string cannot be modified
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `stringMutability-ok`
   
   ```swifttest
@@ -454,7 +454,7 @@ constantString += " and another Highlander"
   /> variableString is now \"\(variableString)\"
   </ variableString is now "Horse and carriage"
   ```
-}
+-->
 
 > Note: This approach is different from string mutation in Objective-C and Cocoa,
 > where you choose between two classes (`NSString` and `NSMutableString`)
@@ -499,7 +499,7 @@ for character in "Dog!🐶" {
 ```
 
 
-@Comment {
+<!--
   - test: `characters`
   
   ```swifttest
@@ -512,7 +512,7 @@ for character in "Dog!🐶" {
   </ !
   </ 🐶
   ```
-}
+-->
 
 The `for`-`in` loop is described in <doc:ControlFlow#For-In-Loops>.
 
@@ -524,13 +524,13 @@ let exclamationMark: Character = "!"
 ```
 
 
-@Comment {
+<!--
   - test: `characters`
   
   ```swifttest
   -> let exclamationMark: Character = "!"
   ```
-}
+-->
 
 `String` values can be constructed by passing an array of `Character` values
 as an argument to its initializer:
@@ -543,7 +543,7 @@ print(catString)
 ```
 
 
-@Comment {
+<!--
   - test: `characters`
   
   ```swifttest
@@ -552,7 +552,7 @@ print(catString)
   -> print(catString)
   <- Cat!🐱
   ```
-}
+-->
 
 ## Concatenating Strings and Characters
 
@@ -567,7 +567,7 @@ var welcome = string1 + string2
 ```
 
 
-@Comment {
+<!--
   - test: `concatenation`
   
   ```swifttest
@@ -577,7 +577,7 @@ var welcome = string1 + string2
   /> welcome now equals \"\(welcome)\"
   </ welcome now equals "hello there"
   ```
-}
+-->
 
 You can also append a `String` value to an existing `String` variable
 with the addition assignment operator (`+=`):
@@ -589,7 +589,7 @@ instruction += string2
 ```
 
 
-@Comment {
+<!--
   - test: `concatenation`
   
   ```swifttest
@@ -598,7 +598,7 @@ instruction += string2
   /> instruction now equals \"\(instruction)\"
   </ instruction now equals "look over there"
   ```
-}
+-->
 
 You can append a `Character` value to a `String` variable
 with the `String` type's `append()` method:
@@ -610,7 +610,7 @@ welcome.append(exclamationMark)
 ```
 
 
-@Comment {
+<!--
   - test: `concatenation`
   
   ```swifttest
@@ -619,7 +619,7 @@ welcome.append(exclamationMark)
   /> welcome now equals \"\(welcome)\"
   </ welcome now equals "hello there!"
   ```
-}
+-->
 
 > Note: You can't append a `String` or `Character` to an existing `Character` variable,
 > because a `Character` value must contain a single character only.
@@ -656,7 +656,7 @@ print(goodStart + end)
 ```
 
 
-@Comment {
+<!--
   - test: `concatenate-multiline-string-literals`
   
   ```swifttest
@@ -683,7 +683,7 @@ print(goodStart + end)
   </ two
   </ three
   ```
-}
+-->
 
 In the code above,
 concatenating `badStart` with `end`
@@ -715,7 +715,7 @@ let message = "\(multiplier) times 2.5 is \(Double(multiplier) * 2.5)"
 ```
 
 
-@Comment {
+<!--
   - test: `stringInterpolation`
   
   ```swifttest
@@ -724,7 +724,7 @@ let message = "\(multiplier) times 2.5 is \(Double(multiplier) * 2.5)"
   /> message is \"\(message)\"
   </ message is "3 times 2.5 is 7.5"
   ```
-}
+-->
 
 In the example above,
 the value of `multiplier` is inserted into a string literal as `\(multiplier)`.
@@ -747,14 +747,14 @@ print(#"Write an interpolated string in Swift using \(multiplier)."#)
 ```
 
 
-@Comment {
+<!--
   - test: `stringInterpolation`
   
   ```swifttest
   -> print(#"Write an interpolated string in Swift using \(multiplier)."#)
   <- Write an interpolated string in Swift using \(multiplier).
   ```
-}
+-->
 
 To use string interpolation
 inside a string that uses extended delimiters,
@@ -768,14 +768,14 @@ print(#"6 times 7 is \#(6 * 7)."#)
 ```
 
 
-@Comment {
+<!--
   - test: `stringInterpolation`
   
   ```swifttest
   -> print(#"6 times 7 is \#(6 * 7)."#)
   <- 6 times 7 is 42.
   ```
-}
+-->
 
 > Note: The expressions you write inside parentheses within an interpolated string
 > can't contain an unescaped backslash (`\`), a carriage return, or a line feed.
@@ -833,7 +833,7 @@ let combinedEAcute: Character = "\u{65}\u{301}"          // e followed by ́
 ```
 
 
-@Comment {
+<!--
   - test: `graphemeClusters1`
   
   ```swifttest
@@ -845,7 +845,7 @@ let combinedEAcute: Character = "\u{65}\u{301}"          // e followed by ́
   </ eAcute is é, combinedEAcute is é
   >> assert(eAcute == combinedEAcute)
   ```
-}
+-->
 
 Extended grapheme clusters are a flexible way to represent
 many complex script characters as a single `Character` value.
@@ -860,7 +860,7 @@ let decomposed: Character = "\u{1112}\u{1161}\u{11AB}"   // ᄒ, ᅡ, ᆫ
 ```
 
 
-@Comment {
+<!--
   - test: `graphemeClusters2`
   
   ```swifttest
@@ -871,7 +871,7 @@ let decomposed: Character = "\u{1112}\u{1161}\u{11AB}"   // ᄒ, ᅡ, ᆫ
   /> precomposed is \(precomposed), decomposed is \(decomposed)
   </ precomposed is 한, decomposed is 한
   ```
-}
+-->
 
 Extended grapheme clusters enable
 scalars for enclosing marks (such as `COMBINING ENCLOSING CIRCLE`, or `U+20DD`)
@@ -883,7 +883,7 @@ let enclosedEAcute: Character = "\u{E9}\u{20DD}"
 ```
 
 
-@Comment {
+<!--
   - test: `graphemeClusters3`
   
   ```swifttest
@@ -892,7 +892,7 @@ let enclosedEAcute: Character = "\u{E9}\u{20DD}"
   /> enclosedEAcute is \(enclosedEAcute)
   </ enclosedEAcute is é⃝
   ```
-}
+-->
 
 Unicode scalars for regional indicator symbols
 can be combined in pairs to make a single `Character` value,
@@ -905,7 +905,7 @@ let regionalIndicatorForUS: Character = "\u{1F1FA}\u{1F1F8}"
 ```
 
 
-@Comment {
+<!--
   - test: `graphemeClusters4`
   
   ```swifttest
@@ -914,7 +914,7 @@ let regionalIndicatorForUS: Character = "\u{1F1FA}\u{1F1F8}"
   /> regionalIndicatorForUS is \(regionalIndicatorForUS)
   </ regionalIndicatorForUS is 🇺🇸
   ```
-}
+-->
 
 ## Counting Characters
 
@@ -928,7 +928,7 @@ print("unusualMenagerie has \(unusualMenagerie.count) characters")
 ```
 
 
-@Comment {
+<!--
   - test: `characterCount`
   
   ```swifttest
@@ -936,7 +936,7 @@ print("unusualMenagerie has \(unusualMenagerie.count) characters")
   -> print("unusualMenagerie has \(unusualMenagerie.count) characters")
   <- unusualMenagerie has 40 characters
   ```
-}
+-->
 
 Note that Swift's use of extended grapheme clusters for `Character` values
 means that string concatenation and modification may not always affect
@@ -959,7 +959,7 @@ print("the number of characters in \(word) is \(word.count)")
 ```
 
 
-@Comment {
+<!--
   - test: `characterCount`
   
   ```swifttest
@@ -972,7 +972,7 @@ print("the number of characters in \(word) is \(word.count)")
   -> print("the number of characters in \(word) is \(word.count)")
   <- the number of characters in café is 4
   ```
-}
+-->
 
 > Note: Extended grapheme clusters can be composed of multiple Unicode scalars.
 > This means that different characters—
@@ -1040,7 +1040,7 @@ greeting[index]
 ```
 
 
-@Comment {
+<!--
   - test: `stringIndex`
   
   ```swifttest
@@ -1067,7 +1067,7 @@ greeting[index]
   << a
   // a
   ```
-}
+-->
 
 Attempting to access an index outside of a string's range
 or a `Character` at an index outside of a string's range
@@ -1079,12 +1079,12 @@ greeting.index(after: greeting.endIndex) // Error
 ```
 
 
-@Comment {
+<!--
   The code above triggers an assertion failure in the stdlib, causing a stack
   trace, which makes it a poor candidate for being tested.
-}
+-->
 
-@Comment {
+<!--
   - test: `emptyStringIndices`
   
   ```swifttest
@@ -1093,7 +1093,7 @@ greeting.index(after: greeting.endIndex) // Error
   -> emptyString.isEmpty && emptyString.startIndex == emptyString.endIndex
   -> )
   ```
-}
+-->
 
 Use the `indices` property to access all of the
 indices of individual characters in a string.
@@ -1106,7 +1106,7 @@ for index in greeting.indices {
 ```
 
 
-@Comment {
+<!--
   - test: `stringIndex`
   
   ```swifttest
@@ -1117,11 +1117,11 @@ for index in greeting.indices {
   << G u t e n   T a g !
   // Prints "G u t e n   T a g ! "
   ```
-}
+-->
 
-@Comment {
+<!--
   Workaround for rdar://26016325
-}
+-->
 
 > Note: You can use the `startIndex` and `endIndex` properties
 > and the `index(before:)`, `index(after:)`, and `index(_:offsetBy:)` methods
@@ -1146,7 +1146,7 @@ welcome.insert(contentsOf: " there", at: welcome.index(before: welcome.endIndex)
 ```
 
 
-@Comment {
+<!--
   - test: `stringInsertionAndRemoval`
   
   ```swifttest
@@ -1159,7 +1159,7 @@ welcome.insert(contentsOf: " there", at: welcome.index(before: welcome.endIndex)
   /> welcome now equals \"\(welcome)\"
   </ welcome now equals "hello there!"
   ```
-}
+-->
 
 To remove a single character from a string at a specified index,
 use the `remove(at:)` method,
@@ -1176,7 +1176,7 @@ welcome.removeSubrange(range)
 ```
 
 
-@Comment {
+<!--
   - test: `stringInsertionAndRemoval`
   
   ```swifttest
@@ -1189,11 +1189,11 @@ welcome.removeSubrange(range)
   /> welcome now equals \"\(welcome)\"
   </ welcome now equals "hello"
   ```
-}
+-->
 
-@Comment {
+<!--
   TODO: Find and Replace section, once the standard library supports finding substrings
-}
+-->
 
 > Note: You can use the `insert(_:at:)`, `insert(contentsOf:at:)`,
 > `remove(at:)`, and `removeSubrange(_:)` methods
@@ -1229,7 +1229,7 @@ let newString = String(beginning)
 ```
 
 
-@Comment {
+<!--
   - test: `string-and-substring`
   
   ```swifttest
@@ -1242,7 +1242,7 @@ let newString = String(beginning)
   // Convert the result to a String for long-term storage.
   -> let newString = String(beginning)
   ```
-}
+-->
 
 Like strings, each substring has a region of memory
 where the characters that make up the substring are stored.
@@ -1275,10 +1275,10 @@ when it's created from the substring,
 it has its own storage.
 The figure below shows these relationships:
 
-@Comment {
+<!--
   FIXME: The connection between the code and the figure
   would be clearer if the variable names appeared in the figure.
-}
+-->
 
 ![](stringSubstring)
 
@@ -1310,7 +1310,7 @@ if quotation == sameQuotation {
 ```
 
 
-@Comment {
+<!--
   - test: `stringEquality`
   
   ```swifttest
@@ -1321,7 +1321,7 @@ if quotation == sameQuotation {
      }
   <- These two strings are considered equal
   ```
-}
+-->
 
 Two `String` values (or two `Character` values) are considered equal if
 their extended grapheme clusters are *canonically equivalent*.
@@ -1329,7 +1329,7 @@ Extended grapheme clusters are canonically equivalent if they have
 the same linguistic meaning and appearance,
 even if they're composed from different Unicode scalars behind the scenes.
 
-@Comment {
+<!--
   - test: `characterComparisonUsesCanonicalEquivalence`
   
   ```swifttest
@@ -1342,9 +1342,9 @@ even if they're composed from different Unicode scalars behind the scenes.
      }
   <- equivalent, as expected
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `stringComparisonUsesCanonicalEquivalence`
   
   ```swifttest
@@ -1357,7 +1357,7 @@ even if they're composed from different Unicode scalars behind the scenes.
      }
   <- equivalent, as expected
   ```
-}
+-->
 
 For example, `LATIN SMALL LETTER E WITH ACUTE` (`U+00E9`)
 is canonically equivalent to `LATIN SMALL LETTER E` (`U+0065`)
@@ -1379,7 +1379,7 @@ if eAcuteQuestion == combinedEAcuteQuestion {
 ```
 
 
-@Comment {
+<!--
   - test: `stringEquality`
   
   ```swifttest
@@ -1394,7 +1394,7 @@ if eAcuteQuestion == combinedEAcuteQuestion {
      }
   <- These two strings are considered equal
   ```
-}
+-->
 
 Conversely, `LATIN CAPITAL LETTER A` (`U+0041`, or `"A"`),
 as used in English, is *not* equivalent to
@@ -1415,7 +1415,7 @@ if latinCapitalLetterA != cyrillicCapitalLetterA {
 ```
 
 
-@Comment {
+<!--
   - test: `stringEquality`
   
   ```swifttest
@@ -1430,15 +1430,15 @@ if latinCapitalLetterA != cyrillicCapitalLetterA {
      }
   <- These two characters aren't equivalent.
   ```
-}
+-->
 
 > Note: String and character comparisons in Swift aren't locale-sensitive.
 
-@Comment {
+<!--
   TODO: Add a cross reference to NSString.localizedCompare and
   NSString.localizedCaseInsensitiveCompare.  See also
   https://developer.apple.com/library/ios/documentation/Cocoa/Conceptual/Strings/Articles/SearchingStrings.html#//apple_ref/doc/uid/20000149-SW4
-}
+-->
 
 ### Prefix and Suffix Equality
 
@@ -1446,7 +1446,7 @@ To check whether a string has a particular string prefix or suffix,
 call the string's `hasPrefix(_:)` and `hasSuffix(_:)` methods,
 both of which take a single argument of type `String` and return a Boolean value.
 
-@Comment {
+<!--
   - test: `prefixComparisonUsesCharactersNotScalars`
   
   ```swifttest
@@ -1464,9 +1464,9 @@ both of which take a single argument of type `String` and return a Boolean value
      }
   <- Has U+0065 U+0301 prefix, as expected.
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `suffixComparisonUsesCharactersNotScalars`
   
   ```swifttest
@@ -1484,7 +1484,7 @@ both of which take a single argument of type `String` and return a Boolean value
      }
   <- Has U+0065 U+0301 suffix, as expected.
   ```
-}
+-->
 
 The examples below consider an array of strings representing
 the scene locations from the first two acts of Shakespeare's *Romeo and Juliet*:
@@ -1506,7 +1506,7 @@ let romeoAndJuliet = [
 ```
 
 
-@Comment {
+<!--
   - test: `prefixesAndSuffixes`
   
   ```swifttest
@@ -1524,7 +1524,7 @@ let romeoAndJuliet = [
         "Act 2 Scene 6: Friar Lawrence's cell"
      ]
   ```
-}
+-->
 
 You can use the `hasPrefix(_:)` method with the `romeoAndJuliet` array
 to count the number of scenes in Act 1 of the play:
@@ -1541,7 +1541,7 @@ print("There are \(act1SceneCount) scenes in Act 1")
 ```
 
 
-@Comment {
+<!--
   - test: `prefixesAndSuffixes`
   
   ```swifttest
@@ -1554,7 +1554,7 @@ print("There are \(act1SceneCount) scenes in Act 1")
   -> print("There are \(act1SceneCount) scenes in Act 1")
   <- There are 5 scenes in Act 1
   ```
-}
+-->
 
 Similarly, use the `hasSuffix(_:)` method to count the number of scenes
 that take place in or around Capulet's mansion and Friar Lawrence's cell:
@@ -1574,7 +1574,7 @@ print("\(mansionCount) mansion scenes; \(cellCount) cell scenes")
 ```
 
 
-@Comment {
+<!--
   - test: `prefixesAndSuffixes`
   
   ```swifttest
@@ -1590,7 +1590,7 @@ print("\(mansionCount) mansion scenes; \(cellCount) cell scenes")
   -> print("\(mansionCount) mansion scenes; \(cellCount) cell scenes")
   <- 6 mansion scenes; 2 cell scenes
   ```
-}
+-->
 
 > Note: The `hasPrefix(_:)` and `hasSuffix(_:)` methods
 > perform a character-by-character canonical equivalence comparison between
@@ -1631,13 +1631,13 @@ let dogString = "Dog‼🐶"
 ```
 
 
-@Comment {
+<!--
   - test: `unicodeRepresentations`
   
   ```swifttest
   -> let dogString = "Dog‼🐶"
   ```
-}
+-->
 
 ### UTF-8 Representation
 
@@ -1659,7 +1659,7 @@ print("")
 ```
 
 
-@Comment {
+<!--
   - test: `unicodeRepresentations`
   
   ```swifttest
@@ -1670,11 +1670,11 @@ print("")
   << 68 111 103 226 128 188 240 159 144 182
   // Prints "68 111 103 226 128 188 240 159 144 182 "
   ```
-}
+-->
 
-@Comment {
+<!--
   Workaround for rdar://26016325
-}
+-->
 
 In the example above, the first three decimal `codeUnit` values
 (`68`, `111`, `103`)
@@ -1686,14 +1686,14 @@ are a three-byte UTF-8 representation of the `DOUBLE EXCLAMATION MARK` character
 The last four `codeUnit` values (`240`, `159`, `144`, `182`)
 are a four-byte UTF-8 representation of the `DOG FACE` character.
 
-@Comment {
+<!--
   TODO: contiguousUTF8()
-}
+-->
 
-@Comment {
+<!--
   TODO: nulTerminatedUTF8()
   (which returns a NativeArray, but handwave this for now)
-}
+-->
 
 ### UTF-16 Representation
 
@@ -1715,7 +1715,7 @@ print("")
 ```
 
 
-@Comment {
+<!--
   - test: `unicodeRepresentations`
   
   ```swifttest
@@ -1726,11 +1726,11 @@ print("")
   << 68 111 103 8252 55357 56374
   // Prints "68 111 103 8252 55357 56374 "
   ```
-}
+-->
 
-@Comment {
+<!--
   Workaround for rdar://26016325
-}
+-->
 
 Again, the first three `codeUnit` values
 (`68`, `111`, `103`)
@@ -1771,7 +1771,7 @@ print("")
 ```
 
 
-@Comment {
+<!--
   - test: `unicodeRepresentations`
   
   ```swifttest
@@ -1782,11 +1782,11 @@ print("")
   << 68 111 103 8252 128054
   // Prints "68 111 103 8252 128054 "
   ```
-}
+-->
 
-@Comment {
+<!--
   Workaround for rdar://26016325
-}
+-->
 
 The `value` properties for the first three `UnicodeScalar` values
 (`68`, `111`, `103`)
@@ -1817,7 +1817,7 @@ for scalar in dogString.unicodeScalars {
 ```
 
 
-@Comment {
+<!--
   - test: `unicodeRepresentations`
   
   ```swifttest
@@ -1830,10 +1830,10 @@ for scalar in dogString.unicodeScalars {
   </ ‼
   </ 🐶
   ```
-}
+-->
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -1841,4 +1841,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Subscripts.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Subscripts.md
@@ -16,10 +16,10 @@ Subscripts aren't limited to a single dimension,
 and you can define subscripts with multiple input parameters
 to suit your custom type's needs.
 
-@Comment {
+<!--
   TODO: this chapter should provide an example of subscripting an enumeration,
   as per Joe Groff's example from rdar://16555559.
-}
+-->
 
 ## Subscript Syntax
 
@@ -45,7 +45,7 @@ subscript(index: Int) -> Int {
 ```
 
 
-@Comment {
+<!--
   - test: `subscriptSyntax`
   
   ```swifttest
@@ -61,7 +61,7 @@ subscript(index: Int) -> Int {
      }
   >> }
   ```
-}
+-->
 
 The type of `newValue` is the same as the return value of the subscript.
 As with computed properties, you can choose not to specify
@@ -80,7 +80,7 @@ subscript(index: Int) -> Int {
 ```
 
 
-@Comment {
+<!--
   - test: `subscriptSyntax`
   
   ```swifttest
@@ -91,7 +91,7 @@ subscript(index: Int) -> Int {
      }
   >> }
   ```
-}
+-->
 
 Here's an example of a read-only subscript implementation,
 which defines a `TimesTable` structure to represent an *n*-times-table of integers:
@@ -109,7 +109,7 @@ print("six times three is \(threeTimesTable[6])")
 ```
 
 
-@Comment {
+<!--
   - test: `timesTable`
   
   ```swifttest
@@ -123,7 +123,7 @@ print("six times three is \(threeTimesTable[6])")
   -> print("six times three is \(threeTimesTable[6])")
   <- six times three is 18
   ```
-}
+-->
 
 In this example, a new instance of `TimesTable` is created
 to represent the three-times-table.
@@ -159,14 +159,14 @@ numberOfLegs["bird"] = 2
 ```
 
 
-@Comment {
+<!--
   - test: `dictionarySubscript`
   
   ```swifttest
   -> var numberOfLegs = ["spider": 8, "ant": 6, "cat": 4]
   -> numberOfLegs["bird"] = 2
   ```
-}
+-->
 
 The example above defines a variable called `numberOfLegs`
 and initializes it with a dictionary literal containing three key-value pairs.
@@ -201,7 +201,7 @@ and <doc:Functions#Default-Parameter-Values>.
 However, unlike functions,
 subscripts can't use in-out parameters.
 
-@Comment {
+<!--
   - test: `subscripts-can-have-default-arguments`
   
   ```swifttest
@@ -214,7 +214,7 @@ subscripts can't use in-out parameters.
   >> print(s[0])
   << 100
   ```
-}
+-->
 
 A class or structure can provide as many subscript implementations as it needs,
 and the appropriate subscript to be used will be inferred based on
@@ -255,7 +255,7 @@ struct Matrix {
 ```
 
 
-@Comment {
+<!--
   - test: `matrixSubscript, matrixSubscriptAssert`
   
   ```swifttest
@@ -282,7 +282,7 @@ struct Matrix {
         }
      }
   ```
-}
+-->
 
 `Matrix` provides an initializer that takes two parameters called `rows` and `columns`,
 and creates an array that's large enough to store `rows * columns` values of type `Double`.
@@ -300,14 +300,14 @@ var matrix = Matrix(rows: 2, columns: 2)
 ```
 
 
-@Comment {
+<!--
   - test: `matrixSubscript, matrixSubscriptAssert`
   
   ```swifttest
   -> var matrix = Matrix(rows: 2, columns: 2)
   >> assert(matrix.grid == [0.0, 0.0, 0.0, 0.0])
   ```
-}
+-->
 
 The example above creates a new `Matrix` instance with two rows and two columns.
 The `grid` array for this `Matrix` instance
@@ -326,7 +326,7 @@ matrix[1, 0] = 3.2
 ```
 
 
-@Comment {
+<!--
   - test: `matrixSubscript, matrixSubscriptAssert`
   
   ```swifttest
@@ -337,7 +337,7 @@ matrix[1, 0] = 3.2
   >> print(matrix[1, 0])
   << 3.2
   ```
-}
+-->
 
 These two statements call the subscript's setter to set
 a value of `1.5` in the top right position of the matrix
@@ -362,7 +362,7 @@ func indexIsValid(row: Int, column: Int) -> Bool {
 ```
 
 
-@Comment {
+<!--
   - test: `matrixSubscript`
   
   ```swifttest
@@ -372,7 +372,7 @@ func indexIsValid(row: Int, column: Int) -> Bool {
         return row >= 0 && row < rows && column >= 0 && column < columns
      }
   ```
-}
+-->
 
 An assertion is triggered if you try to access a subscript
 that's outside of the matrix bounds:
@@ -383,7 +383,7 @@ let someValue = matrix[2, 2]
 ```
 
 
-@Comment {
+<!--
   - test: `matrixSubscriptAssert`
   
   ```swifttest
@@ -391,7 +391,7 @@ let someValue = matrix[2, 2]
   xx assert
   // This triggers an assert, because [2, 2] is outside of the matrix bounds.
   ```
-}
+-->
 
 ## Type Subscripts
 
@@ -417,7 +417,7 @@ print(mars)
 ```
 
 
-@Comment {
+<!--
   - test: `static-subscript`
   
   ```swifttest
@@ -432,10 +432,10 @@ print(mars)
   -> print(mars)
   << mars
   ```
-}
+-->
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -443,4 +443,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/TheBasics.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/TheBasics.md
@@ -65,14 +65,14 @@ var currentLoginAttempt = 0
 ```
 
 
-@Comment {
+<!--
   - test: `constantsAndVariables`
   
   ```swifttest
   -> let maximumNumberOfLoginAttempts = 10
   -> var currentLoginAttempt = 0
   ```
-}
+-->
 
 This code can be read as:
 
@@ -95,7 +95,7 @@ var x = 0.0, y = 0.0, z = 0.0
 ```
 
 
-@Comment {
+<!--
   - test: `multipleDeclarations`
   
   ```swifttest
@@ -103,7 +103,7 @@ var x = 0.0, y = 0.0, z = 0.0
   >> print(x, y, z)
   << 0.0 0.0 0.0
   ```
-}
+-->
 
 > Note: If a stored value in your code won't change,
 > always declare it as a constant with the `let` keyword.
@@ -124,13 +124,13 @@ var welcomeMessage: String
 ```
 
 
-@Comment {
+<!--
   - test: `typeAnnotations`
   
   ```swifttest
   -> var welcomeMessage: String
   ```
-}
+-->
 
 The colon in the declaration means “…of type…,”
 so the code above can be read as:
@@ -147,7 +147,7 @@ welcomeMessage = "Hello"
 ```
 
 
-@Comment {
+<!--
   - test: `typeAnnotations`
   
   ```swifttest
@@ -155,7 +155,7 @@ welcomeMessage = "Hello"
   >> print(welcomeMessage)
   << Hello
   ```
-}
+-->
 
 You can define multiple related variables of the same type on a single line,
 separated by commas, with a single type annotation after the final variable name:
@@ -165,13 +165,13 @@ var red, green, blue: Double
 ```
 
 
-@Comment {
+<!--
   - test: `typeAnnotations`
   
   ```swifttest
   -> var red, green, blue: Double
   ```
-}
+-->
 
 > Note: It's rare that you need to write type annotations in practice.
 > If you provide an initial value for a constant or variable at the point that it's defined,
@@ -193,7 +193,7 @@ let 🐶🐮 = "dogcow"
 ```
 
 
-@Comment {
+<!--
   - test: `constantsAndVariables`
   
   ```swifttest
@@ -201,7 +201,7 @@ let 🐶🐮 = "dogcow"
   -> let 你好 = "你好世界"
   -> let 🐶🐮 = "dogcow"
   ```
-}
+-->
 
 Constant and variable names can't contain
 whitespace characters, mathematical symbols, arrows, private-use Unicode scalar values,
@@ -230,7 +230,7 @@ friendlyWelcome = "Bonjour!"
 ```
 
 
-@Comment {
+<!--
   - test: `constantsAndVariables`
   
   ```swifttest
@@ -239,7 +239,7 @@ friendlyWelcome = "Bonjour!"
   /> friendlyWelcome is now \"\(friendlyWelcome)\"
   </ friendlyWelcome is now "Bonjour!"
   ```
-}
+-->
 
 Unlike a variable, the value of a constant can't be changed after it's set.
 Attempting to do so is reported as an error when your code is compiled:
@@ -251,7 +251,7 @@ languageName = "Swift++"
 ```
 
 
-@Comment {
+<!--
   - test: `constantsAndVariables_err`
   
   ```swifttest
@@ -266,7 +266,7 @@ languageName = "Swift++"
   !! ^~~
   !! var
   ```
-}
+-->
 
 ### Printing Constants and Variables
 
@@ -278,14 +278,14 @@ print(friendlyWelcome)
 ```
 
 
-@Comment {
+<!--
   - test: `constantsAndVariables`
   
   ```swifttest
   -> print(friendlyWelcome)
   <- Bonjour!
   ```
-}
+-->
 
 The `print(_:separator:terminator:)` function
 is a global function that prints one or more values
@@ -301,7 +301,7 @@ pass an empty string as the terminator --- for example,
 For information about parameters with default values,
 see <doc:Functions#Default-Parameter-Values>.
 
-@Comment {
+<!--
   - test: `printingWithoutNewline`
   
   ```swifttest
@@ -310,17 +310,17 @@ see <doc:Functions#Default-Parameter-Values>.
   -> print(someValue)
   << 1010
   ```
-}
+-->
 
-@Comment {
+<!--
   QUESTION: have I referred to Xcode's console correctly here?
   Should I mention other output streams, such as the REPL / playgrounds?
-}
+-->
 
-@Comment {
+<!--
   NOTE: this is a deliberately simplistic description of what you can do with print().
   It will be expanded later on.
-}
+-->
 
 Swift uses *string interpolation* to include the name of a constant or variable
 as a placeholder in a longer string,
@@ -333,14 +333,14 @@ print("The current value of friendlyWelcome is \(friendlyWelcome)")
 ```
 
 
-@Comment {
+<!--
   - test: `constantsAndVariables`
   
   ```swifttest
   -> print("The current value of friendlyWelcome is \(friendlyWelcome)")
   <- The current value of friendlyWelcome is Bonjour!
   ```
-}
+-->
 
 > Note: All options you can use with string interpolation
 > are described in <doc:StringsAndCharacters#String-Interpolation>.
@@ -359,13 +359,13 @@ Single-line comments begin with two forward-slashes (`//`):
 ```
 
 
-@Comment {
+<!--
   - test: `comments`
   
   ```swifttest
   -> // This is a comment.
   ```
-}
+-->
 
 Multiline comments start with a forward-slash followed by an asterisk (`/*`)
 and end with an asterisk followed by a forward-slash (`*/`):
@@ -376,14 +376,14 @@ but is written over multiple lines. */
 ```
 
 
-@Comment {
+<!--
   - test: `comments`
   
   ```swifttest
   -> /* This is also a comment
      but is written over multiple lines. */
   ```
-}
+-->
 
 Unlike multiline comments in C,
 multiline comments in Swift can be nested inside other multiline comments.
@@ -398,7 +398,7 @@ This is the end of the first multiline comment. */
 ```
 
 
-@Comment {
+<!--
   - test: `comments`
   
   ```swifttest
@@ -406,7 +406,7 @@ This is the end of the first multiline comment. */
         /* This is the second, nested multiline comment. */
      This is the end of the first multiline comment. */
   ```
-}
+-->
 
 Nested multiline comments enable you to comment out large blocks of code quickly and easily,
 even if the code already contains multiline comments.
@@ -425,14 +425,14 @@ let cat = "🐱"; print(cat)
 ```
 
 
-@Comment {
+<!--
   - test: `semiColons`
   
   ```swifttest
   -> let cat = "🐱"; print(cat)
   <- 🐱
   ```
-}
+-->
 
 ## Integers
 
@@ -458,7 +458,7 @@ let maxValue = UInt8.max  // maxValue is equal to 255, and is of type UInt8
 ```
 
 
-@Comment {
+<!--
   - test: `integerBounds`
   
   ```swifttest
@@ -467,7 +467,7 @@ let maxValue = UInt8.max  // maxValue is equal to 255, and is of type UInt8
   >> print(minValue, maxValue)
   << 0 255
   ```
-}
+-->
 
 The values of these properties are of the appropriate-sized number type
 (such as `UInt8` in the example above)
@@ -522,14 +522,14 @@ Swift provides two signed floating-point number types:
 > values you need to work with in your code.
 > In situations where either type would be appropriate, `Double` is preferred.
 
-@Comment {
+<!--
   TODO: Explicitly mention situations where Float is appropriate,
   such as when optimizing for storage size of collections?
-}
+-->
 
-@Comment {
+<!--
   TODO: mention infinity, -infinity etc.
-}
+-->
 
 ## Type Safety and Type Inference
 
@@ -575,7 +575,7 @@ let meaningOfLife = 42
 ```
 
 
-@Comment {
+<!--
   - test: `typeInference`
   
   ```swifttest
@@ -584,7 +584,7 @@ let meaningOfLife = 42
   >> print(type(of: meaningOfLife))
   << Int
   ```
-}
+-->
 
 Likewise, if you don't specify a type for a floating-point literal,
 Swift infers that you want to create a `Double`:
@@ -595,7 +595,7 @@ let pi = 3.14159
 ```
 
 
-@Comment {
+<!--
   - test: `typeInference`
   
   ```swifttest
@@ -604,7 +604,7 @@ let pi = 3.14159
   >> print(type(of: pi))
   << Double
   ```
-}
+-->
 
 Swift always chooses `Double` (rather than `Float`)
 when inferring the type of floating-point numbers.
@@ -618,7 +618,7 @@ let anotherPi = 3 + 0.14159
 ```
 
 
-@Comment {
+<!--
   - test: `typeInference`
   
   ```swifttest
@@ -627,7 +627,7 @@ let anotherPi = 3 + 0.14159
   >> print(type(of: anotherPi))
   << Double
   ```
-}
+-->
 
 The literal value of `3` has no explicit type in and of itself,
 and so an appropriate output type of `Double` is inferred
@@ -652,7 +652,7 @@ let hexadecimalInteger = 0x11     // 17 in hexadecimal notation
 ```
 
 
-@Comment {
+<!--
   - test: `numberLiterals`
   
   ```swifttest
@@ -663,7 +663,7 @@ let hexadecimalInteger = 0x11     // 17 in hexadecimal notation
   >> print(binaryInteger, octalInteger, hexadecimalInteger)
   << 17 17 17
   ```
-}
+-->
 
 Floating-point literals can be decimal (with no prefix),
 or hexadecimal (with a `0x` prefix).
@@ -673,7 +673,7 @@ indicated by an uppercase or lowercase `e`;
 hexadecimal floats must have an exponent,
 indicated by an uppercase or lowercase `p`.
 
-@Comment {
+<!--
   - test: `float-required-vs-optional-exponent-err`
   
   ```swifttest
@@ -682,9 +682,9 @@ indicated by an uppercase or lowercase `p`.
   !! let hexWithout = 0x1.5
   !!                       ^
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `float-required-vs-optional-exponent`
   
   ```swifttest
@@ -692,7 +692,7 @@ indicated by an uppercase or lowercase `p`.
   -> let decimalWithout = 0.5
   -> let decimalWith = 0.5e7
   ```
-}
+-->
 
 For decimal numbers with an exponent of `x`,
 the base number is multiplied by 10ˣ:
@@ -715,7 +715,7 @@ let hexadecimalDouble = 0xC.3p0
 ```
 
 
-@Comment {
+<!--
   - test: `numberLiterals`
   
   ```swifttest
@@ -723,7 +723,7 @@ let hexadecimalDouble = 0xC.3p0
   -> let exponentDouble = 1.21875e1
   -> let hexadecimalDouble = 0xC.3p0
   ```
-}
+-->
 
 Numeric literals can contain extra formatting to make them easier to read.
 Both integers and floats can be padded with extra zeros
@@ -737,7 +737,7 @@ let justOverOneMillion = 1_000_000.000_000_1
 ```
 
 
-@Comment {
+<!--
   - test: `numberLiterals`
   
   ```swifttest
@@ -745,7 +745,7 @@ let justOverOneMillion = 1_000_000.000_000_1
   -> let oneMillion = 1_000_000
   -> let justOverOneMillion = 1_000_000.000_000_1
   ```
-}
+-->
 
 ## Numeric Type Conversion
 
@@ -780,7 +780,7 @@ let tooBig: Int8 = Int8.max + 1
 ```
 
 
-@Comment {
+<!--
   - test: `constantsAndVariablesOverflowError`
   
   ```swifttest
@@ -796,7 +796,7 @@ let tooBig: Int8 = Int8.max + 1
   !! let cannotBeNegative: UInt8 = -1
   !!                                ^
   ```
-}
+-->
 
 Because each numeric type can store a different range of values,
 you must opt in to numeric type conversion on a case-by-case basis.
@@ -821,7 +821,7 @@ let twoThousandAndOne = twoThousand + UInt16(one)
 ```
 
 
-@Comment {
+<!--
   - test: `typeConversion`
   
   ```swifttest
@@ -831,7 +831,7 @@ let twoThousandAndOne = twoThousand + UInt16(one)
   >> print(twoThousandAndOne)
   << 2001
   ```
-}
+-->
 
 Because both sides of the addition are now of type `UInt16`,
 the addition is allowed.
@@ -860,7 +860,7 @@ let pi = Double(three) + pointOneFourOneFiveNine
 ```
 
 
-@Comment {
+<!--
   - test: `typeConversion`
   
   ```swifttest
@@ -870,7 +870,7 @@ let pi = Double(three) + pointOneFourOneFiveNine
   /> pi equals \(pi), and is inferred to be of type Double
   </ pi equals 3.14159, and is inferred to be of type Double
   ```
-}
+-->
 
 Here, the value of the constant `three` is used to create a new value of type `Double`,
 so that both sides of the addition are of the same type.
@@ -885,7 +885,7 @@ let integerPi = Int(pi)
 ```
 
 
-@Comment {
+<!--
   - test: `typeConversion`
   
   ```swifttest
@@ -893,7 +893,7 @@ let integerPi = Int(pi)
   /> integerPi equals \(integerPi), and is inferred to be of type Int
   </ integerPi equals 3, and is inferred to be of type Int
   ```
-}
+-->
 
 Floating-point values are always truncated when used to initialize a new integer value in this way.
 This means that `4.75` becomes `4`, and `-3.9` becomes `-3`.
@@ -904,11 +904,11 @@ This means that `4.75` becomes `4`, and `-3.9` becomes `-3`.
 > because number literals don't have an explicit type in and of themselves.
 > Their type is inferred only at the point that they're evaluated by the compiler.
 
-@Comment {
+<!--
   NOTE: this section on explicit conversions could be included in the Operators section.
   I think it's more appropriate here, however,
   and helps to reinforce the “just use Int” message.
-}
+-->
 
 ## Type Aliases
 
@@ -924,13 +924,13 @@ typealias AudioSample = UInt16
 ```
 
 
-@Comment {
+<!--
   - test: `typeAliases`
   
   ```swifttest
   -> typealias AudioSample = UInt16
   ```
-}
+-->
 
 Once you define a type alias,
 you can use the alias anywhere you might use the original name:
@@ -941,7 +941,7 @@ var maxAmplitudeFound = AudioSample.min
 ```
 
 
-@Comment {
+<!--
   - test: `typeAliases`
   
   ```swifttest
@@ -949,7 +949,7 @@ var maxAmplitudeFound = AudioSample.min
   /> maxAmplitudeFound is now \(maxAmplitudeFound)
   </ maxAmplitudeFound is now 0
   ```
-}
+-->
 
 Here, `AudioSample` is defined as an alias for `UInt16`.
 Because it's an alias,
@@ -970,14 +970,14 @@ let turnipsAreDelicious = false
 ```
 
 
-@Comment {
+<!--
   - test: `booleans`
   
   ```swifttest
   -> let orangesAreOrange = true
   -> let turnipsAreDelicious = false
   ```
-}
+-->
 
 The types of `orangesAreOrange` and `turnipsAreDelicious`
 have been inferred as `Bool` from the fact that
@@ -1001,7 +1001,7 @@ if turnipsAreDelicious {
 ```
 
 
-@Comment {
+<!--
   - test: `booleans`
   
   ```swifttest
@@ -1012,7 +1012,7 @@ if turnipsAreDelicious {
      }
   <- Eww, turnips are horrible.
   ```
-}
+-->
 
 Conditional statements such as the `if` statement are covered in more detail in <doc:ControlFlow>.
 
@@ -1027,7 +1027,7 @@ if i {
 ```
 
 
-@Comment {
+<!--
   - test: `booleansNotBoolean`
   
   ```swifttest
@@ -1040,7 +1040,7 @@ if i {
   !!   ^
   !! ( != 0)
   ```
-}
+-->
 
 However, the alternative example below is valid:
 
@@ -1052,7 +1052,7 @@ if i == 1 {
 ```
 
 
-@Comment {
+<!--
   - test: `booleansIsBoolean`
   
   ```swifttest
@@ -1061,7 +1061,7 @@ if i == 1 {
         // this example will compile successfully
      }
   ```
-}
+-->
 
 The result of the `i == 1` comparison is of type `Bool`,
 and so this second example passes the type-check.
@@ -1087,7 +1087,7 @@ let http404Error = (404, "Not Found")
 ```
 
 
-@Comment {
+<!--
   - test: `tuples`
   
   ```swifttest
@@ -1095,7 +1095,7 @@ let http404Error = (404, "Not Found")
   /> http404Error is of type (Int, String), and equals (\(http404Error.0), \"\(http404Error.1)\")
   </ http404Error is of type (Int, String), and equals (404, "Not Found")
   ```
-}
+-->
 
 The `(404, "Not Found")` tuple groups together an `Int` and a `String`
 to give the HTTP status code two separate values:
@@ -1120,7 +1120,7 @@ print("The status message is \(statusMessage)")
 ```
 
 
-@Comment {
+<!--
   - test: `tuples`
   
   ```swifttest
@@ -1130,7 +1130,7 @@ print("The status message is \(statusMessage)")
   -> print("The status message is \(statusMessage)")
   <- The status message is Not Found
   ```
-}
+-->
 
 If you only need some of the tuple's values,
 ignore parts of the tuple with an underscore (`_`)
@@ -1143,7 +1143,7 @@ print("The status code is \(justTheStatusCode)")
 ```
 
 
-@Comment {
+<!--
   - test: `tuples`
   
   ```swifttest
@@ -1151,7 +1151,7 @@ print("The status code is \(justTheStatusCode)")
   -> print("The status code is \(justTheStatusCode)")
   <- The status code is 404
   ```
-}
+-->
 
 Alternatively,
 access the individual element values in a tuple using index numbers starting at zero:
@@ -1164,7 +1164,7 @@ print("The status message is \(http404Error.1)")
 ```
 
 
-@Comment {
+<!--
   - test: `tuples`
   
   ```swifttest
@@ -1173,7 +1173,7 @@ print("The status message is \(http404Error.1)")
   -> print("The status message is \(http404Error.1)")
   <- The status message is Not Found
   ```
-}
+-->
 
 You can name the individual elements in a tuple when the tuple is defined:
 
@@ -1182,13 +1182,13 @@ let http200Status = (statusCode: 200, description: "OK")
 ```
 
 
-@Comment {
+<!--
   - test: `tuples`
   
   ```swifttest
   -> let http200Status = (statusCode: 200, description: "OK")
   ```
-}
+-->
 
 If you name the elements in a tuple,
 you can use the element names to access the values of those elements:
@@ -1201,7 +1201,7 @@ print("The status message is \(http200Status.description)")
 ```
 
 
-@Comment {
+<!--
   - test: `tuples`
   
   ```swifttest
@@ -1210,7 +1210,7 @@ print("The status message is \(http200Status.description)")
   -> print("The status message is \(http200Status.description)")
   <- The status message is OK
   ```
-}
+-->
 
 Tuples are particularly useful as the return values of functions.
 A function that tries to retrieve a web page might return the `(Int, String)` tuple type
@@ -1264,7 +1264,7 @@ let convertedNumber = Int(possibleNumber)
 ```
 
 
-@Comment {
+<!--
   - test: `optionals`
   
   ```swifttest
@@ -1274,7 +1274,7 @@ let convertedNumber = Int(possibleNumber)
   >> print(type(of: convertedNumber))
   << Optional<Int>
   ```
-}
+-->
 
 Because the initializer might fail,
 it returns an *optional* `Int`, rather than an `Int`.
@@ -1298,7 +1298,7 @@ serverResponseCode = nil
 ```
 
 
-@Comment {
+<!--
   - test: `optionals`
   
   ```swifttest
@@ -1308,7 +1308,7 @@ serverResponseCode = nil
   -> serverResponseCode = nil
   // serverResponseCode now contains no value
   ```
-}
+-->
 
 > Note: You can't use `nil` with non-optional constants and variables.
 > If a constant or variable in your code needs to work with
@@ -1324,14 +1324,14 @@ var surveyAnswer: String?
 ```
 
 
-@Comment {
+<!--
   - test: `optionals`
   
   ```swifttest
   -> var surveyAnswer: String?
   // surveyAnswer is automatically set to nil
   ```
-}
+-->
 
 > Note: Swift's `nil` isn't the same as `nil` in Objective-C.
 > In Objective-C, `nil` is a pointer to a nonexistent object.
@@ -1355,7 +1355,7 @@ if convertedNumber != nil {
 ```
 
 
-@Comment {
+<!--
   - test: `optionals`
   
   ```swifttest
@@ -1364,7 +1364,7 @@ if convertedNumber != nil {
      }
   <- convertedNumber contains some integer value.
   ```
-}
+-->
 
 Once you're sure that the optional *does* contain a value,
 you can access its underlying value
@@ -1381,7 +1381,7 @@ if convertedNumber != nil {
 ```
 
 
-@Comment {
+<!--
   - test: `optionals`
   
   ```swifttest
@@ -1390,7 +1390,7 @@ if convertedNumber != nil {
      }
   <- convertedNumber has an integer value of 123.
   ```
-}
+-->
 
 For more about the `if` statement, see <doc:ControlFlow>.
 
@@ -1432,7 +1432,7 @@ if let actualNumber = Int(possibleNumber) {
 ```
 
 
-@Comment {
+<!--
   - test: `optionals`
   
   ```swifttest
@@ -1443,7 +1443,7 @@ if let actualNumber = Int(possibleNumber) {
      }
   <- The string "123" has an integer value of 123
   ```
-}
+-->
 
 This code can be read as:
 
@@ -1472,7 +1472,7 @@ if let myNumber = myNumber {
 ```
 
 
-@Comment {
+<!--
   - test: `optionals`
   
   ```swifttest
@@ -1484,7 +1484,7 @@ if let myNumber = myNumber {
      }
   <- My number is 123
   ```
-}
+-->
 
 This code starts by checking whether `myNumber` contains a value,
 just like the code in the previous example.
@@ -1509,7 +1509,7 @@ if let myNumber {
 ```
 
 
-@Comment {
+<!--
   - test: `optionals`
   
   ```swifttest
@@ -1518,7 +1518,7 @@ if let myNumber {
      }
   <- My number is 123
   ```
-}
+-->
 
 You can use both constants and variables with optional binding.
 If you wanted to manipulate the value of `myNumber`
@@ -1556,7 +1556,7 @@ if let firstNumber = Int("4") {
 ```
 
 
-@Comment {
+<!--
   - test: `multipleOptionalBindings`
   
   ```swifttest
@@ -1574,16 +1574,16 @@ if let firstNumber = Int("4") {
      }
   <- 4 < 42 < 100
   ```
-}
+-->
 
-@Comment {
+<!--
   The example above uses multiple optional bindings
   to show that you can have more than one
   and to show the short-circuiting behavior.
   It has multiple Boolean conditions
   to show that you should join logically related conditions
   using the && operator instead of a comma.
-}
+-->
 
 > Note: Constants and variables created with optional binding in an `if` statement
 > are available only within the body of the `if` statement.
@@ -1633,7 +1633,7 @@ let implicitString: String = assumedString // no need for an exclamation point
 ```
 
 
-@Comment {
+<!--
   - test: `implicitlyUnwrappedOptionals`
   
   ```swifttest
@@ -1643,7 +1643,7 @@ let implicitString: String = assumedString // no need for an exclamation point
   -> let assumedString: String! = "An implicitly unwrapped optional string."
   -> let implicitString: String = assumedString // no need for an exclamation point
   ```
-}
+-->
 
 You can think of an implicitly unwrapped optional as
 giving permission for the optional to be force-unwrapped if needed.
@@ -1664,7 +1664,7 @@ let optionalString = assumedString
 ```
 
 
-@Comment {
+<!--
   - test: `implicitlyUnwrappedOptionals`
   
   ```swifttest
@@ -1673,7 +1673,7 @@ let optionalString = assumedString
   >> print(type(of: optionalString))
   << Optional<String>
   ```
-}
+-->
 
 If an implicitly unwrapped optional is `nil` and you try to access its wrapped value,
 you'll trigger a runtime error.
@@ -1691,7 +1691,7 @@ if assumedString != nil {
 ```
 
 
-@Comment {
+<!--
   - test: `implicitlyUnwrappedOptionals`
   
   ```swifttest
@@ -1700,7 +1700,7 @@ if assumedString != nil {
      }
   <- An implicitly unwrapped optional string.
   ```
-}
+-->
 
 You can also use an implicitly unwrapped optional with optional binding,
 to check and unwrap its value in a single statement:
@@ -1713,7 +1713,7 @@ if let definiteString = assumedString {
 ```
 
 
-@Comment {
+<!--
   - test: `implicitlyUnwrappedOptionals`
   
   ```swifttest
@@ -1722,7 +1722,7 @@ if let definiteString = assumedString {
      }
   <- An implicitly unwrapped optional string.
   ```
-}
+-->
 
 > Note: Don't use an implicitly unwrapped optional when there's a possibility of
 > a variable becoming `nil` at a later point.
@@ -1750,7 +1750,7 @@ func canThrowAnError() throws {
 ```
 
 
-@Comment {
+<!--
   - test: `errorHandling`
   
   ```swifttest
@@ -1765,7 +1765,7 @@ func canThrowAnError() throws {
   >>    }
      }
   ```
-}
+-->
 
 A function indicates that it can throw an error
 by including the `throws` keyword in its declaration.
@@ -1785,7 +1785,7 @@ do {
 ```
 
 
-@Comment {
+<!--
   - test: `errorHandling`
   
   ```swifttest
@@ -1799,7 +1799,7 @@ do {
   -> }
   << Error
   ```
-}
+-->
 
 A `do` statement creates a new containing scope,
 which allows errors to be propagated to one or more `catch` clauses.
@@ -1823,7 +1823,7 @@ do {
 ```
 
 
-@Comment {
+<!--
   - test: `errorHandlingTwo`
   
   ```swifttest
@@ -1847,7 +1847,7 @@ do {
          buyGroceries(ingredients)
      }
   ```
-}
+-->
 
 In this example, the `makeASandwich()` function will throw an error
 if no clean dishes are available
@@ -1921,13 +1921,13 @@ without impacting performance in production.
 
 ### Debugging with Assertions
 
-@Comment {
+<!--
   If your code triggers an assertion while running in a debug environment,
   such as when you build and run an app in Xcode,
   you can see exactly where the invalid state occurred
   and query the state of your app at the time that the assertion was triggered.
   An assertion also lets you provide a suitable debug message as to the nature of the assert.
-}
+-->
 
 You write an assertion by calling the
 [assert(_:_:file:line:)](https://developer.apple.com/documentation/swift/1541112-assert) function
@@ -1943,7 +1943,7 @@ assert(age >= 0, "A person's age can't be less than zero.")
 ```
 
 
-@Comment {
+<!--
   - test: `assertions-1`
   
   ```swifttest
@@ -1952,7 +1952,7 @@ assert(age >= 0, "A person's age can't be less than zero.")
   xx assert
   // This assertion fails because -3 isn't >= 0.
   ```
-}
+-->
 
 In this example, code execution continues if `age >= 0` evaluates to `true`,
 that is, if the value of `age` is nonnegative.
@@ -1968,7 +1968,7 @@ assert(age >= 0)
 ```
 
 
-@Comment {
+<!--
   - test: `assertions-2`
   
   ```swifttest
@@ -1976,9 +1976,9 @@ assert(age >= 0)
   -> assert(age >= 0)
   xx assert
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `assertionsCanUseStringInterpolation`
   
   ```swifttest
@@ -1986,7 +1986,7 @@ assert(age >= 0)
   -> assert(age >= 0, "A person's age can't be less than zero, but value is \(age).")
   xx assert
   ```
-}
+-->
 
 If the code already checks the condition,
 you use the
@@ -2005,7 +2005,7 @@ if age > 10 {
 ```
 
 
-@Comment {
+<!--
   - test: `assertions-3`
   
   ```swifttest
@@ -2019,7 +2019,7 @@ if age > 10 {
      }
   xx assert
   ```
-}
+-->
 
 ### Enforcing Preconditions
 
@@ -2040,7 +2040,7 @@ precondition(index > 0, "Index must be greater than zero.")
 ```
 
 
-@Comment {
+<!--
   - test: `preconditions`
   
   ```swifttest
@@ -2049,7 +2049,7 @@ precondition(index > 0, "Index must be greater than zero.")
   -> precondition(index > 0, "Index must be greater than zero.")
   xx assert
   ```
-}
+-->
 
 You can also call the
 [preconditionFailure(_:file:line:)](https://developer.apple.com/documentation/swift/1539374-preconditionfailure) function
@@ -2072,7 +2072,7 @@ by one of the switch's other cases.
 > you can be sure that execution always halts
 > if it encounters a stub implementation.
 
-@Comment {
+<!--
   "\ " in the first cell below lets it be empty.
   Otherwise RST treats the row as a continuation.
   
@@ -2085,17 +2085,17 @@ by one of the switch's other cases.
   ------------ -----  ----------  -------------------------------
   Fatal Error  Yes    Yes         Yes
   ============ =====  ==========  ===============================
-}
+-->
 
-@Comment {
+<!--
   TODO: In Xcode, can you set a breakpoint on assertion/precondition failure?
   If so, mention that fact and give a link to a guide that shows you how.
   In LLDB, 'breakpoint set -E swift' catches when errors are thrown,
   but doesn't stop at assertions.
-}
+-->
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -2103,4 +2103,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/TypeCasting.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/TypeCasting.md
@@ -39,7 +39,7 @@ class MediaItem {
 ```
 
 
-@Comment {
+<!--
   - test: `typeCasting, typeCasting-err`
   
   ```swifttest
@@ -50,7 +50,7 @@ class MediaItem {
         }
      }
   ```
-}
+-->
 
 The next snippet defines two subclasses of `MediaItem`.
 The first subclass, `Movie`, encapsulates additional information about a movie or film.
@@ -78,7 +78,7 @@ class Song: MediaItem {
 ```
 
 
-@Comment {
+<!--
   - test: `typeCasting, typeCasting-err`
   
   ```swifttest
@@ -98,7 +98,7 @@ class Song: MediaItem {
         }
      }
   ```
-}
+-->
 
 The final snippet creates a constant array called `library`,
 which contains two `Movie` instances and three `Song` instances.
@@ -120,7 +120,7 @@ let library = [
 ```
 
 
-@Comment {
+<!--
   - test: `typeCasting`
   
   ```swifttest
@@ -135,7 +135,7 @@ let library = [
   << Array<MediaItem>
   // the type of "library" is inferred to be [MediaItem]
   ```
-}
+-->
 
 The items stored in `library` are still `Movie` and `Song` instances behind the scenes.
 However, if you iterate over the contents of this array,
@@ -173,7 +173,7 @@ print("Media library contains \(movieCount) movies and \(songCount) songs")
 ```
 
 
-@Comment {
+<!--
   - test: `typeCasting`
   
   ```swifttest
@@ -191,7 +191,7 @@ print("Media library contains \(movieCount) movies and \(songCount) songs")
   -> print("Media library contains \(movieCount) movies and \(songCount) songs")
   <- Media library contains 2 movies and 3 songs
   ```
-}
+-->
 
 This example iterates through all items in the `library` array.
 On each pass, the `for`-`in` loop sets the `item` constant
@@ -259,7 +259,7 @@ for item in library {
 ```
 
 
-@Comment {
+<!--
   - test: `typeCasting`
   
   ```swifttest
@@ -277,7 +277,7 @@ for item in library {
   </ Song: The One And Only, by Chesney Hawkes
   </ Song: Never Gonna Give You Up, by Rick Astley
   ```
-}
+-->
 
 The example starts by trying to downcast the current `item` as a `Movie`.
 Because `item` is a `MediaItem` instance, it's possible that it *might* be a `Movie`;
@@ -310,17 +310,17 @@ whenever a `Song` is found in the library.
 > The underlying instance remains the same; it's simply treated and accessed
 > as an instance of the type to which it has been cast.
 
-@Comment {
+<!--
   TODO: This example should be followed by the same example written with switch,
   to introduce type casting in a pattern matching context
   and to set up the crazy Any example at the end of the chapter.
-}
+-->
 
-@Comment {
+<!--
   TODO: No section on upcasting because nobody can come up with
   an example that isn't excessively contrived.
   The reference shows the behavior in a contrived example.
-}
+-->
 
 ## Type Casting for Any and AnyObject
 
@@ -351,7 +351,7 @@ things.append({ (name: String) -> String in "Hello, \(name)" })
 ```
 
 
-@Comment {
+<!--
   - test: `typeCasting, typeCasting-err`
   
   ```swifttest
@@ -366,7 +366,7 @@ things.append({ (name: String) -> String in "Hello, \(name)" })
   -> things.append(Movie(name: "Ghostbusters", director: "Ivan Reitman"))
   -> things.append({ (name: String) -> String in "Hello, \(name)" })
   ```
-}
+-->
 
 The `things` array contains
 two `Int` values, two `Double` values, a `String` value,
@@ -420,7 +420,7 @@ for thing in things {
 ```
 
 
-@Comment {
+<!--
   - test: `typeCasting`
   
   ```swifttest
@@ -458,7 +458,7 @@ for thing in things {
   </ a movie called Ghostbusters, dir. Ivan Reitman
   </ Hello, Michael
   ```
-}
+-->
 
 > Note: The `Any` type represents values of any type, including optional types.
 > Swift gives you a warning if you use an optional value
@@ -473,7 +473,7 @@ for thing in things {
 > things.append(optionalNumber as Any) // No warning
 > ```
 
-@Comment {
+<!--
   - test: `typeCasting-err`
 
   ```swifttest
@@ -496,9 +496,9 @@ for thing in things {
   !!                              as Any
   -> things.append(optionalNumber as Any) // No warning
   ```
-}
+-->
 
-@Comment {
+<!--
   Rejected examples to illustrate AnyObject:
 
   Array of delegates which may conform to one or more of the class's delegate protocols.
@@ -527,10 +527,10 @@ for thing in things {
       let userData: AnyObject?  // In Cocoa APIs, userData is a void*
   }
   ```
-}
+-->
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -538,4 +538,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/AboutTheLanguageReference.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/AboutTheLanguageReference.md
@@ -58,7 +58,7 @@ getter-setter-block --> ``{`` setter-clause getter-clause ``}``
 *getter-setter-block* → `{` *setter-clause* *getter-clause* `}`
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -66,4 +66,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Attributes.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Attributes.md
@@ -51,14 +51,14 @@ These arguments begin with one of the following platform or language names:
 - `tvOSApplicationExtension`
 - `swift`
 
-@Comment {
+<!--
   If you need to add a new platform to this list,
   you probably need to update platform-name in the grammar too.
-}
+-->
 
-@Comment {
+<!--
   For the list in source, see include/swift/AST/PlatformKinds.def
-}
+-->
 
 You can also use an asterisk (`*`) to indicate the
 availability of the declaration on all of the platform names listed above.
@@ -137,7 +137,7 @@ including important milestones.
   ```
   
   
-  @Comment {
+  <!--
     - test: `renamed1`
     
     ```swifttest
@@ -146,7 +146,7 @@ including important milestones.
            // protocol definition
        }
     ```
-  }
+  -->
   
   ```swift
   // Subsequent release renames MyProtocol
@@ -159,7 +159,7 @@ including important milestones.
   ```
   
   
-  @Comment {
+  <!--
     - test: `renamed2`
     
     ```swifttest
@@ -171,7 +171,7 @@ including important milestones.
     -> @available(*, unavailable, renamed: "MyRenamedProtocol")
        typealias MyProtocol = MyRenamedProtocol
     ```
-  }
+  -->
 
 You can apply multiple `available` attributes on a single declaration
 to specify the declaration's availability on different platforms
@@ -183,7 +183,7 @@ If you use multiple `available` attributes,
 the effective availability is the combination of
 the platform and Swift availabilities.
 
-@Comment {
+<!--
   - test: `multipleAvailableAttributes`
   
   ```swifttest
@@ -192,7 +192,7 @@ the platform and Swift availabilities.
   -> func foo() { }
   -> foo()
   ```
-}
+-->
 
 If an `available` attribute only specifies an `introduced` argument
 in addition to a platform or language name argument,
@@ -217,7 +217,7 @@ class MyClass {
 ```
 
 
-@Comment {
+<!--
   - test: `availableShorthand`
   
   ```swifttest
@@ -226,7 +226,7 @@ class MyClass {
          // class definition
      }
   ```
-}
+-->
 
 An `available` attribute
 that specifies availability using a Swift version number
@@ -243,7 +243,7 @@ struct MyStruct {
 ```
 
 
-@Comment {
+<!--
   - test: `availableMultipleAvailabilities`
   
   ```swifttest
@@ -253,7 +253,7 @@ struct MyStruct {
          // struct definition
      }
   ```
-}
+-->
 
 ### discardableResult
 
@@ -299,7 +299,7 @@ dial.dynamicallyCall(withArguments: [4, 1, 1])
 ```
 
 
-@Comment {
+<!--
   - test: `dynamicCallable`
   
   ```swifttest
@@ -327,7 +327,7 @@ dial.dynamicallyCall(withArguments: [4, 1, 1])
   -> dial.dynamicallyCall(withArguments: [4, 1, 1])
   << Get Swift help on forums.swift.org
   ```
-}
+-->
 
 The declaration of the `dynamicallyCall(withArguments:)` method
 must have a single parameter that conforms to the
@@ -360,7 +360,7 @@ print(repeatLabels(a: 1, b: 2, c: 3, b: 2, a: 1))
 ```
 
 
-@Comment {
+<!--
   - test: `dynamicCallable`
   
   ```swifttest
@@ -383,7 +383,7 @@ print(repeatLabels(a: 1, b: 2, c: 3, b: 2, a: 1))
   </ b b
   </ a
   ```
-}
+-->
 
 The declaration of the `dynamicallyCall(withKeywordArguments:)` method
 must have a single parameter that conforms to the
@@ -415,7 +415,7 @@ repeatLabels(a: "four") // Error
 ```
 
 
-@Comment {
+<!--
   - test: `dynamicCallable-err`
   
   ```swifttest
@@ -435,7 +435,7 @@ repeatLabels(a: "four") // Error
   !! repeatLabels(a: "four") // Error
   !! ^
   ```
-}
+-->
 
 ### dynamicMemberLookup
 
@@ -491,7 +491,7 @@ print(dynamic == equivalent)
 ```
 
 
-@Comment {
+<!--
   - test: `dynamicMemberLookup`
   
   ```swifttest
@@ -515,7 +515,7 @@ print(dynamic == equivalent)
   -> print(dynamic == equivalent)
   <- true
   ```
-}
+-->
 
 Dynamic member lookup by key path
 can be used to implement a wrapper type
@@ -539,7 +539,7 @@ print(wrapper.x)
 ```
 
 
-@Comment {
+<!--
   - test: `dynamicMemberLookup`
   
   ```swifttest
@@ -558,7 +558,7 @@ print(wrapper.x)
   -> print(wrapper.x)
   << 381
   ```
-}
+-->
 
 ### frozen
 
@@ -576,27 +576,27 @@ but they break ABI compatibility for frozen types.
 > all structures and enumerations are implicitly frozen,
 > and this attribute is ignored.
 
-@Comment {
+<!--
   - test: `can-use-frozen-without-evolution`
   
   ```swifttest
   >> @frozen public enum E { case x, y }
   >> @frozen public struct S { var a: Int = 10 }
   ```
-}
+-->
 
-@Comment {
+<!--
   <rdar://problem/54041692> Using @frozen without Library Evolution has inconsistent error messages [SE-0260]
-}
+-->
 
-@Comment {
+<!--
   - test: `frozen-is-fine-with-evolution`
   
   ```swifttest
   >> @frozen public enum E { case x, y }
   >> @frozen public struct S { var a: Int = 10 }
   ```
-}
+-->
 
 In library evolution mode,
 code that interacts with members of nonfrozen structures and enumerations
@@ -621,7 +621,7 @@ and expressions that provide the initial value for stored instance properties
 must follow the same restrictions as inlinable functions,
 as discussed in <doc:Attributes#inlinable>.
 
-@Comment {
+<!--
   - test: `frozen-struct-prop-init-cant-refer-to-private-type`
   
   ```swifttest
@@ -642,7 +642,7 @@ as discussed in <doc:Attributes#inlinable>.
   !! private struct PrivateStruct: P { }
   !! ^
   ```
-}
+-->
 
 To enable library evolution mode on the command line,
 pass the `-enable-library-evolution` option to the Swift compiler.
@@ -651,13 +651,13 @@ set the "Build Libraries for Distribution" build setting
 (`BUILD_LIBRARY_FOR_DISTRIBUTION`) to Yes,
 as described in [Xcode Help](https://help.apple.com/xcode/mac/current/#/dev04b3a04ba).
 
-@Comment {
+<!--
   This is the first time we're talking about a specific compiler flag/option.
   In the long term, the discussion of library evolution mode
   will need to move to a new chapter in the guide
   that also talks about things like @available and ABI.
   See <rdar://problem/51929017> TSPL: Give guidance to library authors about @available @frozen and friends
-}
+-->
 
 A switch statement over a frozen enumeration doesn't require a `default` case,
 as discussed in <doc:Statements#Switching-Over-Future-Enumeration-Cases>.
@@ -665,16 +665,16 @@ Including a `default` or `@unknown default` case
 when switching over a frozen enumeration
 produces a warning because that code is never executed.
 
-@Comment {
+<!--
   - test: `NoUnknownDefaultOverFrozenEnum`
   
   ```swifttest
   >> public enum E { case x, y }
   >> @frozen public enum F { case x, y }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `NoUnknownDefaultOverFrozenEnum_Test1`
   
   ```swifttest
@@ -689,9 +689,9 @@ produces a warning because that code is never executed.
   >> }
   // Note that there's no warning -- this is fine because E isn't frozen.
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `NoUnknownDefaultOverFrozenEnum_Test2`
   
   ```swifttest
@@ -719,7 +719,7 @@ produces a warning because that code is never executed.
   !! case .y: print(8)
   !! ^
   ```
-}
+-->
 
 ### GKInspectable
 
@@ -727,10 +727,10 @@ Apply this attribute to expose a custom GameplayKit component property
 to the SpriteKit editor UI.
 Applying this attribute also implies the `objc` attribute.
 
-@Comment {
+<!--
   See also <rdar://problem/27287369> Document @GKInspectable attribute
   which we will want to link to, once it's written.
-}
+-->
 
 ### inlinable
 
@@ -756,7 +756,7 @@ Functions and closures that are defined inside an inlinable function
 are implicitly inlinable,
 even though they can't be marked with this attribute.
 
-@Comment {
+<!--
   - test: `cant-inline-private`
   
   ```swifttest
@@ -765,9 +765,9 @@ even though they can't be marked with this attribute.
   !! @inlinable private func f() { }
   !! ^~~~~~~~~~~
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `cant-inline-nested`
   
   ```swifttest
@@ -779,9 +779,9 @@ even though they can't be marked with this attribute.
   !! ^~~~~~~~~~~
   !!-
   ```
-}
+-->
 
-@Comment {
+<!--
   TODO: When we get resilience, this will actually be a problem.
   Until then, per discussion with [Contributor 6004], there's no (supported) way
   for folks to get into the state where this behavior would be triggered.
@@ -799,7 +799,7 @@ even though they can't be marked with this attribute.
   inlined copies outside the module would use the old algorithm
   and the noninlined copy would use the new algorithm,
   yielding inconsistent results.
-}
+-->
 
 ### main
 
@@ -819,7 +819,7 @@ struct MyTopLevel {
 ```
 
 
-@Comment {
+<!--
   - test: `atMain`
   
   ```swifttest
@@ -832,7 +832,7 @@ struct MyTopLevel {
   -> }
   << Hello
   ```
-}
+-->
 
 Another way to describe the requirements of the `main` attribute
 is that the type you write this attribute on
@@ -846,7 +846,7 @@ protocol ProvidesMain {
 ```
 
 
-@Comment {
+<!--
   - test: `atMain_ProvidesMain`
   
   ```swifttest
@@ -854,13 +854,13 @@ protocol ProvidesMain {
          static func main() throws
      }
   ```
-}
+-->
 
 The Swift code you compile to make an executable
 can contain at most one top-level entry point,
 as discussed in <doc:Declarations#Top-Level-Code>.
 
-@Comment {
+<!--
   - test: `no-at-main-in-top-level-code`
   
   ```swifttest
@@ -878,9 +878,9 @@ as discussed in <doc:Declarations#Top-Level-Code>.
   !! @main
   !! ^
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `atMain_library`
   
   ```swifttest
@@ -889,16 +889,16 @@ as discussed in <doc:Declarations#Top-Level-Code>.
          public static func main() { print("Hello") }
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `atMain_client`
   
   ```swifttest
   -> import atMain_library
   -> @main class CC: C { }
   ```
-}
+-->
 
 ### nonobjc
 
@@ -944,10 +944,10 @@ NSApplicationMain(CommandLine.argc, CommandLine.unsafeArgv)
 ```
 
 
-@Comment {
+<!--
   Above code isn't tested because it hangs the REPL indefinitely,
   which is correct behavior if you call a non-returning function like this.
-}
+-->
 
 The Swift code you compile to make an executable
 can contain at most one top-level entry point,
@@ -964,10 +964,10 @@ The type of the property must conform to the `NSCopying` protocol.
 The `NSCopying` attribute behaves in a way similar to the Objective-C `copy`
 property attribute.
 
-@Comment {
+<!--
   TODO: If and when Dave includes a section about this in the Guide,
   provide a link to the relevant section.
-}
+-->
 
 ### NSManaged
 
@@ -1050,7 +1050,7 @@ class ExampleClass: NSObject {
 ```
 
 
-@Comment {
+<!--
   - test: `objc-attribute`
   
   ```swifttest
@@ -1064,7 +1064,7 @@ class ExampleClass: NSObject {
         }
      }
   ```
-}
+-->
 
 For more information, see
 [Importing Swift into Objective-C](https://developer.apple.com/documentation/swift/imported_c_and_objective-c_apis/importing_swift_into_objective-c).
@@ -1100,12 +1100,12 @@ the introspection facilities of the Objective-C runtime.
 Applying the `objc` attribute when it isn't needed
 can increase your binary size and adversely affect performance.
 
-@Comment {
+<!--
   The binary size comes from the additional thunks
   to translate between calling conventions.
   The performance of linking and launch are slower
   because of the larger symbol table slowing dyld down.
-}
+-->
 
 ### propertyWrapper
 
@@ -1119,7 +1119,7 @@ apply the attribute to a local stored variable declaration
 to wrap access to the variable the same way.
 Computed variables, global variables, and constants can't use property wrappers.
 
-@Comment {
+<!--
   - test: `property-wrappers-can-go-on-stored-variable`
   
   ```swifttest
@@ -1131,9 +1131,9 @@ Computed variables, global variables, and constants can't use property wrappers.
   >> f()
   << 20
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `property-wrappers-cant-go-on-constants`
   
   ```swifttest
@@ -1146,9 +1146,9 @@ Computed variables, global variables, and constants can't use property wrappers.
   !! @UselessWrapper let d: Int = 20
   !! ^
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `property-wrappers-cant-go-on-computed-variable`
   
   ```swifttest
@@ -1162,7 +1162,7 @@ Computed variables, global variables, and constants can't use property wrappers.
   !! @UselessWrapper var d: Int { return 20 }
   !! ^
   ```
-}
+-->
 
 The wrapper must define a `wrappedValue` instance property.
 The *wrapped value* of the property
@@ -1225,7 +1225,7 @@ struct SomeStruct {
 ```
 
 
-@Comment {
+<!--
   - test: `propertyWrapper`
   
   ```swifttest
@@ -1259,15 +1259,15 @@ struct SomeStruct {
          @SomeWrapper(wrappedValue: 30, custom: 98.7) var d
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   Comments in the SomeStruct part of the example above
   are on the line before instead of at the end of the line
   because the last example gets too long to fit on one line.
-}
+-->
 
-@Comment {
+<!--
   Initialization of a wrapped property using ``init(wrappedValue:)``
   can be split across multiple statements.
   However, you can only see that behavior using local variables
@@ -1277,7 +1277,7 @@ struct SomeStruct {
   @SomeWrapper var e
   e = 20  // Uses init(wrappedValue:)
   e = 30  // Uses the property setter
-}
+-->
 
 The *projected value* for a wrapped property is a second value
 that a property wrapper can use to expose additional functionality.
@@ -1314,7 +1314,7 @@ s.$x.wrapper  // WrapperWithProjection value
 ```
 
 
-@Comment {
+<!--
   - test: `propertyWrapper-projection`
   
   ```swifttest
@@ -1340,7 +1340,7 @@ s.$x.wrapper  // WrapperWithProjection value
   >> _ =
   -> s.$x.wrapper  // WrapperWithProjection value
   ```
-}
+-->
 
 ### resultBuilder
 
@@ -1379,9 +1379,9 @@ they default to being the same as `Component`.
 
 The result-building methods are as follows:
 
-@Comment {
+<!--
   start of term/defn list
-}
+-->
 
 - term `static func buildBlock(_ components: Component...) -> Component`: Combines an array of partial results into a single partial result.
 A result builder must implement this method.
@@ -1412,9 +1412,9 @@ that performs an availability check.
 You can use this to erase type information
 that varies between the conditional branches.
 
-@Comment {
+<!--
   end of term/defn list
-}
+-->
 
 For example, the code below defines a simple result builder
 that builds an array of integers.
@@ -1449,7 +1449,7 @@ struct ArrayBuilder {
 ```
 
 
-@Comment {
+<!--
   - test: `array-result-builder`
   
   ```swifttest
@@ -1481,7 +1481,7 @@ struct ArrayBuilder {
          }
      }
   ```
-}
+-->
 
 #### Result Transformations
 
@@ -1500,7 +1500,7 @@ into code that calls the static methods of the result builder type:
   ```
   
   
-  @Comment {
+  <!--
     - test: `array-result-builder`
     
     ```swifttest
@@ -1508,7 +1508,7 @@ into code that calls the static methods of the result builder type:
     -> var manualNumber = ArrayBuilder.buildExpression(10)
     >> assert(builderNumber == manualNumber)
     ```
-  }
+  -->
 - An assignment statement is transformed like an expression,
   but is understood to evaluate to `()`.
   You can define an overload of `buildExpression(_:)`
@@ -1659,7 +1659,7 @@ into code that calls the static methods of the result builder type:
   ```
   
   
-  @Comment {
+  <!--
     - test: `array-result-builder`
     
     ```swifttest
@@ -1693,7 +1693,7 @@ into code that calls the static methods of the result builder type:
     << Building second... [32]
     << Building first... [32]
     ```
-  }
+  -->
 - A branch statement that might not produce a value,
   like an `if` statement without an `else` clause,
   becomes a call to `buildOptional(_:)`.
@@ -1715,7 +1715,7 @@ into code that calls the static methods of the result builder type:
   ```
   
   
-  @Comment {
+  <!--
     - test: `array-result-builder`
     
     ```swifttest
@@ -1732,7 +1732,7 @@ into code that calls the static methods of the result builder type:
     << Building optional... Optional([20])
     >> assert(builderOptional == manualOptional)
     ```
-  }
+  -->
 - A code block or `do` statement
   becomes a call to the `buildBlock(_:)` method.
   Each of the statements inside of the block is transformed,
@@ -1755,7 +1755,7 @@ into code that calls the static methods of the result builder type:
   ```
   
   
-  @Comment {
+  <!--
     - test: `array-result-builder`
     
     ```swifttest
@@ -1772,7 +1772,7 @@ into code that calls the static methods of the result builder type:
        )
     >> assert(builderBlock == manualBlock)
     ```
-  }
+  -->
 - A `for` loop becomes a temporary variable, a `for` loop,
   and call to the `buildArray(_:)` method.
   The new `for` loop iterates over the sequence
@@ -1796,7 +1796,7 @@ into code that calls the static methods of the result builder type:
   ```
   
   
-  @Comment {
+  <!--
     - test: `array-result-builder`
     
     ```swifttest
@@ -1814,13 +1814,13 @@ into code that calls the static methods of the result builder type:
     -> let manualArray = ArrayBuilder.buildArray(temporary)
     >> assert(builderArray == manualArray)
     ```
-  }
+  -->
 - If the result builder has a `buildFinalResult(_:)` method,
   the final result becomes a call to that method.
   This transformation is always last.
 
 
-@Comment {
+<!--
   - test: `result-builder-limited-availability-broken, result-builder-limited-availability-ok`
   
   ```swifttest
@@ -1858,9 +1858,9 @@ into code that calls the static methods of the result builder type:
          }
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `result-builder-limited-availability-broken`
   
   ```swifttest
@@ -1886,9 +1886,9 @@ into code that calls the static methods of the result builder type:
   !! struct DrawingBuilder {
   !! ^
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `result-builder-limited-availability-ok`
   
   ```swifttest
@@ -1925,7 +1925,7 @@ into code that calls the static methods of the result builder type:
   /> The type of typeErasedDrawing is \(type(of: typeErasedDrawing))
   </ The type of typeErasedDrawing is Line<DrawEither<AnyDrawable, Line<Text>>>
   ```
-}
+-->
 
 Although the transformation behavior is described in terms of temporary variables,
 using a result builder doesn't actually create any new declarations
@@ -1951,7 +1951,7 @@ For example, the expression `4 + 5 * 6` becomes
 Likewise, nested branch statements become
 a single binary tree of calls to the `buildEither` methods.
 
-@Comment {
+<!--
   - test: `result-builder-transform-complex-expression`
   
   ```swifttest
@@ -1972,7 +1972,7 @@ a single binary tree of calls to the `buildEither` methods.
   >> print(x)
   << [46]
   ```
-}
+-->
 
 #### Custom Result-Builder Attributes
 
@@ -2000,7 +2000,7 @@ to provide default values as part of their definitions.
 This attribute is inferred for any class
 that inherits from `NSManagedObject`.
 
-@Comment {
+<!--
   - test: `requires_stored_property_inits-requires-default-values`
   
   ```swifttest
@@ -2019,7 +2019,7 @@ that inherits from `NSManagedObject`.
   !! @requires_stored_property_inits class NoDefaultValue {
   !! ^
   ```
-}
+-->
 
 ### testable
 
@@ -2093,7 +2093,7 @@ Although either `inlinable` or `usableFromInline`
 can be applied to `internal` declarations,
 applying both attributes is an error.
 
-@Comment {
+<!--
   - test: `usableFromInline-and-inlinable-is-redundant`
   
   ```swifttest
@@ -2102,7 +2102,7 @@ applying both attributes is an error.
   !! @usableFromInline @inlinable internal func f() { }
   !! ^~~~~~~~~~~~~~~~~~
   ```
-}
+-->
 
 ### warn_unqualified_access
 
@@ -2134,9 +2134,9 @@ Swift provides the following Interface Builder attributes:
 These attributes are conceptually the same as their
 Objective-C counterparts.
 
-@Comment {
+<!--
   TODO: Need to link to the relevant discussion of these attributes in Objc.
-}
+-->
 
 You apply the `IBOutlet` and `IBInspectable` attributes
 to property declarations of a class.
@@ -2180,10 +2180,10 @@ one of the following arguments:
 - The `c` argument indicates a C function reference.
   The function value carries no context and uses the C calling convention.
 
-@Comment {
+<!--
   @convention(thin) is private, even though it doesn't have an underscore
   https://forums.swift.org/t/12087/6
-}
+-->
 
 With a few exceptions,
 a function of any calling convention can be used
@@ -2253,7 +2253,7 @@ balanced-token --> Any punctuation except ``(``, ``)``, ``[``, ``]``, ``{``, or 
 
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -2261,4 +2261,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Attributes.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Attributes.md
@@ -1056,13 +1056,13 @@ class ExampleClass: NSObject {
   ```swifttest
   >> import Foundation
   -> class ExampleClass: NSObject {
-        @objc var enabled: Bool {
-           @objc(isEnabled) get {
-              // Return the appropriate value
+  ->    @objc var enabled: Bool {
+  ->       @objc(isEnabled) get {
+  ->          // Return the appropriate value
   >>          return true
-           }
-        }
-     }
+  ->       }
+  ->    }
+  -> }
   ```
 -->
 
@@ -1248,16 +1248,16 @@ struct SomeStruct {
      }
   ---
   -> struct SomeStruct {
-         // Uses init()
-         @SomeWrapper var a: Int
+  ->     // Uses init()
+  ->     @SomeWrapper var a: Int
   ---
-         // Uses init(wrappedValue:)
-         @SomeWrapper var b = 10
+  ->     // Uses init(wrappedValue:)
+  ->     @SomeWrapper var b = 10
   ---
-         // Both use init(wrappedValue:custom:)
-         @SomeWrapper(custom: 98.7) var c = 30
-         @SomeWrapper(wrappedValue: 30, custom: 98.7) var d
-     }
+  ->     // Both use init(wrappedValue:custom:)
+  ->     @SomeWrapper(custom: 98.7) var c = 30
+  ->     @SomeWrapper(wrappedValue: 30, custom: 98.7) var d
+  -> }
   ```
 -->
 
@@ -1274,9 +1274,9 @@ struct SomeStruct {
   which currently can't have a property wrapper.
   It would look like this:
   
-  @SomeWrapper var e
-  e = 20  // Uses init(wrappedValue:)
-  e = 30  // Uses the property setter
+  -> @SomeWrapper var e
+  -> e = 20  // Uses init(wrappedValue:)
+  -> e = 30  // Uses the property setter
 -->
 
 The *projected value* for a wrapped property is a second value
@@ -1330,8 +1330,8 @@ s.$x.wrapper  // WrapperWithProjection value
   }
   ---
   -> struct SomeStruct {
-         @WrapperWithProjection var x = 123
-     }
+  ->     @WrapperWithProjection var x = 123
+  -> }
   -> let s = SomeStruct()
   >> _ =
   -> s.x           // Int value
@@ -2008,7 +2008,7 @@ that inherits from `NSManagedObject`.
          var value: Int = -1
          init() { self.value = 0 }
      }
-     @requires_stored_property_inits class NoDefaultValue {
+  -> @requires_stored_property_inits class NoDefaultValue {
          var value: Int
          init() { self.value = 0 }
      }
@@ -2181,7 +2181,7 @@ one of the following arguments:
   The function value carries no context and uses the C calling convention.
 
 <!--
-  @convention(thin) is private, even though it doesn't have an underscore
+  Note: @convention(thin) is private, even though it doesn't have an underscore
   https://forums.swift.org/t/12087/6
 -->
 

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Declarations.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Declarations.md
@@ -91,13 +91,13 @@ The *statements* inside a code block include declarations,
 expressions, and other kinds of statements and are executed in order
 of their appearance in source code.
 
-@Comment {
+<!--
   TR: What exactly are the scope rules for Swift?
-}
+-->
 
-@Comment {
+<!--
   TODO: Discuss scope.  I assume a code block creates a new scope?
-}
+-->
 
 ```
 Grammar of a code block
@@ -132,9 +132,9 @@ import <#module#>.<#submodule#>
 ```
 
 
-@Comment {
+<!--
   TODO: Need to add more to this section.
-}
+-->
 
 ```
 Grammar of an import declaration
@@ -185,13 +185,13 @@ let (firstNumber, secondNumber) = (10, 42)
 ```
 
 
-@Comment {
+<!--
   - test: `constant-decl`
   
   ```swifttest
   -> let (firstNumber, secondNumber) = (10, 42)
   ```
-}
+-->
 
 In this example,
 `firstNumber` is a named constant for the value `10`,
@@ -206,7 +206,7 @@ print("The second number is \(secondNumber).")
 ```
 
 
-@Comment {
+<!--
   - test: `constant-decl`
   
   ```swifttest
@@ -215,7 +215,7 @@ print("The second number is \(secondNumber).")
   -> print("The second number is \(secondNumber).")
   <- The second number is 42.
   ```
-}
+-->
 
 The type annotation (`:` *type*) is optional in a constant declaration
 when the type of the *constant name* can be inferred,
@@ -228,7 +228,7 @@ you can't mark it with the `class` or `final` declaration modifier
 to allow or disallow overriding by subclasses.
 Type properties are discussed in <doc:Properties#Type-Properties>.
 
-@Comment {
+<!--
   - test: `class-constants-cant-have-class-or-final`
   
   ```swifttest
@@ -242,7 +242,7 @@ Type properties are discussed in <doc:Properties#Type-Properties>.
   !!                  ^~~~~~
   !!-
   ```
-}
+-->
 
 For more information about constants and for guidance about when to use them,
 see <doc:TheBasics#Constants-and-Variables> and <doc:Properties#Stored-Properties>.
@@ -383,7 +383,7 @@ This expression is evaluated the first time you read the property's value.
 If you overwrite the property's initial value without reading it,
 this expression is evaluated before the first time you write to the property.
 
-@Comment {
+<!--
   - test: `overwriting-property-without-writing`
   
   ```swifttest
@@ -401,7 +401,7 @@ this expression is evaluated before the first time you write to the property.
   << initial value: 100
   << y: 100
   ```
-}
+-->
 
 The `willSet` and `didSet` observers provide a way to observe (and to respond appropriately)
 when the value of a variable or property is being set.
@@ -474,7 +474,7 @@ newAndOld.x = 200
 ```
 
 
-@Comment {
+<!--
   - test: `didSet-calls-superclass-getter`
   
   ```swifttest
@@ -513,12 +513,12 @@ newAndOld.x = 200
   <- Getter was called
   <- Old value 12 - new value 200
   ```
-}
+-->
 
 For more information and to see an example of how to use property observers,
 see <doc:Properties#Property-Observers>.
 
-@Comment {
+<!--
   - test: `cant-mix-get-set-and-didSet`
   
   ```swifttest
@@ -533,7 +533,7 @@ see <doc:Properties#Property-Observers>.
   !! didSet { print("S didSet") }
   !! ^
   ```
-}
+-->
 
 ### Type Variable Properties
 
@@ -575,10 +575,10 @@ didSet-clause --> attributes-OPT ``didSet`` setter-name-OPT code-block
 ```
 
 
-@Comment {
+<!--
   NOTE: Type annotations are required for computed properties -- the
   types of those properties aren't computed/inferred.
-}
+-->
 
 ## Type Alias Declaration
 
@@ -611,7 +611,7 @@ var dictionary2: Dictionary<String, Int> = [:]
 ```
 
 
-@Comment {
+<!--
   - test: `typealias-with-generic`
   
   ```swifttest
@@ -621,7 +621,7 @@ var dictionary2: Dictionary<String, Int> = [:]
   -> var dictionary1: StringDictionary<Int> = [:]
   -> var dictionary2: Dictionary<String, Int> = [:]
   ```
-}
+-->
 
 When a type alias is declared with generic parameters, the constraints on those
 parameters must match exactly the constraints on the existing type's generic parameters.
@@ -632,13 +632,13 @@ typealias DictionaryOfInts<Key: Hashable> = Dictionary<Key, Int>
 ```
 
 
-@Comment {
+<!--
   - test: `typealias-with-generic-constraint`
   
   ```swifttest
   -> typealias DictionaryOfInts<Key: Hashable> = Dictionary<Key, Int>
   ```
-}
+-->
 
 Because the type alias and the existing type can be used interchangeably,
 the type alias can't introduce additional generic constraints.
@@ -654,26 +654,26 @@ typealias Diccionario = Dictionary
 ```
 
 
-@Comment {
+<!--
   - test: `typealias-using-shorthand`
   
   ```swifttest
   -> typealias Diccionario = Dictionary
   ```
-}
+-->
 
-@Comment {
+<!--
   Note that the compiler doesn't currently enforce this. For example, this works but shouldn't:
   typealias ProvidingMoreSpecificConstraints<T: Comparable & Hashable> = Dictionary<T, Int>
-}
+-->
 
-@Comment {
+<!--
   Things that shouldn't work:
   typealias NotRedeclaringSomeOfTheGenericParameters = Dictionary<T, String>
   typealias NotRedeclaringAnyOfTheGenericParameters = Dictionary
   typealias NotProvidingTheCorrectConstraints<T> = Dictionary<T, Int>
   typealias ProvidingMoreSpecificConstraints<T: Comparable & Hashable> = Dictionary<T, Int>
-}
+-->
 
 Inside a protocol declaration,
 a type alias can give a shorter and more convenient name
@@ -692,7 +692,7 @@ func sum<T: Sequence>(_ sequence: T) -> Int where T.Element == Int {
 ```
 
 
-@Comment {
+<!--
   - test: `typealias-in-protocol`
   
   ```swifttest
@@ -706,7 +706,7 @@ func sum<T: Sequence>(_ sequence: T) -> Int where T.Element == Int {
   >>     return 9000
      }
   ```
-}
+-->
 
 Without this type alias,
 the `sum` function would have to refer to the associated type
@@ -723,13 +723,13 @@ typealias-assignment --> ``=`` type
 ```
 
 
-@Comment {
+<!--
   Old grammar:
   typealias-declaration --> typealias-head typealias-assignment
   typealias-head --> ``typealias`` typealias-name type-inheritance-clause-OPT
   typealias-name --> identifier
   typealias-assignment --> ``=`` type
-}
+-->
 
 ## Function Declaration
 
@@ -770,18 +770,18 @@ only when the expression's type and the function's return type
 aren't `Void`
 and aren't an enumeration like `Never` that doesn't have any cases.
 
-@Comment {
+<!--
   As of Swift 5.3,
   the only way to make an uninhabited type is to create an empty enum,
   so just say that directly instead of using & defining the compiler jargon.
-}
+-->
 
 Functions can return multiple values using a tuple type
 as the return type of the function.
 
-@Comment {
+<!--
   TODO: ^-- Add some more here.
-}
+-->
 
 A function definition can appear inside another function declaration.
 This kind of function is known as a *nested function*.
@@ -822,7 +822,7 @@ f(x: 1, y: 2) // both x and y are labeled
 ```
 
 
-@Comment {
+<!--
   - test: `default-parameter-names`
   
   ```swifttest
@@ -831,12 +831,12 @@ f(x: 1, y: 2) // both x and y are labeled
   -> f(x: 1, y: 2) // both x and y are labeled
   >> assert(r0 == 3)
   ```
-}
+-->
 
-@Comment {
+<!--
   Rewrite the above to avoid bare expressions.
   Tracking bug is <rdar://problem/35301593>
-}
+-->
 
 You can override the default behavior for argument labels
 with one of the following forms:
@@ -863,14 +863,14 @@ repeatGreeting("Hello, world!", count: 2) //  count is labeled, greeting is not
 ```
 
 
-@Comment {
+<!--
   - test: `overridden-parameter-names`
   
   ```swifttest
   -> func repeatGreeting(_ greeting: String, count n: Int) { /* Greet n times */ }
   -> repeatGreeting("Hello, world!", count: 2) //  count is labeled, greeting is not
   ```
-}
+-->
 
 ### In-Out Parameters
 
@@ -912,13 +912,13 @@ you can't pass the same value to multiple in-out parameters.
 For more information about memory safety and memory exclusivity,
 see <doc:MemorySafety>.
 
-@Comment {
+<!--
   When the call-by-reference optimization is in play,
   it would happen to do what you want.
   But you still shouldn't do that --
   as noted above, you're not allowed to depend on
   behavioral differences that happen because of call by reference.
-}
+-->
 
 A closure or nested function
 that captures an in-out parameter must be nonescaping.
@@ -933,7 +933,7 @@ func someFunction(a: inout Int) -> () -> Int {
 ```
 
 
-@Comment {
+<!--
   - test: `explicit-capture-for-inout`
   
   ```swifttest
@@ -948,7 +948,7 @@ func someFunction(a: inout Int) -> () -> Int {
   >> print(r, r == c.x)
   << 101 false
   ```
-}
+-->
 
 If you need to capture and mutate an in-out parameter,
 use an explicit local copy,
@@ -968,7 +968,7 @@ func multithreadedFunction(queue: DispatchQueue, x: inout Int) {
 ```
 
 
-@Comment {
+<!--
   - test: `cant-pass-inout-aliasing`
   
   ```swifttest
@@ -984,12 +984,12 @@ func multithreadedFunction(queue: DispatchQueue, x: inout Int) {
         queue.sync {}
      }
   ```
-}
+-->
 
 For more discussion and examples of in-out parameters,
 see <doc:Functions#In-Out-Parameters>.
 
-@Comment {
+<!--
   - test: `escaping-cant-capture-inout`
   
   ```swifttest
@@ -1021,7 +1021,7 @@ see <doc:Functions#In-Out-Parameters>.
   !! return { a += 1 }
   !! ^
   ```
-}
+-->
 
 ### Special Kinds of Parameters
 
@@ -1064,7 +1064,7 @@ f(7)      // Invalid, missing argument label
 ```
 
 
-@Comment {
+<!--
   - test: `default-args-and-labels`
   
   ```swifttest
@@ -1080,14 +1080,14 @@ f(7)      // Invalid, missing argument label
   !!   ^
   !!   x:
   ```
-}
+-->
 
-@Comment {
+<!--
   Rewrite the above to avoid discarding the function's return value.
   Tracking bug is <rdar://problem/35301593>
-}
+-->
 
-@Comment {
+<!--
   - test: `default-args-evaluated-at-call-site`
   
   ```swifttest
@@ -1105,7 +1105,7 @@ f(7)      // Invalid, missing argument label
   << evaluated
   << x is 10
   ```
-}
+-->
 
 ### Special Kinds of Methods
 
@@ -1126,7 +1126,7 @@ A class type method marked with the `class` declaration modifier
 can be overridden by a subclass implementation;
 a class type method marked with `class final` or `static` can't be overridden.
 
-@Comment {
+<!--
   - test: `overriding-class-methods-err`
   
   ```swifttest
@@ -1147,9 +1147,9 @@ a class type method marked with `class final` or `static` can't be overridden.
   !! class S2 { static func f() -> Int { return 12 } }
   !! ^
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `overriding-class-methods`
   
   ```swifttest
@@ -1158,7 +1158,7 @@ a class type method marked with `class final` or `static` can't be overridden.
   -> print(SS3.f())
   <- 120
   ```
-}
+-->
 
 ### Methods with Special Names
 
@@ -1187,12 +1187,12 @@ and adds labeled or unlabeled arguments ---
 for example, `callAsFunction(_:_:)` and `callAsFunction(something:)`
 are also valid call-as-function method names.
 
-@Comment {
+<!--
   Above, callAsFunction( is in code voice even though
   it's not actually a symbol that exists in the reader's code.
   Per discussion with Chuck, this is the closest typographic convention
   to what we're trying to express here.
-}
+-->
 
 The following function calls are equivalent:
 
@@ -1210,7 +1210,7 @@ callable.callAsFunction(4, scale: 2)
 ```
 
 
-@Comment {
+<!--
   - test: `call-as-function`
   
   ```swifttest
@@ -1227,7 +1227,7 @@ callable.callAsFunction(4, scale: 2)
   << 208
   << 208
   ```
-}
+-->
 
 The call-as-function methods
 and the methods from the `dynamicCallable` attribute
@@ -1252,7 +1252,7 @@ let someFunction2: (Int, Int) -> Void = callable.callAsFunction(_:scale:)
 ```
 
 
-@Comment {
+<!--
   - test: `call-as-function-err`
   
   ```swifttest
@@ -1269,7 +1269,7 @@ let someFunction2: (Int, Int) -> Void = callable.callAsFunction(_:scale:)
   !! let someFunction1: (Int, Int) -> Void = callable(_:scale:)  // Error
   !! ^~~~~~~~~~~~~~~~~~
   ```
-}
+-->
 
 The `subscript(dynamicMember:)` subscript
 enables syntactic sugar for member lookup,
@@ -1322,7 +1322,7 @@ func someFunction(callback: () throws -> Void) rethrows {
 ```
 
 
-@Comment {
+<!--
   - test: `rethrows`
   
   ```swifttest
@@ -1330,7 +1330,7 @@ func someFunction(callback: () throws -> Void) rethrows {
          try callback()
      }
   ```
-}
+-->
 
 A rethrowing function or method can contain a `throw` statement
 only inside a `catch` clause.
@@ -1359,7 +1359,7 @@ func someFunction(callback: () throws -> Void) rethrows {
 ```
 
 
-@Comment {
+<!--
   - test: `double-negative-rethrows`
   
   ```swifttest
@@ -1380,9 +1380,9 @@ func someFunction(callback: () throws -> Void) rethrows {
   !!               throw AnotherError.error
   !!               ^
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `throwing-in-rethrowing-function`
   
   ```swifttest
@@ -1401,7 +1401,7 @@ func someFunction(callback: () throws -> Void) rethrows {
   !! throw SomeError.d  // Error
   !! ^
   ```
-}
+-->
 
 A throwing method can't override a rethrowing method,
 and a throwing method can't satisfy a protocol requirement for a rethrowing method.
@@ -1445,7 +1445,7 @@ and an asynchronous method can't satisfy a protocol requirement for a synchronou
 That said, a synchronous method can override an asynchronous method,
 and a synchronous method can satisfy a protocol requirement for an asynchronous method.
 
-@Comment {
+<!--
   - test: `sync-satisfy-async-protocol-requirements`
   
   ```swifttest
@@ -1457,7 +1457,7 @@ and a synchronous method can satisfy a protocol requirement for an asynchronous 
   >>     func f() -> Int { return 120 }
   >> }
   ```
-}
+-->
 
 ### Functions that Never Return
 
@@ -1502,14 +1502,14 @@ default-argument-clause --> ``=`` expression
 ```
 
 
-@Comment {
+<!--
   NOTE: Code block is optional in the context of a protocol.
   Everywhere else, it's required.
   We could refactor to have a separation between function definition/declaration.
   There's also the low-level "asm name" FFI
   which is a definition and declaration corner case.
   Let's just deal with this difference in prose.
-}
+-->
 
 ## Enumeration Declaration
 
@@ -1583,7 +1583,7 @@ let evenInts: [Number] = [0, 2, 4, 6].map(f)
 ```
 
 
-@Comment {
+<!--
   - test: `enum-case-as-function`
   
   ```swifttest
@@ -1597,14 +1597,14 @@ let evenInts: [Number] = [0, 2, 4, 6].map(f)
   -> // Apply f to create an array of Number instances with integer values
   -> let evenInts: [Number] = [0, 2, 4, 6].map(f)
   ```
-}
+-->
 
-@Comment {
+<!--
   No expectation for evenInts because there isn't a good way to spell one.
   Using print() puts a module prefix like tmpabc in front of Number
   so the expectation would need to be a regex (which we don't have),
   and assert() would require Number to conform to Equatable.
-}
+-->
 
 For more information and to see examples of cases with associated value types,
 see <doc:Enumerations#Associated-Values>.
@@ -1623,12 +1623,12 @@ To enable indirection for a particular enumeration case,
 mark it with the `indirect` declaration modifier.
 An indirect case must have an associated value.
 
-@Comment {
+<!--
   TODO The word "enable" is kind of a weasel word.
   Better to have a more concrete discussion of exactly when
   it is and isn't used.
   For example, does "indirect enum { X(Int) } mark X as indirect?
-}
+-->
 
 ```swift
 enum Tree<T> {
@@ -1638,7 +1638,7 @@ enum Tree<T> {
 ```
 
 
-@Comment {
+<!--
   - test: `indirect-enum`
   
   ```swifttest
@@ -1650,7 +1650,7 @@ enum Tree<T> {
   >> let l2 = Tree.node(value: 100, left: Tree.empty, right: Tree.empty)
   >> let t = Tree.node(value: 50, left: l1, right: l2)
   ```
-}
+-->
 
 To enable indirection for all the cases of an enumeration
 that have an associated value,
@@ -1663,22 +1663,22 @@ can contain a mixture of cases that have associated values and cases those that 
 That said,
 it can't contain any cases that are also marked with the `indirect` modifier.
 
-@Comment {
+<!--
   It really should be an associated value **that includes the enum type**
   but right now the compiler is satisfied with any associated value.
   Alex emailed Joe Groff 2015-07-08 about this.
-}
+-->
 
-@Comment {
+<!--
   assertion indirect-in-indirect
   
   -> indirect enum E { indirect case c(E) }
   !! <REPL Input>:1:19: error: enum case in 'indirect' enum cannot also be 'indirect'
   !! indirect enum E { indirect case c(E) }
   !!                   ^
-}
+-->
 
-@Comment {
+<!--
   assertion indirect-without-recursion
   
   -> enum E { indirect case c }
@@ -1690,7 +1690,7 @@ it can't contain any cases that are also marked with the `indirect` modifier.
   -> enum E2 { indirect case c(Int) }  // This is fine, but probably shouldn't be
   ---
   -> indirect enum E3 { case x }
-}
+-->
 
 ### Enumerations with Cases of a Raw-Value Type
 
@@ -1721,10 +1721,10 @@ or `ExpressibleByExtendedGraphemeClusterLiteral` for string literals
 that contain only a single character.
 Each case must have a unique name and be assigned a unique raw value.
 
-@Comment {
+<!--
   The list of ExpressibleBy... protocols above also appears in LexicalStructure_Literals.
   This list is shorter because these five protocols are explicitly supported in the compiler.
-}
+-->
 
 If the raw-value type is specified as `Int`
 and you don't assign a value to the cases explicitly,
@@ -1739,7 +1739,7 @@ enum ExampleEnum: Int {
 ```
 
 
-@Comment {
+<!--
   - test: `raw-value-enum`
   
   ```swifttest
@@ -1747,7 +1747,7 @@ enum ExampleEnum: Int {
         case a, b, c = 5, d
      }
   ```
-}
+-->
 
 In the above example, the raw value of `ExampleEnum.a` is `0` and the value of
 `ExampleEnum.b` is `1`. And because the value of `ExampleEnum.c` is
@@ -1765,7 +1765,7 @@ enum GamePlayMode: String {
 ```
 
 
-@Comment {
+<!--
   - test: `raw-value-enum-implicit-string-values`
   
   ```swifttest
@@ -1773,7 +1773,7 @@ enum GamePlayMode: String {
         case cooperative, individual, competitive
      }
   ```
-}
+-->
 
 In the above example, the raw value of `GamePlayMode.cooperative` is `"cooperative"`,
 the raw value of `GamePlayMode.individual` is `"individual"`,
@@ -1805,15 +1805,15 @@ The enumeration type is pattern-matched against the enumeration case patterns
 in the case blocks of the `switch` statement,
 as described in <doc:Patterns#Enumeration-Case-Pattern>.
 
-@Comment {
+<!--
   FIXME: Or use if-case:
   enum E { case c(Int) }
   let e = E.c(100)
   if case E.c(let i) = e { print(i) }
   // prints 100
-}
+-->
 
-@Comment {
+<!--
   NOTE: Note that you can require protocol adoption,
   by using a protocol type as the raw-value type,
   but you do need to make it be one of the types
@@ -1821,12 +1821,12 @@ as described in <doc:Patterns#Enumeration-Case-Pattern>.
   You can have: <#raw-value type, protocol conformance#>.
   UPDATE: You can only have one raw-value type specified.
   I changed the grammar to be more restrictive in light of this.
-}
+-->
 
-@Comment {
+<!--
   NOTE: Per Doug and Ted, "('->' type)?" isn't part of the grammar.
   We removed it from our grammar, below.
-}
+-->
 
 ```
 Grammar of an enumeration declaration
@@ -1854,7 +1854,7 @@ raw-value-literal --> numeric-literal | static-string-literal | boolean-literal
 ```
 
 
-@Comment {
+<!--
   NOTE: The two types of enums are sufficiently different enough to warrant separating
   the grammar accordingly. ([Contributor 6004] pointed this out in his email.)
   I'm not sure I'm happy with the names I've chosen for two kinds of enums,
@@ -1866,9 +1866,9 @@ raw-value-literal --> numeric-literal | static-string-literal | boolean-literal
   because they behave differently. I'm not sure why we've blended them together,
   especially given that they have distinct syntactic declaration requirements
   and they behave differently.
-}
+-->
 
-@Comment {
+<!--
   old-grammar
   Grammar of an enumeration declaration
   
@@ -1881,7 +1881,7 @@ raw-value-literal --> numeric-literal | static-string-literal | boolean-literal
   enumerator --> enumerator-name tuple-type-OPT
   enumerator-name --> identifier
   raw-value-assignment --> ``=`` literal
-}
+-->
 
 ## Structure Declaration
 
@@ -1987,14 +1987,14 @@ A class can override properties, methods, subscripts, and initializers of its su
 Overridden properties, methods, subscripts,
 and designated initializers must be marked with the `override` declaration modifier.
 
-@Comment {
+<!--
   - test: `designatedInitializersRequireOverride`
   
   ```swifttest
   -> class C { init() {} }
   -> class D: C { override init() { super.init() } }
   ```
-}
+-->
 
 To require that subclasses implement a superclass's initializer,
 mark the superclass's initializer with the `required` declaration modifier.
@@ -2111,13 +2111,13 @@ see <doc:ClassesAndStructures#Classes-Are-Reference-Types>.
 You can extend the behavior of a structure type with an extension declaration,
 as discussed in <doc:Declarations#Extension-Declaration>.
 
-@Comment {
+<!--
   TODO Additional bits from the SE-0306 actors proposal:
   
   Partial applications of isolated functions are only permitted
   when the expression is a direct argument
   whose corresponding parameter is non-escaping and non-Sendable.
-}
+-->
 
 ```
 Grammar of an actor declaration
@@ -2187,13 +2187,13 @@ and for guidance about how to access optional protocol members---
 for example, when you're not sure whether a conforming type implements them---
 see <doc:Protocols#Optional-Protocol-Requirements>.
 
-@Comment {
+<!--
   TODO: Currently, you can't check for an optional initializer,
   so we're leaving those out of the documentation, even though you can mark
   an initializer with the @optional attribute. It's still being decided by the
   compiler team. Update this section if they decide to make everything work
   properly for optional initializer requirements.
-}
+-->
 
 The cases of an enumeration can satisfy
 protocol requirements for type members.
@@ -2219,7 +2219,7 @@ enum MyEnum: SomeProtocol {
 ```
 
 
-@Comment {
+<!--
   - test: `enum-case-satisfy-protocol-requirement`
   
   ```swifttest
@@ -2232,7 +2232,7 @@ enum MyEnum: SomeProtocol {
          case someFunction(x: Int)
      }
   ```
-}
+-->
 
 To restrict the adoption of a protocol to class types only,
 include the `AnyObject` protocol in the *inherited protocols*
@@ -2246,7 +2246,7 @@ protocol SomeProtocol: AnyObject {
 ```
 
 
-@Comment {
+<!--
   - test: `protocol-declaration`
   
   ```swifttest
@@ -2254,7 +2254,7 @@ protocol SomeProtocol: AnyObject {
          /* Protocol members go here */
      }
   ```
-}
+-->
 
 Any protocol that inherits from a protocol that's marked with the `AnyObject` requirement
 can likewise be adopted only by class types.
@@ -2332,7 +2332,7 @@ use the same keyword as the type they extend uses.
 Extensions that provide a default implementation for a type property requirement
 use the `static` keyword.
 
-@Comment {
+<!--
   - test: `protocols-with-type-property-requirements`
   
   ```swifttest
@@ -2349,9 +2349,9 @@ use the `static` keyword.
   !! class C2: P { class var x = 30 }
   !!               ~~~~~     ^
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `protocol-type-property-default-implementation`
   
   ```swifttest
@@ -2364,7 +2364,7 @@ use the `static` keyword.
   -> print(S2.x)
   <- 10
   ```
-}
+-->
 
 See also <doc:Declarations#Variable-Declaration>.
 
@@ -2398,9 +2398,9 @@ use the `static` keyword.
 
 See also <doc:Declarations#Function-Declaration>.
 
-@Comment {
+<!--
   TODO: Talk about using ``Self`` in parameters and return types.
-}
+-->
 
 ```
 Grammar of a protocol method declaration
@@ -2505,7 +2505,7 @@ protocol SubProtocolB: SomeProtocol where SomeType: Equatable { }
 ```
 
 
-@Comment {
+<!--
   - test: `protocol-associatedtype`
   
   ```swifttest
@@ -2528,13 +2528,13 @@ protocol SubProtocolB: SomeProtocol where SomeType: Equatable { }
   // This syntax is preferred.
   -> protocol SubProtocolB: SomeProtocol where SomeType: Equatable { }
   ```
-}
+-->
 
-@Comment {
+<!--
   TODO: Finish writing this section after WWDC.
-}
+-->
 
-@Comment {
+<!--
   NOTE:
   What are associated types? What are they "associated" with? Is "Self"
   an implicit associated type of every protocol? [...]
@@ -2597,7 +2597,7 @@ protocol SubProtocolB: SomeProtocol where SomeType: Equatable { }
   class String : Sequence { typealias Element = ... }
   
   Here you have to pick one or the other -- you can't have both.
-}
+-->
 
 See also <doc:Declarations#Type-Alias-Declaration>.
 
@@ -2718,7 +2718,7 @@ struct SomeStruct {
 ```
 
 
-@Comment {
+<!--
   - test: `failable`
   
   ```swifttest
@@ -2734,7 +2734,7 @@ struct SomeStruct {
          }
      }
   ```
-}
+-->
 
 You call an `init?` failable initializer in the same way that you call a nonfailable initializer,
 except that you must deal with the optionality of the result.
@@ -2748,7 +2748,7 @@ if let actualInstance = SomeStruct(input: "Hello") {
 ```
 
 
-@Comment {
+<!--
   - test: `failable`
   
   ```swifttest
@@ -2759,7 +2759,7 @@ if let actualInstance = SomeStruct(input: "Hello") {
          // initialization of 'SomeStruct' failed and the initializer returned 'nil'
      }
   ```
-}
+-->
 
 A failable initializer can return `nil`
 at any point in the implementation of the initializer's body.
@@ -2911,11 +2911,11 @@ To illustrate this behavior,
 the following example defines two protocols
 and a generic type that conditionally conforms to both protocols.
 
-@Comment {
+<!--
   This test needs to be compiled so that it will recognize Pair's
   CustomStringConvertible conformance -- the deprecated REPL doesn't
   seem to use the description property at all.
-}
+-->
 
 ```swift
 protocol Loggable {
@@ -2959,7 +2959,7 @@ extension String: TitledLoggable {
 ```
 
 
-@Comment {
+<!--
   - test: `conditional-conformance`
   
   ```swifttest
@@ -3002,7 +3002,7 @@ extension String: TitledLoggable {
         }
      }
   ```
-}
+-->
 
 The `Pair` structure conforms to `Loggable` and `TitledLoggable`
 whenever its generic type conforms to `Loggable` or `TitledLoggable`, respectively.
@@ -3020,7 +3020,7 @@ oneAndTwo.log()
 ```
 
 
-@Comment {
+<!--
   - test: `conditional-conformance`
   
   ```swifttest
@@ -3028,7 +3028,7 @@ oneAndTwo.log()
   -> oneAndTwo.log()
   <- Pair of 'String': (one, two)
   ```
-}
+-->
 
 However, when `oneAndTwo` is used in a generic context
 or as an instance of the `Loggable` protocol,
@@ -3047,7 +3047,7 @@ doSomething(with: oneAndTwo)
 ```
 
 
-@Comment {
+<!--
   - test: `conditional-conformance`
   
   ```swifttest
@@ -3057,7 +3057,7 @@ doSomething(with: oneAndTwo)
      doSomething(with: oneAndTwo)
   <- (one, two)
   ```
-}
+-->
 
 When `log()` is called on the instance that's passed to `doSomething(_:)`,
 the customized title is omitted from the logged string.
@@ -3105,7 +3105,7 @@ extension Array: Serializable where Element == String {
 ```
 
 
-@Comment {
+<!--
   - test: `multiple-conformances`
   
   ```swifttest
@@ -3133,7 +3133,7 @@ extension Array: Serializable where Element == String {
   !! extension Array: Serializable where Element == Int {
   !! ^
   ```
-}
+-->
 
 If you need to add conditional conformance based on multiple concrete types,
 create a new protocol that each type can conform to
@@ -3152,7 +3152,7 @@ extension Array: Serializable where Element: SerializableInArray {
 ```
 
 
-@Comment {
+<!--
   - test: `multiple-conformances-success`
   
   ```swifttest
@@ -3168,7 +3168,7 @@ extension Array: Serializable where Element: SerializableInArray {
   ->     }
      }
   ```
-}
+-->
 
 #### Resolving Implicit Redundancy
 
@@ -3209,7 +3209,7 @@ extension Array: MarkedLoggable where Element: MarkedLoggable { }
 ```
 
 
-@Comment {
+<!--
   - test: `conditional-conformance`
   
   ```swifttest
@@ -3232,7 +3232,7 @@ extension Array: MarkedLoggable where Element: MarkedLoggable { }
      }
      extension Array: MarkedLoggable where Element: MarkedLoggable { }
   ```
-}
+-->
 
 Without the extension
 to explicitly declare conditional conformance to `Loggable`,
@@ -3246,7 +3246,7 @@ extension Array: Loggable where Element: MarkedLoggable { }
 ```
 
 
-@Comment {
+<!--
   - test: `conditional-conformance-implicit-overlap`
   
   ```swifttest
@@ -3263,9 +3263,9 @@ extension Array: Loggable where Element: MarkedLoggable { }
   !! extension Array: Loggable where Element: TitledLoggable { }
   !! ^
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `types-cant-have-multiple-implicit-conformances`
   
   ```swifttest
@@ -3298,9 +3298,9 @@ extension Array: Loggable where Element: MarkedLoggable { }
   !! extension Array: MarkedLoggable where Element: MarkedLoggable { }
   !! ^
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `extension-can-have-where-clause`
   
   ```swifttest
@@ -3312,9 +3312,9 @@ extension Array: Loggable where Element: MarkedLoggable { }
   >> let r0 = x.f(x: y)
   >> assert(r0 == 7)
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `extensions-can-have-where-clause-and-inheritance-together`
   
   ```swifttest
@@ -3325,7 +3325,7 @@ extension Array: Loggable where Element: MarkedLoggable { }
   >> let r0 = [1, 2, 3].foo()
   >> assert(r0 == 0)
   ```
-}
+-->
 
 ```
 Grammar of an extension declaration
@@ -3413,7 +3413,7 @@ In a class declaration,
 the `static` keyword has the same effect as marking the declaration
 with both the `class` and `final` declaration modifiers.
 
-@Comment {
+<!--
   - test: `cant-override-static-subscript-in-subclass`
   
   ```swifttest
@@ -3426,7 +3426,7 @@ with both the `class` and `final` declaration modifiers.
   !! class Super { static subscript(i: Int) -> Int { return 10 } }
   !!                      ^
   ```
-}
+-->
 
 ```
 Grammar of a subscript declaration
@@ -3663,13 +3663,13 @@ and for guidance about how to access optional protocol members---
 for example, when you're not sure whether a conforming type implements them---
 see <doc:Protocols#Optional-Protocol-Requirements>.
 
-@Comment {
+<!--
   TODO: Currently, you can't check for an optional initializer,
   so we're leaving those out of the documentation, even though you can mark
   an initializer with the @optional attribute. It's still being decided by the
   compiler team. Update this section if they decide to make everything work
   properly for optional initializer requirements.
-}
+-->
 - term `required`: Apply this modifier to a designated or convenience initializer
 of a class to indicate that every subclass must implement that initializer.
 The subclass's implementation of that initializer
@@ -3783,7 +3783,7 @@ actor-isolation-modifier --> ``nonisolated``
 
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -3791,4 +3791,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Declarations.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Declarations.md
@@ -725,10 +725,10 @@ typealias-assignment --> ``=`` type
 
 <!--
   Old grammar:
-  typealias-declaration --> typealias-head typealias-assignment
-  typealias-head --> ``typealias`` typealias-name type-inheritance-clause-OPT
-  typealias-name --> identifier
-  typealias-assignment --> ``=`` type
+  typealias-declaration -> typealias-head typealias-assignment
+  typealias-head -> ``typealias`` typealias-name type-inheritance-clause-OPT
+  typealias-name -> identifier
+  typealias-assignment -> ``=`` type
 -->
 
 ## Function Declaration
@@ -1872,15 +1872,15 @@ raw-value-literal --> numeric-literal | static-string-literal | boolean-literal
   old-grammar
   Grammar of an enumeration declaration
   
-  enum-declaration --> attribute-list-OPT ``enum`` enum-name generic-parameter-clause-OPT type-inheritance-clause-OPT enum-body
-  enum-name --> identifier
-  enum-body --> ``{`` declarations-OPT ``}``
+  enum-declaration -> attribute-list-OPT ``enum`` enum-name generic-parameter-clause-OPT type-inheritance-clause-OPT enum-body
+  enum-name -> identifier
+  enum-body -> ``{`` declarations-OPT ``}``
   
-  enum-member-declaration --> attribute-list-OPT ``case`` enumerator-list
-  enumerator-list --> enumerator raw-value-assignment-OPT | enumerator raw-value-assignment-OPT ``,`` enumerator-list
-  enumerator --> enumerator-name tuple-type-OPT
-  enumerator-name --> identifier
-  raw-value-assignment --> ``=`` literal
+  enum-member-declaration -> attribute-list-OPT ``case`` enumerator-list
+  enumerator-list -> enumerator raw-value-assignment-OPT | enumerator raw-value-assignment-OPT ``,`` enumerator-list
+  enumerator -> enumerator-name tuple-type-OPT
+  enumerator-name -> identifier
+  raw-value-assignment -> ``=`` literal
 -->
 
 ## Structure Declaration
@@ -2549,9 +2549,9 @@ protocol SubProtocolB: SomeProtocol where SomeType: Equatable { }
   that are related to the type of ``Self``, such as a type of data stored in a
   collection or the node and edge types of a graph." Is this still true?
   
-  --> If we expand the discussion here,
-  --> add a link from Types_SelfType
-  --> to give more details about Self in protocols.
+    -> If we expand the discussion here,
+    -> add a link from Types_SelfType
+    -> to give more details about Self in protocols.
   
   NOTES from Doug:
   At one point, Self was an associated type, but that's the wrong modeling of

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Expressions.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Expressions.md
@@ -1679,11 +1679,11 @@ c.observe(\.someProperty) { object, change in
   ```swifttest
   >> import Foundation
   -> class SomeClass: NSObject {
-         @objc dynamic var someProperty: Int
-         init(someProperty: Int) {
-             self.someProperty = someProperty
-         }
-     }
+  ->     @objc dynamic var someProperty: Int
+  ->     init(someProperty: Int) {
+  ->         self.someProperty = someProperty
+  ->     }
+  -> }
   ---
   -> let c = SomeClass(someProperty: 10)
   >> let r0 =
@@ -2077,9 +2077,9 @@ let selectorForPropertyGetter = #selector(getter: SomeClass.property)
   ```swifttest
   >> import Foundation
   -> class SomeClass: NSObject {
-         @objc let property: String
+  ->     @objc let property: String
   ---
-         @objc(doSomethingWithInt:)
+  ->     @objc(doSomethingWithInt:)
          func doSomething(_ x: Int) { }
   ---
          init(property: String) {
@@ -2124,7 +2124,7 @@ let anotherSelector = #selector(SomeClass.doSomething(_:) as (SomeClass) -> (Str
   >>     }
   >> }
   -> extension SomeClass {
-         @objc(doSomethingWithString:)
+  ->     @objc(doSomethingWithString:)
          func doSomething(_ x: String) { }
      }
   -> let anotherSelector = #selector(SomeClass.doSomething(_:) as (SomeClass) -> (String) -> Void)
@@ -2199,7 +2199,7 @@ if let value = c.value(forKey: keyPath) {
   ```swifttest
   >> import Foundation
   -> class SomeClass: NSObject {
-        @objc var someProperty: Int
+  ->    @objc var someProperty: Int
         init(someProperty: Int) {
             self.someProperty = someProperty
         }

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Expressions.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Expressions.md
@@ -130,7 +130,7 @@ sum = (try someThrowingFunction()) + anotherThrowingFunction()
 ```
 
 
-@Comment {
+<!--
   - test: `placement-of-try`
   
   ```swifttest
@@ -161,13 +161,13 @@ sum = (try someThrowingFunction()) + anotherThrowingFunction()
   !!                                      ^
   !!                                      try!
   ```
-}
+-->
 
 A `try` expression can't appear on the right-hand side of an infix operator,
 unless the infix operator is the assignment operator
 or the `try` expression is enclosed in parentheses.
 
-@Comment {
+<!--
   - test: `try-on-right`
   
   ```swifttest
@@ -179,15 +179,15 @@ or the `try` expression is enclosed in parentheses.
   !!           ^
   -> sum = 7 + (try someThrowingFunction()) // OK
   ```
-}
+-->
 
 If an expression includes both the `try` and `await` operator,
 the `try` operator must appear first.
 
-@Comment {
+<!--
   The "try await" ordering is also part of the grammar for 'expression',
   but it's important enough to be worth re-stating in prose.
-}
+-->
 
 For more information and to see examples of how to use `try`, `try?`, and `try!`,
 see <doc:ErrorHandling>.
@@ -245,7 +245,7 @@ sum = (await someAsyncFunction()) + anotherAsyncFunction()
 ```
 
 
-@Comment {
+<!--
   - test: `placement-of-await`
   
   ```swifttest
@@ -271,13 +271,13 @@ sum = (await someAsyncFunction()) + anotherAsyncFunction()
   !! sum = (await someAsyncFunction()) + anotherAsyncFunction()
   !! ^
   ```
-}
+-->
 
 An `await` expression can't appear on the right-hand side of an infix operator,
 unless the infix operator is the assignment operator
 or the `await` expression is enclosed in parentheses.
 
-@Comment {
+<!--
   - test: `await-on-right`
   
   ```swifttest
@@ -292,15 +292,15 @@ or the `await` expression is enclosed in parentheses.
   >> _ = sum  // Suppress irrelevant written-but-not-read warning
   >> }
   ```
-}
+-->
 
 If an expression includes both the `await` and `try` operator,
 the `try` operator must appear first.
 
-@Comment {
+<!--
   The "try await" ordering is also part of the grammar for 'expression',
   but it's important enough to be worth re-stating in prose.
-}
+-->
 
 ```
 Grammar of an await expression
@@ -327,7 +327,7 @@ see <doc:BasicOperators> and <doc:AdvancedOperators>.
 For information about the operators provided by the Swift standard library,
 see [Operator Declarations](https://developer.apple.com/documentation/swift/operator_declarations).
 
-@Comment {
+<!--
   You have essentially expression sequences here, and within it are
   parts of the expressions.  We're calling them "expressions" even
   though they aren't what we ordinarily think of as expressions.  We
@@ -335,7 +335,7 @@ see [Operator Declarations](https://developer.apple.com/documentation/swift/oper
   which gives a rough parse tree.  Then after name binding we know
   operator precedence and we do a second phase of parsing that builds
   something that's a more traditional tree.
-}
+-->
 
 > Note: At parse time,
 > an expression made up of infix operators is represented
@@ -385,7 +385,7 @@ For example:
 ```
 
 
-@Comment {
+<!--
   - test: `assignmentOperator`
   
   ```swifttest
@@ -394,7 +394,7 @@ For example:
   /> a is \"\(a)\", b is \(b), c is \(c), and 9.45 is ignored
   </ a is "test", b is 12, c is 3, and 9.45 is ignored
   ```
-}
+-->
 
 The assignment operator doesn't return any value.
 
@@ -456,7 +456,7 @@ can be cast to the specified *type*.
 It returns `true` if the *expression* can be cast to the specified *type*;
 otherwise, it returns `false`.
 
-@Comment {
+<!--
   - test: `triviallyTrueIsAndAs`
   
   ```swifttest
@@ -469,9 +469,9 @@ otherwise, it returns `false`.
   !! assert(!("hello" is Int))
   !!          ~~~~~~~ ^  ~~~
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `is-operator-tautology`
   
   ```swifttest
@@ -485,7 +485,7 @@ otherwise, it returns `false`.
   !! assert(s is Base)
   !!          ^
   ```
-}
+-->
 
 The `as` operator performs a cast
 when it's known at compile time
@@ -511,7 +511,7 @@ f(x as Any)
 ```
 
 
-@Comment {
+<!--
   - test: `explicit-type-with-as-operator`
   
   ```swifttest
@@ -528,7 +528,7 @@ f(x as Any)
   -> f(x as Any)
   <- Function for Any
   ```
-}
+-->
 
 Bridging lets you use an expression of
 a Swift standard library type such as `String`
@@ -593,18 +593,18 @@ primary-expression --> key-path-string-expression
 ```
 
 
-@Comment {
+<!--
   NOTE: One reason for breaking primary expressions out of postfix
   expressions is for exposition -- it makes it easier to organize the
   prose surrounding the production rules.
-}
+-->
 
-@Comment {
+<!--
   TR: Is a generic argument clause allowed
   after an identifier in expression context?
   It seems like that should only occur when an identifier
   is a *type* identifier.
-}
+-->
 
 ### Literal Expression
 
@@ -653,7 +653,7 @@ or other code that doesn't become part of the shipping program.
 > In the future, the string might contain multiple slashes,
 > such as `MyModule/some/disambiguation/MyFile.swift`.
 
-@Comment {
+<!--
   - test: `pound-file-flavors`
   
   ```swifttest
@@ -662,7 +662,7 @@ or other code that doesn't become part of the shipping program.
   >> print(#file == #fileID)
   << false
   ```
-}
+-->
 
 Inside a function,
 the value of `#function` is the name of that function,
@@ -676,10 +676,10 @@ When used as the default value of a function or method parameter,
 the special literal's value is determined
 when the default value expression is evaluated at the call site.
 
-@Comment {
+<!--
   See also "Special Kinds of Parameters" in "Declarations"
   where the general rule is defined.
-}
+-->
 
 ```swift
 func logFunctionName(string: String = #function) {
@@ -691,7 +691,7 @@ func myFunction() {
 ```
 
 
-@Comment {
+<!--
   - test: `special-literal-evaluated-at-call-site`
   
   ```swifttest
@@ -713,7 +713,7 @@ func myFunction() {
   >> namedArgs(i: 1, withJay: 2)
   << namedArgs(i:withJay:)
   ```
-}
+-->
 
 An *array literal* is
 an ordered collection of values.
@@ -737,13 +737,13 @@ var emptyArray: [Double] = []
 ```
 
 
-@Comment {
+<!--
   - test: `array-literal-brackets`
   
   ```swifttest
   -> var emptyArray: [Double] = []
   ```
-}
+-->
 
 A *dictionary literal* is
 an unordered collection of key-value pairs.
@@ -772,13 +772,13 @@ var emptyDictionary: [String: Double] = [:]
 ```
 
 
-@Comment {
+<!--
   - test: `dictionary-literal-brackets`
   
   ```swifttest
   -> var emptyDictionary: [String: Double] = [:]
   ```
-}
+-->
 
 A *playground literal*
 is used by Xcode to create an interactive representation
@@ -827,9 +827,9 @@ self.init(<#initializer arguments#>)
 ```
 
 
-@Comment {
+<!--
   TODO: Come back and explain the second to last form (i.e., self(arg: value)).
-}
+-->
 
 In an initializer, subscript, or instance method, `self` refers to the current
 instance of the type in which it occurs. In a type method,
@@ -851,7 +851,7 @@ class SomeClass {
 ```
 
 
-@Comment {
+<!--
   - test: `self-expression`
   
   ```swifttest
@@ -862,7 +862,7 @@ class SomeClass {
          }
      }
   ```
-}
+-->
 
 In a mutating method of a value type,
 you can assign a new instance of that value type to `self`.
@@ -878,7 +878,7 @@ struct Point {
 ```
 
 
-@Comment {
+<!--
   - test: `self-expression`
   
   ```swifttest
@@ -893,11 +893,11 @@ struct Point {
   >> print("The point is now at (\(somePoint.x), \(somePoint.y))")
   << The point is now at (3.0, 4.0)
   ```
-}
+-->
 
-@Comment {
+<!--
   iBooks Store screenshot begins here.
-}
+-->
 
 ```
 Grammar of a self expression
@@ -981,9 +981,9 @@ it's understood to be asynchronous.
 There are several special forms
 that allow closures to be written more concisely:
 
-@Comment {
+<!--
   iBooks Store screenshot ends here.
-}
+-->
 
 - A closure can omit the types
   of its parameters, its return type, or both.
@@ -1017,7 +1017,7 @@ myFunction { $0 + $1 }
 ```
 
 
-@Comment {
+<!--
   - test: `closure-expression-forms`
   
   ```swifttest
@@ -1034,7 +1034,7 @@ myFunction { $0 + $1 }
   ---
   -> myFunction { $0 + $1 }
   ```
-}
+-->
 
 For information about passing a closure as an argument to a function,
 see <doc:Expressions#Function-Call-Expression>.
@@ -1092,7 +1092,7 @@ closure()
 ```
 
 
-@Comment {
+<!--
   - test: `capture-list-value-semantics`
   
   ```swifttest
@@ -1107,7 +1107,7 @@ closure()
   -> closure()
   <- 0 10
   ```
-}
+-->
 
 There are two different things named `a`,
 the variable in the surrounding scope
@@ -1125,14 +1125,14 @@ In contrast, there's only one variable named `b` ---
 the `b` in the outer scope ---
 so changes from inside or outside the closure are visible in both places.
 
-@Comment {
+<!--
   [Contributor 6004] also describes the distinction as
   "capturing the variable, not the value"
   but he notes that we don't have a rigorous definition of
   capturing a variable in Swift
   (unlike some other languages)
   so that description's not likely to be very helpful for developers.
-}
+-->
 
 This distinction isn't visible
 when the captured variable's type has reference semantics.
@@ -1159,7 +1159,7 @@ closure()
 ```
 
 
-@Comment {
+<!--
   - test: `capture-list-reference-semantics`
   
   ```swifttest
@@ -1177,9 +1177,9 @@ closure()
   -> closure()
   <- 10 10
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `capture-list-with-commas`
   
   ```swifttest
@@ -1189,14 +1189,14 @@ closure()
   >> let r0 = f()
   >> assert(r0 == 107)
   ```
-}
+-->
 
-@Comment {
+<!--
   It's not an error to capture things that aren't included in the capture list,
   although maybe it should be.  See also rdar://17024367.
-}
+-->
 
-@Comment {
+<!--
   - test: `capture-list-is-not-exhaustive`
   
   ```swifttest
@@ -1210,7 +1210,7 @@ closure()
   -> let r1 = g()
   -> assert(r1 == 107)
   ```
-}
+-->
 
 If the type of the expression's value is a class,
 you can mark the expression in a capture list
@@ -1225,7 +1225,7 @@ myFunction { [unowned self] in print(self.title) }  // unowned capture
 ```
 
 
-@Comment {
+<!--
   - test: `closure-expression-weak`
   
   ```swifttest
@@ -1244,7 +1244,7 @@ myFunction { [unowned self] in print(self.title) }  // unowned capture
   << Title
   << Title
   ```
-}
+-->
 
 You can also bind an arbitrary expression
 to a named value in a capture list.
@@ -1258,7 +1258,7 @@ myFunction { [weak parent = self.parent] in print(parent!.title) }
 ```
 
 
-@Comment {
+<!--
   - test: `closure-expression-capture`
   
   ```swifttest
@@ -1273,14 +1273,14 @@ myFunction { [weak parent = self.parent] in print(parent!.title) }
   >> C().method()
   << Title
   ```
-}
+-->
 
 For more information and examples of closure expressions,
 see <doc:Closures#Closure-Expressions>.
 For more information and examples of capture lists,
 see <doc:AutomaticReferenceCounting#Resolving-Strong-Reference-Cycles-for-Closures>.
 
-@Comment {
+<!--
   - test: `async-throwing-closure-syntax`
   
   ```swifttest
@@ -1297,7 +1297,7 @@ see <doc:AutomaticReferenceCounting#Resolving-Strong-Reference-Cycles-for-Closur
   !! ^
   // NOTE: The error message for c3 gets printed by the REPL before the c2 error.
   ```
-}
+-->
 
 ```
 Grammar of a closure expression
@@ -1344,7 +1344,7 @@ x = .anotherValue
 ```
 
 
-@Comment {
+<!--
   - test: `implicitMemberEnum`
   
   ```swifttest
@@ -1352,7 +1352,7 @@ x = .anotherValue
   -> var x = MyEnumeration.someValue
   -> x = .anotherValue
   ```
-}
+-->
 
 If the inferred type is an optional,
 you can also use a member of the non-optional type
@@ -1363,13 +1363,13 @@ var someOptional: MyEnumeration? = .someValue
 ```
 
 
-@Comment {
+<!--
   - test: `implicitMemberEnum`
   
   ```swifttest
   -> var someOptional: MyEnumeration? = .someValue
   ```
-}
+-->
 
 Implicit member expressions can be followed by
 a postfix operator or other postfix syntax listed in
@@ -1403,7 +1403,7 @@ let z: SomeClass = .sharedSubclass
 ```
 
 
-@Comment {
+<!--
   - test: `implicit-member-chain`
   
   ```swifttest
@@ -1421,7 +1421,7 @@ let z: SomeClass = .sharedSubclass
   -> let y: SomeClass? = .shared
   -> let z: SomeClass = .sharedSubclass
   ```
-}
+-->
 
 In the code above,
 the type of `x` matches the type implied by its context exactly,
@@ -1436,14 +1436,14 @@ implicit-member-expression --> ``.`` identifier ``.`` postfix-expression
 ```
 
 
-@Comment {
+<!--
   The grammar above allows the additional pieces tested below,
   which work even though they're omitted from the SE-0287 list.
   The grammar also overproduces, allowing any primary expression
   because of the definition of postfix-expression.
-}
+-->
 
-@Comment {
+<!--
   - test: `implicit-member-grammar`
   
   ```swifttest
@@ -1473,7 +1473,7 @@ implicit-member-expression --> ``.`` identifier ``.`` postfix-expression
   >> }
   >> let s: S = .init(bestNumber: 42)
   ```
-}
+-->
 
 ### Parenthesized Expression
 
@@ -1484,9 +1484,9 @@ by explicitly grouping expressions.
 Grouping parentheses don't change an expression's type ---
 for example, the type of `(1)` is simply `Int`.
 
-@Comment {
+<!--
   See "Tuple Expression" below for langref grammar.
-}
+-->
 
 ```
 Grammar of a parenthesized expression
@@ -1519,7 +1519,7 @@ However, `(a: 10, b: (a: 1, x: 2))` is valid ---
 although `a` appears twice,
 it appears once in the outer tuple and once in the inner tuple.
 
-@Comment {
+<!--
   - test: `tuple-labels-must-be-unique`
   
   ```swifttest
@@ -1529,7 +1529,7 @@ it appears once in the outer tuple and once in the inner tuple.
   !! let bad = (a: 10, a: 20)
   !! ^
   ```
-}
+-->
 
 A tuple expression can contain zero expressions,
 or it can contain two or more expressions.
@@ -1564,7 +1564,7 @@ For example, in the following assignment
 ```
 
 
-@Comment {
+<!--
   - test: `wildcardTuple`
   
   ```swifttest
@@ -1572,7 +1572,7 @@ For example, in the following assignment
   -> (x, _) = (10, 20)
   -> // x is 10, and 20 is ignored
   ```
-}
+-->
 
 ```
 Grammar of a wildcard expression
@@ -1615,12 +1615,12 @@ pass the key path to the `subscript(keyPath:)` subscript,
 which is available on all types.
 For example:
 
-@Comment {
+<!--
   The subscript name subscript(keyPath:) above is a little odd,
   but it matches what would be displayed on the web.
   There isn't actually an extension on Any that implements this subscript;
   it's a special case in the compiler.
-}
+-->
 
 ```swift
 struct SomeStructure {
@@ -1635,7 +1635,7 @@ let value = s[keyPath: pathToProperty]
 ```
 
 
-@Comment {
+<!--
   - test: `keypath-expression`
   
   ```swifttest
@@ -1650,7 +1650,7 @@ let value = s[keyPath: pathToProperty]
   /> value is \(value)
   </ value is 12
   ```
-}
+-->
 
 The *type name* can be omitted
 in contexts where type inference
@@ -1673,7 +1673,7 @@ c.observe(\.someProperty) { object, change in
 ```
 
 
-@Comment {
+<!--
   - test: `keypath-expression-implicit-type-name`
   
   ```swifttest
@@ -1691,12 +1691,12 @@ c.observe(\.someProperty) { object, change in
          // ...
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   Rewrite the above to avoid discarding the function's return value.
   Tracking bug is <rdar://problem/35301593>
-}
+-->
 
 The *path* can refer to `self` to create the identity key path (`\.self`).
 The identity key path refers to a whole instance,
@@ -1711,7 +1711,7 @@ compoundValue[keyPath: \.self] = (a: 10, b: 20)
 ```
 
 
-@Comment {
+<!--
   - test: `keypath-expression-self-keypath`
   
   ```swifttest
@@ -1719,7 +1719,7 @@ compoundValue[keyPath: \.self] = (a: 10, b: 20)
   // Equivalent to compoundValue = (a: 10, b: 20)
   -> compoundValue[keyPath: \.self] = (a: 10, b: 20)
   ```
-}
+-->
 
 The *path* can contain multiple property names,
 separated by periods,
@@ -1745,7 +1745,7 @@ let nestedValue = nested[keyPath: nestedKeyPath]
 ```
 
 
-@Comment {
+<!--
   - test: `keypath-expression`
   
   ```swifttest
@@ -1763,7 +1763,7 @@ let nestedValue = nested[keyPath: nestedKeyPath]
   /> nestedValue is \(nestedValue)
   </ nestedValue is 24
   ```
-}
+-->
 
 The *path* can include subscripts using brackets,
 as long as the subscript's parameter type conforms to the `Hashable` protocol.
@@ -1777,7 +1777,7 @@ let myGreeting = greetings[keyPath: \[String].[1]]
 ```
 
 
-@Comment {
+<!--
   - test: `keypath-expression`
   
   ```swifttest
@@ -1786,14 +1786,14 @@ let myGreeting = greetings[keyPath: \[String].[1]]
   /> myGreeting is '\(myGreeting)'
   </ myGreeting is 'hola'
   ```
-}
+-->
 
-@Comment {
+<!--
   TODO: Update examples here and below to remove type names once
   inference bugs are fixed. The compiler currently gives an error
   that the usage is ambiguous.
   <rdar://problem/34376681> [SR-5865]: Key path expression is "ambiguous without more context"
-}
+-->
 
 The value used in a subscript can be a named value or a literal.
 Values are captured in key paths using value semantics.
@@ -1825,7 +1825,7 @@ print(fn(greetings))
 ```
 
 
-@Comment {
+<!--
   - test: `keypath-expression`
   
   ```swifttest
@@ -1847,7 +1847,7 @@ print(fn(greetings))
   -> print(fn(greetings))
   <- 안녕
   ```
-}
+-->
 
 The *path* can use optional chaining and forced unwrapping.
 This code uses optional chaining in a key path
@@ -1865,7 +1865,7 @@ print(count as Any)
 ```
 
 
-@Comment {
+<!--
   - test: `keypath-expression`
   
   ```swifttest
@@ -1878,12 +1878,12 @@ print(count as Any)
   -> print(count as Any)
   <- Optional(5)
   ```
-}
+-->
 
-@Comment {
+<!--
   The test above is failing, which appears to be a compiler bug.
   <rdar://problem/58484319> Swift 5.2 regression in keypaths
-}
+-->
 
 You can mix and match components of key paths to access values
 that are deeply nested within a type.
@@ -1907,7 +1907,7 @@ print(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count.bitWidth
 ```
 
 
-@Comment {
+<!--
   - test: `keypath-expression`
   
   ```swifttest
@@ -1923,7 +1923,7 @@ print(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count.bitWidth
   -> print(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count.bitWidth])
   <- 64
   ```
-}
+-->
 
 You can use a key path expression
 in contexts where you would normally provide a function or closure.
@@ -1950,7 +1950,7 @@ let descriptions2 = toDoList.filter { $0.completed }.map { $0.description }
 ```
 
 
-@Comment {
+<!--
   - test: `keypath-expression`
   
   ```swifttest
@@ -1969,13 +1969,13 @@ let descriptions2 = toDoList.filter { $0.completed }.map { $0.description }
   -> let descriptions2 = toDoList.filter { $0.completed }.map { $0.description }
   >> assert(descriptions == descriptions2)
   ```
-}
+-->
 
-@Comment {
+<!--
   REFERENCE
   The to-do list above draws from the lyrics of the song
   "The Pirates Who Don't Do Anything".
-}
+-->
 
 Any side effects of a key path expression
 are evaluated only at the point where the expression is evaluated.
@@ -1998,7 +1998,7 @@ let someTask = toDoList[keyPath: taskKeyPath]
 ```
 
 
-@Comment {
+<!--
   - test: `keypath-expression`
   
   ```swifttest
@@ -2015,7 +2015,7 @@ let someTask = toDoList[keyPath: taskKeyPath]
   // Using taskKeyPath doesn't call makeIndex() again.
   -> let someTask = toDoList[keyPath: taskKeyPath]
   ```
-}
+-->
 
 For more information about using key paths
 in code that interacts with Objective-C APIs,
@@ -2071,7 +2071,7 @@ let selectorForPropertyGetter = #selector(getter: SomeClass.property)
 ```
 
 
-@Comment {
+<!--
   - test: `selector-expression`
   
   ```swifttest
@@ -2089,7 +2089,7 @@ let selectorForPropertyGetter = #selector(getter: SomeClass.property)
   -> let selectorForMethod = #selector(SomeClass.doSomething(_:))
   -> let selectorForPropertyGetter = #selector(getter: SomeClass.property)
   ```
-}
+-->
 
 When creating a selector for a property's getter,
 the *property name* can be a reference to a variable or constant property.
@@ -2110,7 +2110,7 @@ let anotherSelector = #selector(SomeClass.doSomething(_:) as (SomeClass) -> (Str
 ```
 
 
-@Comment {
+<!--
   - test: `selector-expression-with-as`
   
   ```swifttest
@@ -2129,7 +2129,7 @@ let anotherSelector = #selector(SomeClass.doSomething(_:) as (SomeClass) -> (Str
      }
   -> let anotherSelector = #selector(SomeClass.doSomething(_:) as (SomeClass) -> (String) -> Void)
   ```
-}
+-->
 
 Because a selector is created at compile time, not at runtime,
 the compiler can check that a method or property exists
@@ -2151,12 +2151,12 @@ selector-expression --> ``#selector`` ``(`` ``setter:`` expression  ``)``
 ```
 
 
-@Comment {
+<!--
   Note: The parser does allow an arbitrary expression inside #selector(), not
   just a member name.  For example, see changes in Swift commit ef60d7289d in
   lib/Sema/CSApply.cpp -- there's explicit code to look through parens and
   optional binding.
-}
+-->
 
 ### Key-Path String Expression
 
@@ -2193,7 +2193,7 @@ if let value = c.value(forKey: keyPath) {
 ```
 
 
-@Comment {
+<!--
   - test: `keypath-string-expression`
   
   ```swifttest
@@ -2213,7 +2213,7 @@ if let value = c.value(forKey: keyPath) {
   -> }
   <- 12
   ```
-}
+-->
 
 When you use a key-path string expression within a class,
 you can refer to a property of that class
@@ -2230,7 +2230,7 @@ print(keyPath == c.getSomeKeyPath())
 ```
 
 
-@Comment {
+<!--
   - test: `keypath-string-expression`
   
   ```swifttest
@@ -2242,7 +2242,7 @@ print(keyPath == c.getSomeKeyPath())
   -> print(keyPath == c.getSomeKeyPath())
   <- true
   ```
-}
+-->
 
 Because the key path string is created at compile time, not at runtime,
 the compiler can check that the property exists
@@ -2294,10 +2294,10 @@ postfix-expression --> optional-chaining-expression
 
 ### Function Call Expression
 
-@Comment {
+<!--
   TODO: After we rewrite function decls,
   revisit this section to make sure that the names for things match.
-}
+-->
 
 A *function call expression* consists of a function name
 followed by a comma-separated list of the function's arguments in parentheses.
@@ -2340,7 +2340,7 @@ anotherFunction(x: x) { $0 == 13 } g: { print(99) }
 ```
 
 
-@Comment {
+<!--
   - test: `trailing-closure`
   
   ```swifttest
@@ -2369,12 +2369,12 @@ anotherFunction(x: x) { $0 == 13 } g: { print(99) }
   << 99
   >> assert(r3 == false)
   ```
-}
+-->
 
-@Comment {
+<!--
   Rewrite the above to avoid bare expressions.
   Tracking bug is <rdar://problem/35301593>
-}
+-->
 
 If the trailing closure is the function's only argument,
 you can omit the parentheses.
@@ -2386,7 +2386,7 @@ myData.someMethod { $0 == 13 }
 ```
 
 
-@Comment {
+<!--
   - test: `no-paren-trailing-closure`
   
   ```swifttest
@@ -2405,12 +2405,12 @@ myData.someMethod { $0 == 13 }
   -> myData.someMethod { $0 == 13 }
   >> assert(r1 == false)
   ```
-}
+-->
 
-@Comment {
+<!--
   Rewrite the above to avoid bare expressions.
   Tracking bug is <rdar://problem/35301593>
-}
+-->
 
 To include the trailing closures in the arguments,
 the compiler examines the function's parameters from left to right as follows:
@@ -2454,7 +2454,7 @@ the closure is wrapped as needed.
 For example, if the parameter's type is an optional type,
 the closure is wrapped in `Optional` automatically.
 
-@Comment {
+<!--
   - test: `when-can-you-use-trailing-closure`
   
   ```swifttest
@@ -2477,7 +2477,7 @@ the closure is wrapped in `Optional` automatically.
   >> f5(x: 50) { $0 ? 5 : 500 }
   << 55
   ```
-}
+-->
 
 To ease migration of code from versions of Swift prior to 5.3 ---
 which performed this matching from right to left ---
@@ -2502,7 +2502,7 @@ someFunction { return $0 } secondClosure: { return $0 }  // Prints "10 20"
 ```
 
 
-@Comment {
+<!--
   - test: `trailing-closure-scanning-direction`
   
   ```swifttest
@@ -2528,17 +2528,17 @@ someFunction { return $0 } secondClosure: { return $0 }  // Prints "10 20"
   -> someFunction { return $0 } secondClosure: { return $0 }  // Prints "10 20"
   << 10 20
   ```
-}
+-->
 
 In the example above,
 the function call marked "Ambiguous"
 prints "- 120" and produces a compiler warning on Swift 5.3.
 A future version of Swift will print “110 -”.
 
-@Comment {
+<!--
   Smart quotes on the line above are needed
   because the regex heuristics gets the close quote wrong.
-}
+-->
 
 A class, structure, or enumeration type
 can enable syntactic sugar for function call syntax
@@ -2572,7 +2572,7 @@ withUnsafePointer(to: myNumber) { unsafeFunction(pointer: $0) }
 ```
 
 
-@Comment {
+<!--
   - test: `inout-unsafe-pointer`
   
   ```swifttest
@@ -2587,7 +2587,7 @@ withUnsafePointer(to: myNumber) { unsafeFunction(pointer: $0) }
   << 1234
   << 1234
   ```
-}
+-->
 
 A pointer that's created by these implicit conversions
 is valid only for the duration of the function call.
@@ -2611,7 +2611,7 @@ especially when the function takes several pointer arguments.
 However, when calling functions from other Swift code,
 avoid using `&` instead of using the unsafe APIs explicitly.
 
-@Comment {
+<!--
   - test: `implicit-conversion-to-pointer`
   
   ```swifttest
@@ -2653,7 +2653,7 @@ avoid using `&` instead of using the unsafe APIs explicitly.
   !! takesUnsafeMutablePointerCChar(p: string)
   !!                                   ^
   ```
-}
+-->
 
 ```
 Grammar of a function call expression
@@ -2698,7 +2698,7 @@ class SomeSubClass: SomeSuperClass {
 ```
 
 
-@Comment {
+<!--
   - test: `init-call-superclass`
   
   ```swifttest
@@ -2710,7 +2710,7 @@ class SomeSubClass: SomeSuperClass {
   ->     }
   -> }
   ```
-}
+-->
 
 Like a function, an initializer can be used as a value.
 For example:
@@ -2724,7 +2724,7 @@ print(oneTwoThree)
 ```
 
 
-@Comment {
+<!--
   - test: `init-as-value`
   
   ```swifttest
@@ -2734,7 +2734,7 @@ print(oneTwoThree)
   -> print(oneTwoThree)
   <- 123
   ```
-}
+-->
 
 If you specify a type by name,
 you can access the type's initializer without using an initializer expression.
@@ -2749,7 +2749,7 @@ let s4 = type(of: someValue)(data: 5)       // Error
 ```
 
 
-@Comment {
+<!--
   - test: `explicit-implicit-init`
   
   ```swifttest
@@ -2767,7 +2767,7 @@ let s4 = type(of: someValue)(data: 5)       // Error
   !!                              ^
   !!                              .init
   ```
-}
+-->
 
 ```
 Grammar of an initializer expression
@@ -2802,7 +2802,7 @@ let y = c.someProperty  // Member access
 ```
 
 
-@Comment {
+<!--
   - test: `explicitMemberExpression`
   
   ```swifttest
@@ -2812,7 +2812,7 @@ let y = c.someProperty  // Member access
   -> let c = SomeClass()
   -> let y = c.someProperty  // Member access
   ```
-}
+-->
 
 The members of a tuple
 are implicitly named using integers in the order they appear,
@@ -2826,7 +2826,7 @@ t.0 = t.1
 ```
 
 
-@Comment {
+<!--
   - test: `explicit-member-expression`
   
   ```swifttest
@@ -2834,7 +2834,7 @@ t.0 = t.1
   -> t.0 = t.1
   -> // Now t is (20, 20, 30)
   ```
-}
+-->
 
 The members of a module access
 the top-level declarations of that module.
@@ -2870,7 +2870,7 @@ let d: (Int, Bool) -> Void  = instance.overloadedMethod(x:y:)  // Unambiguous
 ```
 
 
-@Comment {
+<!--
   - test: `function-with-argument-names`
   
   ```swifttest
@@ -2916,7 +2916,7 @@ let d: (Int, Bool) -> Void  = instance.overloadedMethod(x:y:)  // Unambiguous
   !!                   ^
   -> let d: (Int, Bool) -> Void  = instance.overloadedMethod(x:y:)  // Unambiguous
   ```
-}
+-->
 
 If a period appears at the beginning of a line,
 it's understood as part of an explicit member expression,
@@ -2932,7 +2932,7 @@ let x = [10, 3, 20, 15, 4]
 ```
 
 
-@Comment {
+<!--
   - test: `period-at-start-of-line`
   
   ```swifttest
@@ -2943,7 +2943,7 @@ let x = [10, 3, 20, 15, 4]
   >> print(x)
   << [1000, 1500, 2000]
   ```
-}
+-->
 
 You can combine this multiline chained syntax
 with compiler control statements
@@ -2961,7 +2961,7 @@ let numbers = [10, 20, 33, 43, 50]
 ```
 
 
-@Comment {
+<!--
   - test: `pound-if-inside-postfix-expression`
   
   ```swifttest
@@ -2974,16 +2974,16 @@ let numbers = [10, 20, 33, 43, 50]
   >> print(numbers)
   << [33, 43, 50]
   ```
-}
+-->
 
-@Comment {
+<!--
   The indentation gets lost for the .filter lines above
   even if I start them with -> instead of three spaces
   because that's how swift-format re-indents them.
   This is probably not the same issue as
   <rdar://problem/32463195> for multiline string literals,
   but they're likely related.
-}
+-->
 
 Between `#if`, `#endif`, and other compilation directives,
 the conditional compilation block can contain
@@ -3003,7 +3003,7 @@ the branch for the `#if` compilation directive
 must contain at least one expression.
 The other branches can be empty.
 
-@Comment {
+<!--
   - test: `pound-if-empty-if-not-allowed`
   
   ```swifttest
@@ -3016,9 +3016,9 @@ The other branches can be empty.
   !! .filter { $0 > 25 }
   !! ~^~~~~~
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `pound-if-else-can-be-empty`
   
   ```swifttest
@@ -3030,9 +3030,9 @@ The other branches can be empty.
   >> print(numbers)
   << [10, 20, 33, 43, 50]
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `pound-if-cant-use-binary-operators`
   
   ```swifttest
@@ -3045,7 +3045,7 @@ The other branches can be empty.
   !! ^~
   !!-
   ```
-}
+-->
 
 ```
 Grammar of an explicit member expression
@@ -3060,15 +3060,15 @@ argument-name --> identifier ``:``
 ```
 
 
-@Comment {
+<!--
   The grammar for method-name doesn't include the following:
-      method-name --> identifier argument-names-OPT
+      method-name -> identifier argument-names-OPT
   because the "postfix-expression . identifier" line above already covers that case.
-}
+-->
 
-@Comment {
+<!--
   See grammar for initializer-expression for the related "argument name" production there.
-}
+-->
 
 ### Postfix Self Expression
 
@@ -3114,7 +3114,7 @@ with the *index expressions* passed as the subscript parameters.
 To set its value,
 the subscript setter is called in the same way.
 
-@Comment {
+<!--
   TR: Confirm that indexing on
   a comma-separated list of expressions
   is intentional, not just a side effect.
@@ -3126,7 +3126,7 @@ the subscript setter is called in the same way.
   // t : Test = <Test instance>
   (swift) t[1, 2]
   // r0 : Int = 12
-}
+-->
 
 For information about subscript declarations,
 see <doc:Declarations#Protocol-Subscript-Declaration>.
@@ -3138,7 +3138,7 @@ subscript-expression --> postfix-expression ``[`` function-call-argument-list ``
 ```
 
 
-@Comment {
+<!--
   - test: `subscripts-can-take-operators`
   
   ```swifttest
@@ -3152,7 +3152,7 @@ subscript-expression --> postfix-expression ``[`` function-call-argument-list ``
   >> let s = S(x: 10, y: 20)
   >> assert(s[+] == 30)
   ```
-}
+-->
 
 ### Forced-Value Expression
 
@@ -3186,7 +3186,7 @@ someDictionary["a"]![0] = 100
 ```
 
 
-@Comment {
+<!--
   - test: `optional-as-lvalue`
   
   ```swifttest
@@ -3200,7 +3200,7 @@ someDictionary["a"]![0] = 100
   /> someDictionary is now \(someDictionary)
   </ someDictionary is now ["a": [100, 2, 3], "b": [10, 20]]
   ```
-}
+-->
 
 ```
 Grammar of a forced-value expression
@@ -3250,7 +3250,7 @@ var result: Bool? = c?.property.performAction()
 ```
 
 
-@Comment {
+<!--
   - test: `optional-chaining`
   
   ```swifttest
@@ -3260,7 +3260,7 @@ var result: Bool? = c?.property.performAction()
   -> var result: Bool? = c?.property.performAction()
   >> assert(result == nil)
   ```
-}
+-->
 
 The following example shows the behavior
 of the example above
@@ -3274,7 +3274,7 @@ if let unwrappedC = c {
 ```
 
 
-@Comment {
+<!--
   - test: `optional-chaining-alt`
   
   ```swifttest
@@ -3286,7 +3286,7 @@ if let unwrappedC = c {
         result = unwrappedC.property.performAction()
      }
   ```
-}
+-->
 
 The unwrapped value of an optional-chaining expression can be modified,
 either by mutating the value itself,
@@ -3312,7 +3312,7 @@ someDictionary["a"]?[0] = someFunctionWithSideEffects()
 ```
 
 
-@Comment {
+<!--
   - test: `optional-chaining-as-lvalue`
   
   ```swifttest
@@ -3332,7 +3332,7 @@ someDictionary["a"]?[0] = someFunctionWithSideEffects()
   /> someDictionary is now \(someDictionary)
   </ someDictionary is now ["a": [42, 2, 3], "b": [10, 20]]
   ```
-}
+-->
 
 ```
 Grammar of an optional-chaining expression
@@ -3342,7 +3342,7 @@ optional-chaining-expression --> postfix-expression ``?``
 
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -3350,4 +3350,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/GenericParametersAndArguments.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/GenericParametersAndArguments.md
@@ -11,10 +11,10 @@ created or a generic function or initializer is called.
 
 For an overview of generics in Swift, see <doc:Generics>.
 
-@Comment {
+<!--
   NOTE: Generic types are sometimes referred to as :newTerm:`parameterized types`
   because they're declared with one or more type parameters.
-}
+-->
 
 ## Generic Parameter Clause
 
@@ -60,7 +60,7 @@ func simpleMax<T: Comparable>(_ x: T, _ y: T) -> T {
 ```
 
 
-@Comment {
+<!--
   - test: `generic-params`
   
   ```swifttest
@@ -71,7 +71,7 @@ func simpleMax<T: Comparable>(_ x: T, _ y: T) -> T {
         return x
      }
   ```
-}
+-->
 
 Because `Int` and `Double`, for example, both conform to the `Comparable` protocol,
 this function accepts arguments of either type. In contrast with generic types, you don't
@@ -85,7 +85,7 @@ simpleMax(3.14159, 2.71828) // T is inferred to be Double
 ```
 
 
-@Comment {
+<!--
   - test: `generic-params`
   
   ```swifttest
@@ -96,12 +96,12 @@ simpleMax(3.14159, 2.71828) // T is inferred to be Double
   -> simpleMax(3.14159, 2.71828) // T is inferred to be Double
   >> assert(r1 == 3.14159)
   ```
-}
+-->
 
-@Comment {
+<!--
   Rewrite the above to avoid bare expressions.
   Tracking bug is <rdar://problem/35301593>
-}
+-->
 
 ### Generic Where Clauses
 
@@ -163,7 +163,7 @@ extension Collection where Element: SomeProtocol {
 ```
 
 
-@Comment {
+<!--
   - test: `contextual-where-clauses-combine`
   
   ```swifttest
@@ -177,9 +177,9 @@ extension Collection where Element: SomeProtocol {
   >> print( [1, 2, 3].startsWithZero() )
   << false
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `contextual-where-clause-combine-err`
   
   ```swifttest
@@ -198,7 +198,7 @@ extension Collection where Element: SomeProtocol {
   !! func returnTrue() -> Bool where Element == Int {
   !!                                            ^
   ```
-}
+-->
 
 You can overload a generic function or initializer by providing different
 constraints, requirements, or both on the type parameters.
@@ -229,11 +229,11 @@ same-type-requirement --> type-identifier ``==`` type
 ```
 
 
-@Comment {
+<!--
   NOTE: A conformance requirement can only have one type after the colon,
   otherwise, you'd have a syntactic ambiguity
   (a comma-separated list types inside of a comma-separated list of requirements).
-}
+-->
 
 ## Generic Argument Clause
 
@@ -261,9 +261,9 @@ struct Dictionary<Key: Hashable, Value>: Collection, ExpressibleByDictionaryLite
 ```
 
 
-@Comment {
+<!--
   TODO: How are we supposed to wrap code lines like the above?
-}
+-->
 
 The specialized version of the generic `Dictionary` type, `Dictionary<String, Int>`
 is formed by replacing the generic parameters `Key: Hashable` and `Value`
@@ -284,13 +284,13 @@ let arrayOfArrays: Array<Array<Int>> = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 ```
 
 
-@Comment {
+<!--
   - test: `array-of-arrays`
   
   ```swifttest
   -> let arrayOfArrays: Array<Array<Int>> = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
   ```
-}
+-->
 
 As mentioned in <doc:GenericParametersAndArguments#Generic-Parameter-Clause>,
 you don't use a generic argument clause to specify the type arguments
@@ -306,7 +306,7 @@ generic-argument --> type
 
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -314,4 +314,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/LexicalStructure.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/LexicalStructure.md
@@ -29,11 +29,11 @@ vertical tab (U+000B),
 form feed (U+000C)
 and null (U+0000).
 
-@Comment {
+<!--
   Whitespace characters are listed roughly from
   most salient/common to least,
   not in order of Unicode scalar value.
-}
+-->
 
 Comments are treated as whitespace by the compiler.
 Single line comments begin with `//`
@@ -114,11 +114,11 @@ but you can't declare identifiers with that prefix.
 For more information, see the <doc:Attributes#propertyWrapper> section
 of the <doc:Attributes> chapter.
 
-@Comment {
+<!--
   The cross reference above includes both the section and chapter because,
   even though "propertyWrapper" is the title of the section,
   the section name isn't title case so it doesn't necessarily look like a title.
-}
+-->
 
 ```
 Grammar of an identifier
@@ -173,7 +173,7 @@ for example, `self`, `Type`, and `Protocol`
 have special meaning in an explicit member expression,
 so they must be escaped with backticks in that context.
 
-@Comment {
+<!--
   - test: `keywords-without-backticks`
   
   ```swifttest
@@ -181,9 +181,9 @@ so they must be escaped with backticks in that context.
         print(x+y)
      }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `var-requires-backticks`
   
   ```swifttest
@@ -194,9 +194,9 @@ so they must be escaped with backticks in that context.
   !!        ^~~
   !!        `var`
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `let-requires-backticks`
   
   ```swifttest
@@ -207,9 +207,9 @@ so they must be escaped with backticks in that context.
   !!        ^~~
   !!        `let`
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `inout-requires-backticks`
   
   ```swifttest
@@ -220,16 +220,16 @@ so they must be escaped with backticks in that context.
   !!        ^~~~~
   !!                 inout
   ```
-}
+-->
 
-@Comment {
+<!--
   NOTE: This list of language keywords and punctuation
   is derived from the file "swift/include/swift/Parse/Tokens.def"
   and from "utils/gyb_syntax_support/Token.py",
   which generates the TokenKinds.def file.
   
   Last updated at Swift commit 2f1987567f5, for Swift 5.4.
-}
+-->
 
 - Keywords used in declarations:
   `associatedtype`,
@@ -257,9 +257,9 @@ so they must be escaped with backticks in that context.
   `typealias`,
   and `var`.
 
-@Comment {
+<!--
   Token.py doesn't include 'open' but DeclNodes.py does.
-}
+-->
 
 - Keywords used in statements:
   `break`,
@@ -321,23 +321,23 @@ so they must be escaped with backticks in that context.
   `#sourceLocation`,
   and `#warning`.
 
-@Comment {
+<!--
   Token.py includes #assert,
   which looks like it's part of an experimental feature
   based on the pound_assert_disabled diagnostic's error message:
   #assert is an experimental feature that is currently disabled
-}
+-->
 
-@Comment {
+<!--
   Token.py includes #fileID,
   which looks like it's part of a future feature related to
   -enable-experimental-concise-pound-file (see also Swift commit 0e569f5d9e66)
-}
+-->
 
-@Comment {
+<!--
   Token.py includes 'yield' as a keyword,
   which looks like it's related to a future feature around memory ownership.
-}
+-->
 
 - Keywords reserved in particular contexts:
   `associativity`,
@@ -370,12 +370,12 @@ so they must be escaped with backticks in that context.
   Outside the context in which they appear in the grammar,
   they can be used as identifiers.
 
-@Comment {
+<!--
   NOTE: The list of context-sensitive keywords above
   is derived from the file "swift/include/swift/AST/Attr.def"
   where they're marked CONTEXTUAL_SIMPLE_DECL_ATTR.
   However, not all context-sensitive keywords appear there;
-}
+-->
 
 The following tokens are reserved as punctuation
 and can't be used as custom operators:
@@ -400,7 +400,7 @@ true             // Boolean literal
 ```
 
 
-@Comment {
+<!--
   - test: `basic-literals`
   
   ```swifttest
@@ -420,12 +420,12 @@ true             // Boolean literal
   << String
   << Bool
   ```
-}
+-->
 
-@Comment {
+<!--
   Refactor the above if possible to avoid using bare expressions.
   Tracking bug is <rdar://problem/35301593>
-}
+-->
 
 A literal doesn't have a type on its own.
 Instead, a literal is parsed as having infinite precision and Swift's type inference
@@ -458,11 +458,11 @@ Also, `Int8` conforms to the `ExpressibleByIntegerLiteral` protocol,
 and therefore it can be used in the type annotation for the integer literal `42`
 in the declaration `let x: Int8 = 42`.
 
-@Comment {
+<!--
   The list of ExpressibleBy... protocols above also appears in Declarations_EnumerationsWithRawCaseValues.
   ExpressibleByNilLiteral is left out of the list because conformance to it isn't recommended.
   There is no protocol for regex literal in the list because the stdlib intentionally omits that.
-}
+-->
 
 ```
 Grammar of a literal
@@ -504,22 +504,22 @@ The Swift standard library also defines types for various sizes of
 signed and unsigned integers,
 as described in <doc:TheBasics#Integers>.
 
-@Comment {
+<!--
   TR: The prose assumes underscores only belong between digits.
   Is there a reason to allow them at the end of a literal?
   Java and Ruby both require underscores to be between digits.
   Also, are adjacent underscores meant to be allowed, like 5__000?
   (REPL supports them as of swift-1.21 but it seems odd.)
-}
+-->
 
-@Comment {
+<!--
   NOTE: Updated the syntax-grammar to reflect [Contributor 7746]'s comment in
   <rdar://problem/15181997> Teach the compiler about a concept of negative integer literals.
   This feels very strange from a grammatical point of view.
   Update: This is a parser hack, not a lexer hack. Therefore,
   it's not part of the grammar for integer literal, contrary to [Contributor 2562]'s claim.
   (Doug confirmed this, 4/2/2014.)
-}
+-->
 
 ```
 Grammar of an integer literal
@@ -698,13 +698,13 @@ using the following escape sequences:
   where *n* is a hexadecimal number
   that has one to eight digits
 
-@Comment {
+<!--
   The behavior of \n and \r isn't the same as C.
   We specify exactly what those escapes mean.
   The behavior on C is platform dependent --
   in text mode, \n maps to the platform's line separator
   which could be CR or LF or CRLF.
-}
+-->
 
 The value of an expression can be inserted into a string literal
 by placing the expression in parentheses after a backslash (`\`).
@@ -723,7 +723,7 @@ let x = 3; "1 2 \(x)"
 ```
 
 
-@Comment {
+<!--
   - test: `string-literals`
   
   ```swifttest
@@ -744,12 +744,12 @@ let x = 3; "1 2 \(x)"
   !! let x = 3; "1 2 \(x)"
   !!            ^~~~~~~~~~
   ```
-}
+-->
 
-@Comment {
+<!--
   Refactor the above if possible to avoid using bare expressions.
   Tracking bug is <rdar://problem/35301593>
-}
+-->
 
 A string delimited by extended delimiters is a sequence of characters
 surrounded by quotation marks and a balanced set of one or more number signs (`#`).
@@ -787,7 +787,7 @@ print(string == escaped)
 ```
 
 
-@Comment {
+<!--
   - test: `extended-string-delimiters`
   
   ```swifttest
@@ -798,13 +798,13 @@ print(string == escaped)
   -> print(string == escaped)
   <- true
   ```
-}
+-->
 
 If you use more than one number sign to form
 a string delimited by extended delimiters,
 don't place whitespace in between the number signs:
 
-@Comment {
+<!--
   - test: `extended-string-delimiters`
   
   ```swifttest
@@ -812,7 +812,7 @@ don't place whitespace in between the number signs:
   << Line 1
   << Line 2
   ```
-}
+-->
 
 ```swift
 print(###"Line 1\###nLine 2"###) // OK
@@ -820,7 +820,7 @@ print(# # #"Line 1\# # #nLine 2"# # #) // Error
 ```
 
 
-@Comment {
+<!--
   - test: `extended-string-delimiters-err`
   
   ```swifttest
@@ -833,7 +833,7 @@ print(# # #"Line 1\# # #nLine 2"# # #) // Error
   !! print(# # #"Line 1\# # #nLine 2"# # #) // Error
   !! ^
   ```
-}
+-->
 
 Multiline string literals that you create using extended delimiters
 have the same indentation requirements as regular multiline string literals.
@@ -855,14 +855,14 @@ let textB = "Hello world"
 ```
 
 
-@Comment {
+<!--
   - test: `concatenated-strings`
   
   ```swifttest
   -> let textA = "Hello " + "world"
   -> let textB = "Hello world"
   ```
-}
+-->
 
 ```
 Grammar of a string literal
@@ -906,13 +906,13 @@ escaped-newline -->  escape-sequence inline-spaces-OPT line-break
 ```
 
 
-@Comment {
+<!--
   Quoted text resolves to a sequence of escaped characters by way of
   the quoted-text rule which allows repetition; no need to allow
   repetition in the quoted-text/escaped-character rule too.
-}
+-->
 
-@Comment {
+<!--
   Now that single quotes are gone, we don't have a character literal.
   Because we may one bring them back, here's the old grammar for them:
   
@@ -921,7 +921,7 @@ escaped-newline -->  escape-sequence inline-spaces-OPT line-break
   character-literal --> ``'`` quoted-character ``'``
   quoted-character --> escaped-character
   quoted-character --> Any Unicode scalar value except ``'``, ``\``, U+000A, or U+000D
-}
+-->
 
 ### Regular Expression Literals
 
@@ -950,7 +950,7 @@ For example,
 `/\(/` matches a single left parenthesis
 and `/\d/` matches a single digit.
 
-@Comment {
+<!--
   OUTLINE
   
   Doc comments on Regex struct don't have more syntax details,
@@ -972,7 +972,7 @@ and `/\d/` matches a single digit.
   when encountering operator characters containing `/` in an expression position,
   the characters up to the first `/` are split into a prefix operator,
   and regex literal parsing continues as normal.
-}
+-->
 
 A regular expression literal delimited by extended delimiters
 is a sequence of characters surrounded by slashes (`/`)
@@ -1000,11 +1000,11 @@ Inside a multiline regular expression literal,
 the extended regular expression syntax is enabled by default ---
 specifically, whitespace is ignored and comments are allowed.
 
-@Comment {
+<!--
   TODO As details about the multiline syntax shake out during SE review,
   like indentation and whitespace,
   add them above or spin out a separate paragraph.
-}
+-->
 
 If you use more than one number sign to form
 a regular expression literal delimited by extended delimiters,
@@ -1016,14 +1016,14 @@ let regex2 = # #/abc/# #     // Error
 ```
 
 
-@Comment {
+<!--
   - test: `extended-regex-delimiters-err`
   
   ```swifttest
   -> let regex1 = ##/abc/##       // OK
   -> let regex2 = # #/abc/# #     // Error
   ```
-}
+-->
 
 If you need to make an empty regular expression literal,
 you must use the extended delimiter syntax.
@@ -1067,7 +1067,7 @@ it can't contain a dot elsewhere.
 For example, `+.+` is treated as
 the `+` operator followed by the `.+` operator.
 
-@Comment {
+<!--
   - test: `dot-operator-must-start-with-dot`
   
   ```swifttest
@@ -1085,14 +1085,14 @@ the `+` operator followed by the `.+` operator.
   >> infix operator .+
   >> infix operator .+.
   ```
-}
+-->
 
 Although you can define custom operators that contain a question mark (`?`),
 they can't consist of a single question mark character only.
 Additionally, although operators can contain an exclamation point (`!`),
 postfix operators can't begin with either a question mark or an exclamation point.
 
-@Comment {
+<!--
   - test: `postfix-operators-dont-need-unique-prefix`
   
   ```swifttest
@@ -1107,9 +1107,9 @@ postfix operators can't begin with either a question mark or an exclamation poin
   >> print(n+*)
   << 500
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `postfix-operator-cant-start-with-question-mark`
   
   ```swifttest
@@ -1128,7 +1128,7 @@ postfix operators can't begin with either a question mark or an exclamation poin
   !! print(1?+)
   !!         ^
   ```
-}
+-->
 
 > Note: The tokens `=`, `->`, `//`, `/*`, `*/`, `.`,
 > the prefix operators `<`, `&`, and `?`,
@@ -1180,7 +1180,7 @@ to disambiguate between the closing `>` characters in constructs like
 In this example, the closing `>` characters aren't treated as a single token
 that may then be misinterpreted as a bit shift `>>` operator.
 
-@Comment {
+<!--
   NOTE: Once the parser sees a < it goes into a pre-scanning lookahead mode.  It
   matches < and > and looks at what token comes after the > -- if it's a . or
   a ( it treats the <...> as a generic parameter list, otherwise it treats
@@ -1191,18 +1191,18 @@ that may then be misinterpreted as a bit shift `>>` operator.
   
   We call out the > > vs >> because
   C++ typically needs whitespace to resolve the ambiguity.
-}
+-->
 
 To learn how to define new, custom operators,
 see <doc:AdvancedOperators#Custom-Operators> and <doc:Declarations#Operator-Declaration>.
 To learn how to overload existing operators,
 see <doc:AdvancedOperators#Operator-Methods>.
 
-@Comment {
+<!--
   NOTE: The ? is a reserved punctuation.  Optional-chaining (foo?.bar) is actually a
   monad -- the ? is actually a monadic bind operator.  It is like a burrito.
   The current list of reserved punctuation is in Tokens.def.
-}
+-->
 
 ```
 Grammar of operators
@@ -1249,7 +1249,7 @@ postfix-operator --> operator
 
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -1257,4 +1257,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/LexicalStructure.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/LexicalStructure.md
@@ -916,11 +916,11 @@ escaped-newline -->  escape-sequence inline-spaces-OPT line-break
   Now that single quotes are gone, we don't have a character literal.
   Because we may one bring them back, here's the old grammar for them:
   
-  textual-literal --> character-literal | string-literal
+  textual-literal -> character-literal | string-literal
   
-  character-literal --> ``'`` quoted-character ``'``
-  quoted-character --> escaped-character
-  quoted-character --> Any Unicode scalar value except ``'``, ``\``, U+000A, or U+000D
+  character-literal -> ``'`` quoted-character ``'``
+  quoted-character -> escaped-character
+  quoted-character -> Any Unicode scalar value except ``'``, ``\``, U+000A, or U+000D
 -->
 
 ### Regular Expression Literals

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Patterns.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Patterns.md
@@ -59,7 +59,7 @@ for _ in 1...3 {
 ```
 
 
-@Comment {
+<!--
   - test: `wildcard-pattern`
   
   ```swifttest
@@ -67,7 +67,7 @@ for _ in 1...3 {
         // Do something three times.
      }
   ```
-}
+-->
 
 ```
 Grammar of a wildcard pattern
@@ -88,13 +88,13 @@ let someValue = 42
 ```
 
 
-@Comment {
+<!--
   - test: `identifier-pattern`
   
   ```swifttest
   -> let someValue = 42
   ```
-}
+-->
 
 When the match succeeds, the value `42` is bound (assigned)
 to the constant name `someValue`.
@@ -133,7 +133,7 @@ switch point {
 ```
 
 
-@Comment {
+<!--
   - test: `value-binding-pattern`
   
   ```swifttest
@@ -145,7 +145,7 @@ switch point {
      }
   <- The point is at (3, 2).
   ```
-}
+-->
 
 In the example above, `let` distributes to each identifier pattern in the
 tuple pattern `(x, y)`. Because of this behavior, the `switch` cases
@@ -158,13 +158,13 @@ value-binding-pattern --> ``var`` pattern | ``let`` pattern
 ```
 
 
-@Comment {
+<!--
   NOTE: We chose to call this "value-binding pattern"
   instead of "variable pattern",
   because it's a pattern that binds values to either variables or constants,
   not a pattern that varies.
   "Variable pattern" is ambiguous between those two meanings.
-}
+-->
 
 ## Tuple Pattern
 
@@ -193,7 +193,7 @@ for (x, 0) in points {
 ```
 
 
-@Comment {
+<!--
   - test: `tuple-pattern`
   
   ```swifttest
@@ -207,17 +207,17 @@ for (x, 0) in points {
   !! for (x, 0) in points {
   !!         ^
   ```
-}
+-->
 
 The parentheses around a tuple pattern that contains a single element have no effect.
 The pattern matches values of that single element's type. For example, the following are
 equivalent:
 
-@Comment {
+<!--
   This test needs to be compiled.
   The error message in the REPL is unpredictable as of
   Swift version 1.1 (swift-600.0.54.20)
-}
+-->
 
 ```swift
 let a = 2        // a: Int = 2
@@ -226,7 +226,7 @@ let (a): Int = 2 // a: Int = 2
 ```
 
 
-@Comment {
+<!--
   - test: `single-element-tuple-pattern`
   
   ```swifttest
@@ -246,7 +246,7 @@ let (a): Int = 2 // a: Int = 2
   !! let a = 2        // a: Int = 2
   !! ^
   ```
-}
+-->
 
 ```
 Grammar of a tuple pattern
@@ -293,7 +293,7 @@ case nil:
 ```
 
 
-@Comment {
+<!--
   - test: `enum-pattern-matching-optional`
   
   ```swifttest
@@ -309,7 +309,7 @@ case nil:
      }
   <- Turn left
   ```
-}
+-->
 
 ```
 Grammar of an enumeration case pattern
@@ -343,7 +343,7 @@ if case let x? = someOptional {
 ```
 
 
-@Comment {
+<!--
   - test: `optional-pattern`
   
   ```swifttest
@@ -360,7 +360,7 @@ if case let x? = someOptional {
      }
   << 42
   ```
-}
+-->
 
 The optional pattern provides a convenient way to
 iterate over an array of optional values in a `for`-`in` statement,
@@ -378,7 +378,7 @@ for case let number? in arrayOfOptionalInts {
 ```
 
 
-@Comment {
+<!--
   - test: `optional-pattern-for-in`
   
   ```swifttest
@@ -391,7 +391,7 @@ for case let number? in arrayOfOptionalInts {
   </ Found a 3
   </ Found a 5
   ```
-}
+-->
 
 ```
 Grammar of an optional pattern
@@ -466,7 +466,7 @@ switch point {
 ```
 
 
-@Comment {
+<!--
   - test: `expression-pattern`
   
   ```swifttest
@@ -481,7 +481,7 @@ switch point {
      }
   <- (1, 2) is near the origin.
   ```
-}
+-->
 
 You can overload the `~=` operator to provide custom expression matching behavior.
 For example, you can rewrite the above example to compare the `point` expression
@@ -502,7 +502,7 @@ switch point {
 ```
 
 
-@Comment {
+<!--
   - test: `expression-pattern`
   
   ```swifttest
@@ -518,7 +518,7 @@ switch point {
      }
   <- The point is at (1, 2).
   ```
-}
+-->
 
 ```
 Grammar of an expression pattern
@@ -528,7 +528,7 @@ expression-pattern --> expression
 
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -536,4 +536,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Statements.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Statements.md
@@ -38,7 +38,7 @@ statements --> statement statements-OPT
 ```
 
 
-@Comment {
+<!--
   NOTE: Removed semicolon-statement as syntactic category,
   because, according to Doug, they're not really statements.
   For example, you can't have
@@ -47,7 +47,7 @@ statements --> statement statements-OPT
   The semicolon isn't even required for the compiler; we just added
   rules that require them in some places to enforce a certain amount
   of readability.
-}
+-->
 
 ## Loop Statements
 
@@ -363,7 +363,7 @@ case let (x, y) where x == y:
 ```
 
 
-@Comment {
+<!--
   - test: `switch-case-statement`
   
   ```swifttest
@@ -373,7 +373,7 @@ case let (x, y) where x == y:
   >> default: break
   >> }
   ```
-}
+-->
 
 As the above example shows, patterns in a case can also bind constants
 using the `let` keyword (they can also bind variables using the `var` keyword).
@@ -384,10 +384,10 @@ all of the patterns must contain the same constant or variable bindings,
 and each bound variable or constant must have the same type
 in all of the case's patterns.
 
-@Comment {
+<!--
   The discussion above about multi-pattern cases
   matches discussion of multi-pattern catch under Do Statement.
-}
+-->
 
 A `switch` statement can also include a default case, introduced by the `default` keyword.
 The code within a default case is executed only if no other cases match the control expression.
@@ -403,7 +403,7 @@ As a result, if multiple cases contain patterns that evaluate to the same value,
 and thus can match the value of the control expression,
 the program executes only the code within the first matching case in source order.
 
-@Comment {
+<!--
   - test: `switch-case-with-multiple-patterns`
   
   ```swifttest
@@ -414,9 +414,9 @@ the program executes only the code within the first matching case in source orde
   >> }
   << 1
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `switch-case-with-multiple-patterns-err`
   
   ```swifttest
@@ -429,7 +429,7 @@ the program executes only the code within the first matching case in source orde
   !! case (let x, 5), (let x as Any, 1): print(1)
   !!                       ^
   ```
-}
+-->
 
 #### Switch Statements Must Be Exhaustive
 
@@ -494,7 +494,7 @@ case .suppressed:
 ```
 
 
-@Comment {
+<!--
   - test: `unknown-case`
   
   ```swifttest
@@ -511,7 +511,7 @@ case .suppressed:
      }
   <- Generate a default mirror for all ancestor classes.
   ```
-}
+-->
 
 #### Execution Does Not Fall Through Cases Implicitly
 
@@ -549,11 +549,11 @@ switch-else-directive-clause --> else-directive switch-cases-OPT
 ```
 
 
-@Comment {
+<!--
   The grammar above uses attributes-OPT to match what's used
   in all other places where attributes are allowed,
   although as of Swift 4.2 only a single attribute (@unknown) is allowed.
-}
+-->
 
 ## Labeled Statement
 
@@ -572,7 +572,7 @@ For more information and to see examples
 of how to use statement labels,
 see <doc:ControlFlow#Labeled-Statements> in <doc:ControlFlow>.
 
-@Comment {
+<!--
   - test: `backtick-identifier-is-legal-label`
   
   ```swifttest
@@ -586,7 +586,7 @@ see <doc:ControlFlow#Labeled-Statements> in <doc:ControlFlow>.
   -> print(i)
   << 10
   ```
-}
+-->
 
 ```
 Grammar of a labeled statement
@@ -748,10 +748,10 @@ before it's returned to the calling function or method.
 > Note: As described in <doc:Declarations#Failable-Initializers>, a special form of the `return` statement (`return nil`)
 > can be used in a failable initializer to indicate initialization failure.
 
-@Comment {
+<!--
   TODO: Discuss how the conversion takes place and what is allowed to be converted
   in the (yet to be written) chapter on subtyping and type conversions.
-}
+-->
 
 When a `return` statement isn't followed by an expression,
 it can be used only to return from a function or method that doesn't return a value
@@ -839,7 +839,7 @@ f(x: 5)
 ```
 
 
-@Comment {
+<!--
   ```swifttest
   -> func f(x: Int) {
     defer { print("First defer") }
@@ -857,7 +857,7 @@ f(x: 5)
   <- End of function
   <- First defer
   ```
-}
+-->
 
 In the code above,
 the `defer` in the `if` statement
@@ -884,7 +884,7 @@ f()
 ```
 
 
-@Comment {
+<!--
   ```swifttest
   -> func f() {
          defer { print("First defer") }
@@ -896,7 +896,7 @@ f()
   <- Second defer
   <- First defer
   ```
-}
+-->
 
 The statements in the `defer` statement can't
 transfer program control outside of the `defer` statement.
@@ -961,10 +961,10 @@ all of the patterns must contain the same constant or variable bindings,
 and each bound variable or constant must have the same type
 in all of the `catch` clause's patterns.
 
-@Comment {
+<!--
   The discussion above of multi-pattern catch
   matches the discussion of multi-pattern case under Switch Statement.
-}
+-->
 
 To ensure that an error is handled,
 use a `catch` clause with a pattern that matches all errors,
@@ -1041,7 +1041,7 @@ conditions listed in the table below.
 | `canImport()` | A module name |
 | `targetEnvironment()` | `simulator`, `macCatalyst` |
 
-@Comment {
+<!--
   For the full list in the compiler, see the values of
   SupportedConditionalCompilationOSs and SupportedConditionalCompilationArches
   in the file lib/Basic/LangOptions.cpp.
@@ -1052,14 +1052,14 @@ conditions listed in the table below.
   for example "#if os(toaster)" compiles just fine,
   but Swift doesn't actually support running on a toaster oven --
   so don't rely on that when checking possible os/arch values.
-}
+-->
 
-@Comment {
+<!--
   The target environment "UIKitForMac"
   is understood by the compiler as a synonym for "macCatalyst",
   but that spelling is marked "Must be removed" outside of a few places,
   so it's omitted from the table above.
-}
+-->
 
 The version number for the `swift()` and `compiler()` platform conditions
 consists of a major number, optional minor number, optional patch number, and so on,
@@ -1089,7 +1089,7 @@ print("Compiled with the Swift 5 compiler or later in a Swift mode earlier than 
 ```
 
 
-@Comment {
+<!--
   ```swifttest
   -> #if compiler(>=5)
      print("Compiled with the Swift 5 compiler or later")
@@ -1104,12 +1104,12 @@ print("Compiled with the Swift 5 compiler or later in a Swift mode earlier than 
   <- Compiled in Swift 4.2 mode or later
   // Prints "Compiled with the Swift 5 compiler or later in a Swift mode earlier than 5"
   ```
-}
+-->
 
-@Comment {
+<!--
   That testcode is cheating by explicitly printing the third line of output,
   since it's not actually running in Swift 4.2 mode.
-}
+-->
 
 The argument for the `canImport()` platform condition
 is the name of a module that may not be present on all platforms.
@@ -1119,7 +1119,7 @@ but doesn't actually import it.
 If the module is present, the platform condition returns `true`;
 otherwise, it returns `false`.
 
-@Comment {
+<!--
   - test: `canImport_A, canImport`
   
   ```swifttest
@@ -1127,9 +1127,9 @@ otherwise, it returns `false`.
   >>     public init() { }
   >> }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `canImport_A.B, canImport`
   
   ```swifttest
@@ -1137,9 +1137,9 @@ otherwise, it returns `false`.
   >>     public init() { }
   >> }
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `canImport`
   
   ```swifttest
@@ -1155,7 +1155,7 @@ otherwise, it returns `false`.
   >> #error("Can't import A.B")
   >> #endif
   ```
-}
+-->
 
 The `targetEnvironment()` platform condition
 returns `true` when code is being compiled for the specified environment;
@@ -1165,7 +1165,7 @@ otherwise, it returns `false`.
 > The `arch(i386)` platform condition returns `true`
 > when code is compiled for the 32–bit iOS simulator.
 
-@Comment {
+<!--
   - test: `pound-if-swift-version`
   
   ```swifttest
@@ -1185,9 +1185,9 @@ otherwise, it returns `false`.
      #endif
   << 5
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `pound-if-swift-version-err`
   
   ```swifttest
@@ -1199,9 +1199,9 @@ otherwise, it returns `false`.
   !!           ^ ~
   !!-
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `pound-if-compiler-version`
   
   ```swifttest
@@ -1217,7 +1217,7 @@ otherwise, it returns `false`.
          print(3)
      #endif
   ```
-}
+-->
 
 You can combine and negate compilation conditions using the logical operators
 `&&`, `||`, and `!`
@@ -1294,7 +1294,7 @@ environment --> ``simulator`` | ``macCatalyst``
 ```
 
 
-@Comment {
+<!--
   Testing notes:
   
   !!true doesn't work but !(!true) does -- this matches normal expressions
@@ -1306,7 +1306,7 @@ environment --> ``simulator`` | ``macCatalyst``
       #elseif
       #else
       #endif
-}
+-->
 
 ### Line Control Statement
 
@@ -1379,7 +1379,7 @@ diagnostic-message --> static-string-literal
 ```
 
 
-@Comment {
+<!--
   - test: `good-diagnostic-statement-messages`
   
   ```swifttest
@@ -1398,14 +1398,14 @@ diagnostic-message --> static-string-literal
   !! """
   !! ^~~
   ```
-}
+-->
 
-@Comment {
+<!--
   Using !! lines above instead of !$ lines,
   to also confirm that the line number comes through correctly.
-}
+-->
 
-@Comment {
+<!--
   - test: `bad-diagnostic-statement-messages`
   
   ```swifttest
@@ -1419,7 +1419,7 @@ diagnostic-message --> static-string-literal
   !! #warning("Concatenated " + "strings")
   !! ^
   ```
-}
+-->
 
 ## Availability Condition
 
@@ -1489,12 +1489,12 @@ platform-version --> decimal-digits ``.`` decimal-digits ``.`` decimal-digits
 ```
 
 
-@Comment {
+<!--
   If you need to add a new platform to this list,
   you probably need to update the list under @available too.
-}
+-->
 
-@Comment {
+<!--
   - test: `pound-available-platform-names`
   
   ```swifttest
@@ -1525,18 +1525,18 @@ platform-version --> decimal-digits ``.`` decimal-digits ``.`` decimal-digits
   << c
   << dd
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `empty-availability-condition`
   
   ```swifttest
   >> if #available(*) { print("1") }
   << 1
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `empty-unavailability-condition`
   
   ```swifttest
@@ -1545,10 +1545,10 @@ platform-version --> decimal-digits ``.`` decimal-digits ``.`` decimal-digits
   !$ if #unavailable() { print("2") }
   !$                ^
   ```
-}
+-->
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -1556,4 +1556,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Statements.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Statements.md
@@ -506,7 +506,7 @@ case .suppressed:
          print("Generate a default mirror for all ancestor classes.")
      case .suppressed:
          print("Suppress the representation of all ancestor classes.")
-     @unknown default:
+  -> @unknown default:
          print("Use a representation that was unknown when this code was compiled.")
      }
   <- Generate a default mirror for all ancestor classes.

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Types.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Types.md
@@ -65,14 +65,14 @@ func someFunction(a: Int) { /* ... */ }
 ```
 
 
-@Comment {
+<!--
   - test: `type-annotation`
   
   ```swifttest
   -> let someTuple: (Double, Double) = (3.14159, 2.71828)
   -> func someFunction(a: Int) { /* ... */ }
   ```
-}
+-->
 
 In the first example,
 the expression `someTuple` is specified to have the tuple type `(Double, Double)`.
@@ -110,14 +110,14 @@ let origin: Point = (0, 0)
 ```
 
 
-@Comment {
+<!--
   - test: `type-identifier`
   
   ```swifttest
   -> typealias Point = (Int, Int)
   -> let origin: Point = (0, 0)
   ```
-}
+-->
 
 In the second case, a type identifier uses dot (`.`) syntax to refer to named types
 declared in other modules or nested within other types.
@@ -129,7 +129,7 @@ var someValue: ExampleModule.MyType
 ```
 
 
-@Comment {
+<!--
   - test: `type-identifier-dot`
   
   ```swifttest
@@ -138,7 +138,7 @@ var someValue: ExampleModule.MyType
   !! var someValue: ExampleModule.MyType
   !!                ^~~~~~~~~~~~~
   ```
-}
+-->
 
 ```
 Grammar of a type identifier
@@ -170,7 +170,7 @@ someTuple = (left: 5, right: 5)  // Error: names don't match
 ```
 
 
-@Comment {
+<!--
   - test: `tuple-type-names`
   
   ```swifttest
@@ -182,7 +182,7 @@ someTuple = (left: 5, right: 5)  // Error: names don't match
   !! someTuple = (left: 5, right: 5)  // Error: names don't match
   !!             ^~~~~~~~~~~~~~~~~~~
   ```
-}
+-->
 
 All tuple types contain two or more types,
 except for `Void` which is a type alias for the empty tuple type, `()`.
@@ -258,7 +258,7 @@ Argument names in functions and methods
 aren't part of the corresponding function type.
 For example:
 
-@Comment {
+<!--
   - test: `argument-names`
   
   ```swifttest
@@ -272,7 +272,7 @@ For example:
   -> f = anotherFunction              // OK
   -> f = functionWithDifferentLabels  // OK
   ```
-}
+-->
 
 ```swift
 func someFunction(left: Int, right: Int) {}
@@ -291,7 +291,7 @@ f = functionWithDifferentNumberOfArguments // Error
 ```
 
 
-@Comment {
+<!--
   - test: `argument-names-err`
   
   ```swifttest
@@ -315,7 +315,7 @@ f = functionWithDifferentNumberOfArguments // Error
   !! f = functionWithDifferentNumberOfArguments // Error
   !! ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   ```
-}
+-->
 
 Because argument labels aren't part of a function's type,
 you omit them when writing a function type.
@@ -327,7 +327,7 @@ var operation: (Int, Int) -> Int               // OK
 ```
 
 
-@Comment {
+<!--
   - test: `omit-argument-names-in-function-type`
   
   ```swifttest
@@ -355,7 +355,7 @@ var operation: (Int, Int) -> Int               // OK
   -> var operation: (_ lhs: Int, _ rhs: Int) -> Int // OK
   -> var operation: (Int, Int) -> Int               // OK
   ```
-}
+-->
 
 If a function type includes more than a single arrow (`->`),
 the function types are grouped from right to left.
@@ -382,7 +382,7 @@ in the same places as an asynchronous one.
 For information about asynchronous functions,
 see <doc:Declarations#Asynchronous-Functions-and-Methods>.
 
-@Comment {
+<!--
   - test: `function-arrow-is-right-associative`
   
   ```swifttest
@@ -401,7 +401,7 @@ see <doc:Declarations#Asynchronous-Functions-and-Methods>.
   >> let r1 = b(3)(5)
   >> assert(r1 == 8)
   ```
-}
+-->
 
 ### Restrictions for Nonescaping Closures
 
@@ -409,7 +409,7 @@ A parameter that's a nonescaping function
 can't be stored in a property, variable, or constant of type `Any`,
 because that might allow the value to escape.
 
-@Comment {
+<!--
   - test: `cant-store-nonescaping-as-Any`
   
   ```swifttest
@@ -418,7 +418,7 @@ because that might allow the value to escape.
   !! func f(g: ()->Void) { let x: Any = g }
   !!                                    ^
   ```
-}
+-->
 
 A parameter that's a nonescaping function
 can't be passed as an argument to another nonescaping function parameter.
@@ -442,7 +442,7 @@ func takesTwoFunctions(first: (() -> Void) -> Void, second: (() -> Void) -> Void
 ```
 
 
-@Comment {
+<!--
   - test: `memory-nonescaping-functions`
   
   ```swifttest
@@ -470,7 +470,7 @@ func takesTwoFunctions(first: (() -> Void) -> Void, second: (() -> Void) -> Void
   !! second { first {} }      // Error
   !! ^
   ```
-}
+-->
 
 In the code above,
 both of the parameters to `takesTwoFunctions(first:second:)` are functions.
@@ -507,7 +507,7 @@ argument-label --> identifier
 ```
 
 
-@Comment {
+<!--
   NOTE: Functions are first-class citizens in Swift,
   except for generic functions, i.e., parametric polymorphic functions.
   This means that monomorphic functions can be assigned to variables
@@ -521,7 +521,7 @@ argument-label --> identifier
   But, the following is NOT allowed::
   
       var myPolymorphicF = polymorphicF
-}
+-->
 
 ## Array Type
 
@@ -541,7 +541,7 @@ let someArray: [String] = ["Alex", "Brian", "Dave"]
 ```
 
 
-@Comment {
+<!--
   - test: `array-literal`
   
   ```swifttest
@@ -549,7 +549,7 @@ let someArray: [String] = ["Alex", "Brian", "Dave"]
   >> let someArray2: [String] = ["Alex", "Brian", "Dave"]
   >> assert(someArray1 == someArray2)
   ```
-}
+-->
 
 In both cases, the constant `someArray`
 is declared as an array of strings. The elements of an array can be accessed
@@ -567,13 +567,13 @@ var array3D: [[[Int]]] = [[[1, 2], [3, 4]], [[5, 6], [7, 8]]]
 ```
 
 
-@Comment {
+<!--
   - test: `array-3d`
   
   ```swifttest
   -> var array3D: [[[Int]]] = [[[1, 2], [3, 4]], [[5, 6], [7, 8]]]
   ```
-}
+-->
 
 When accessing the elements in a multidimensional array,
 the left-most subscript index refers to the element at that index in the outermost
@@ -610,7 +610,7 @@ let someDictionary: Dictionary<String, Int> = ["Alex": 31, "Paul": 39]
 ```
 
 
-@Comment {
+<!--
   - test: `dictionary-literal`
   
   ```swifttest
@@ -618,7 +618,7 @@ let someDictionary: Dictionary<String, Int> = ["Alex": 31, "Paul": 39]
   >> let someDictionary2: Dictionary<String, Int> = ["Alex": 31, "Paul": 39]
   >> assert(someDictionary1 == someDictionary2)
   ```
-}
+-->
 
 In both cases, the constant `someDictionary`
 is declared as a dictionary with strings as keys and integers as values.
@@ -633,10 +633,10 @@ the subscript returns `nil`.
 
 The key type of a dictionary must conform to the Swift standard library `Hashable` protocol.
 
-@Comment {
+<!--
   Used to have an xref to :ref:`CollectionTypes_HashValuesForSetTypes` here.
   But it doesn't really work now that the Hashable content moved from Dictionary to Set.
-}
+-->
 
 For a detailed discussion of the Swift standard library `Dictionary` type,
 see <doc:CollectionTypes#Dictionaries>.
@@ -660,20 +660,20 @@ var optionalInteger: Optional<Int>
 ```
 
 
-@Comment {
+<!--
   - test: `optional-literal`
   
   ```swifttest
   >> var optionalInteger1: Int?
   >> var optionalInteger2: Optional<Int>
   ```
-}
+-->
 
-@Comment {
+<!--
   We can't test the code listing above,
   because of the redeclaration of optionalInteger,
   so we at least test that the syntax shown in it compiles.
-}
+-->
 
 In both cases, the variable `optionalInteger`
 is declared to have the type of an optional integer.
@@ -685,10 +685,10 @@ Any type can be explicitly declared to be (or implicitly converted to) an option
 If you don't provide an initial value when you declare an
 optional variable or property, its value automatically defaults to `nil`.
 
-@Comment {
+<!--
   TODO Add a link to the Optional Enum Reference page.
   For more information about the Optional type, see ...
-}
+-->
 
 If an instance of an optional type contains a value,
 you can access that value using the postfix operator `!`, as shown below:
@@ -699,7 +699,7 @@ optionalInteger! // 42
 ```
 
 
-@Comment {
+<!--
   - test: `optional-type`
   
   ```swifttest
@@ -709,12 +709,12 @@ optionalInteger! // 42
   -> optionalInteger! // 42
   >> assert(r0 == 42)
   ```
-}
+-->
 
-@Comment {
+<!--
   Refactor the above if possible to avoid using bare expressions.
   Tracking bug is <rdar://problem/35301593>
-}
+-->
 
 Using the `!` operator to unwrap an optional
 that has a value of `nil` results in a runtime error.
@@ -806,10 +806,10 @@ in type annotations,
 in generic parameter clauses,
 and in generic `where` clauses.
 
-@Comment {
+<!--
   In places where a comma-separated list of types is allowed,
   the P&Q syntax isn't allowed.
-}
+-->
 
 Protocol composition types have the following form:
 
@@ -851,7 +851,7 @@ typealias PQR = PQ & Q & R
 ```
 
 
-@Comment {
+<!--
   - test: `protocol-composition-can-have-repeats`
   
   ```swifttest
@@ -861,7 +861,7 @@ typealias PQR = PQ & Q & R
   -> typealias PQ = P & Q
   -> typealias PQR = PQ & Q & R
   ```
-}
+-->
 
 ```
 Grammar of a protocol composition type
@@ -901,11 +901,11 @@ Code that interacts with an opaque value
 can use the value only in ways
 that are part of the interface defined by the *constraint*.
 
-@Comment {
+<!--
   The wording above intentionally follows generic constraints
   because the meaning here and there is the same,
   and the compiler uses the same machinery for both under the hood.
-}
+-->
 
 Protocol declarations can't include opaque types.
 Classes can't use an opaque type as the return type of a nonfinal method.
@@ -965,7 +965,7 @@ type(of: someInstance).printClassName()
 ```
 
 
-@Comment {
+<!--
   - test: `metatype-type`
   
   ```swifttest
@@ -985,7 +985,7 @@ type(of: someInstance).printClassName()
   -> type(of: someInstance).printClassName()
   <- SomeSubClass
   ```
-}
+-->
 
 For more information,
 see [type(of:)](https://developer.apple.com/documentation/swift/2885064-type)
@@ -1012,7 +1012,7 @@ let anotherInstance = metatype.init(string: "some string")
 ```
 
 
-@Comment {
+<!--
   - test: `metatype-type`
   
   ```swifttest
@@ -1028,7 +1028,7 @@ let anotherInstance = metatype.init(string: "some string")
   -> let metatype: AnotherSubClass.Type = AnotherSubClass.self
   -> let anotherInstance = metatype.init(string: "some string")
   ```
-}
+-->
 
 ```
 Grammar of a metatype type
@@ -1053,13 +1053,13 @@ let mixed: [Any] = ["one", 2, true, (4, 5.3), { () -> Int in return 6 }]
 ```
 
 
-@Comment {
+<!--
   - test: `any-type`
   
   ```swifttest
   -> let mixed: [Any] = ["one", 2, true, (4, 5.3), { () -> Int in return 6 }]
   ```
-}
+-->
 
 When you use `Any` as a concrete type for an instance,
 you need to cast the instance to a known type
@@ -1080,7 +1080,7 @@ if let first = mixed.first as? String {
 ```
 
 
-@Comment {
+<!--
   - test: `any-type`
   
   ```swifttest
@@ -1089,7 +1089,7 @@ if let first = mixed.first as? String {
      }
   <- The first item, 'one', is a string.
   ```
-}
+-->
 
 For more information about casting, see <doc:TypeCasting>.
 
@@ -1134,7 +1134,7 @@ For example,
 the code below shows an instance method `f`
 whose return type is `Self`.
 
-@Comment {
+<!--
   - test: `self-in-class-cant-be-a-parameter-type`
   
   ```swifttest
@@ -1144,9 +1144,9 @@ whose return type is `Self`.
   !!                     ^~~~
   !!                     C
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `self-in-class-can-be-a-subscript-param`
   
   ```swifttest
@@ -1154,9 +1154,9 @@ whose return type is `Self`.
   >> let c = C()
   >> _ = c[12]
   ```
-}
+-->
 
-@Comment {
+<!--
   - test: `self-in-class-can-be-a-computed-property-type`
   
   ```swifttest
@@ -1164,7 +1164,7 @@ whose return type is `Self`.
   >> let c = C()
   >> _ = c.s
   ```
-}
+-->
 
 ```swift
 class Superclass {
@@ -1185,7 +1185,7 @@ print(type(of: z.f()))
 ```
 
 
-@Comment {
+<!--
   - test: `self-gives-dynamic-type`
   
   ```swifttest
@@ -1205,18 +1205,18 @@ print(type(of: z.f()))
   -> print(type(of: z.f()))
   <- Subclass
   ```
-}
+-->
 
 The last part of the example above shows that
 `Self` refers to the runtime type `Subclass` of the value of `z`,
 not the compile-time type `Superclass` of the variable itself.
 
-@Comment {
+<!--
   TODO: Using Self as the return type from a subscript or property doesn't
   currently work.  The compiler allows it, but you get the wrong type back,
   and the compiler doesn't enforce that the subscript/property must be
   read-only.  See https://bugs.swift.org/browse/SR-10326
-}
+-->
 
 Inside a nested type declaration,
 the `Self` type refers to the type
@@ -1300,27 +1300,27 @@ let eFloat: Float = 2.71828 // The type of eFloat is Float.
 ```
 
 
-@Comment {
+<!--
   - test: `type-inference`
   
   ```swifttest
   -> let e = 2.71828 // The type of e is inferred to be Double.
   -> let eFloat: Float = 2.71828 // The type of eFloat is Float.
   ```
-}
+-->
 
 Type inference in Swift operates at the level of a single expression or statement.
 This means that all of the information needed to infer an omitted type or part of a type
 in an expression must be accessible from type-checking
 the expression or one of its subexpressions.
 
-@Comment {
+<!--
   TODO: Email Doug for a list of rules or situations describing when type-inference
   is allowed and when types must be fully typed.
-}
+-->
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -1328,4 +1328,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/RevisionHistory/RevisionHistory.md
+++ b/Sources/TSPL/TSPL.docc/RevisionHistory/RevisionHistory.md
@@ -786,7 +786,7 @@
 - Added an example of <doc:Generics#Extending-a-Generic-Type>.
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -794,4 +794,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->

--- a/Sources/TSPL/TSPL.docc/TSPL.md
+++ b/Sources/TSPL/TSPL.docc/TSPL.md
@@ -60,7 +60,7 @@
 - <doc:RevisionHistory>
 
 
-@Comment {
+<!--
 This source file is part of the Swift.org open source project
 
 Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
@@ -68,4 +68,4 @@ Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information
 See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-}
+-->


### PR DESCRIPTION
This reduces the places where content in the comment causes DocC to silently mis-parse the comment and content after it.

The markdown parser for DocC first parses plain markdown syntax, and then identifies places where the `@Comment { }` syntax delimits blocks.  That means it tries to parse the content of a comment as markdown first, and then later it gets turned into a comment.  The parsing of HTML style comments happens as part of the first stage, which makes it less fragile.

Using the DocC syntax for comments, a lot of the issues seem to come from `}` appearing in commented-out in code listings, or from other places where part of the comment is being interpreted as markdown and preventing the later DocC parsing pass from treating that content as a comment, or in some causes causing content after it to be missing.  Using the HTML comment syntax, the `-->` arrow used in comment-out formal grammar conflicts with the end-of-comment marker, which I worked around by changing them to a `->` arrow.  We can probably delete most or all of the commented-out formal grammar blocks, which seem to date back to the original drafting of the book's grammar.

Some of the comment-parsing issues appear to be related to a known issue in Swift-Markdown: https://github.com/apple/swift-markdown/issues/84