### PR TITLE
Add inits and subscripts to the underscore rule.

### DIFF
--- a/Sources/TSPL/TSPL.docc/ReferenceManual/LexicalStructure.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/LexicalStructure.md
@@ -87,7 +87,10 @@ that isn't in a Private Use Area.
 After the first character,
 digits and combining Unicode characters are also allowed.
 
-Treat identifiers that begin with an underscore as internal,
+Treat identifiers that begin with an underscore,
+subscripts whose first argument label begins with an underscore,
+and initializers whose first argument label begins with an underscore,
+as internal,
 even if their declaration has the `public` access-level modifier.
 This convention lets framework authors mark part of an API
 that clients must not interact with or depend on,


### PR DESCRIPTION
Exported from the RST version, where this old branch was reviewed by Steve Canon <scanon@apple.com> on Aug 30 and merged Oct 5.