### PR TITLE
Normalize indentation in code listings

### DIFF
--- a/Sources/TSPL/TSPL.docc/GuidedTour/GuidedTour.md
+++ b/Sources/TSPL/TSPL.docc/GuidedTour/GuidedTour.md
@@ -514,14 +514,14 @@ and tests for equality.
 ```swift
 let vegetable = "red pepper"
 switch vegetable {
-    case "celery":
-        print("Add some raisins and make ants on a log.")
-    case "cucumber", "watercress":
-        print("That would make a good tea sandwich.")
-    case let x where x.hasSuffix("pepper"):
-        print("Is it a spicy \(x)?")
-    default:
-        print("Everything tastes good in soup.")
+case "celery":
+    print("Add some raisins and make ants on a log.")
+case "cucumber", "watercress":
+    print("That would make a good tea sandwich.")
+case let x where x.hasSuffix("pepper"):
+    print("Is it a spicy \(x)?")
+default:
+    print("Everything tastes good in soup.")
 }
 // Prints "Is it a spicy red pepper?"
 ```
@@ -1461,16 +1461,16 @@ enum Rank: Int {
 
     func simpleDescription() -> String {
         switch self {
-            case .ace:
-                return "ace"
-            case .jack:
-                return "jack"
-            case .queen:
-                return "queen"
-            case .king:
-                return "king"
-            default:
-                return String(self.rawValue)
+        case .ace:
+            return "ace"
+        case .jack:
+            return "jack"
+        case .queen:
+            return "queen"
+        case .king:
+            return "king"
+        default:
+            return String(self.rawValue)
         }
     }
 }
@@ -1558,14 +1558,14 @@ enum Suit {
 
     func simpleDescription() -> String {
         switch self {
-            case .spades:
-                return "spades"
-            case .hearts:
-                return "hearts"
-            case .diamonds:
-                return "diamonds"
-            case .clubs:
-                return "clubs"
+        case .spades:
+            return "spades"
+        case .hearts:
+            return "hearts"
+        case .diamonds:
+            return "diamonds"
+        case .clubs:
+            return "clubs"
         }
     }
 }
@@ -1681,10 +1681,10 @@ let success = ServerResponse.result("6:00 am", "8:09 pm")
 let failure = ServerResponse.failure("Out of cheese.")
 
 switch success {
-    case let .result(sunrise, sunset):
-        print("Sunrise is at \(sunrise) and sunset is at \(sunset).")
-    case let .failure(message):
-        print("Failure...  \(message)")
+case let .result(sunrise, sunset):
+    print("Sunrise is at \(sunrise) and sunset is at \(sunset).")
+case let .failure(message):
+    print("Failure...  \(message)")
 }
 // Prints "Sunrise is at 6:00 am and sunset is at 8:09 pm."
 ```

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/AccessControl.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/AccessControl.md
@@ -230,25 +230,25 @@ the default access level of the type's members will be internal.
 
 ```swift
 public class SomePublicClass {                  // explicitly public class
-   public var somePublicProperty = 0            // explicitly public class member
-   var someInternalProperty = 0                 // implicitly internal class member
-   fileprivate func someFilePrivateMethod() {}  // explicitly file-private class member
-   private func somePrivateMethod() {}          // explicitly private class member
+    public var somePublicProperty = 0            // explicitly public class member
+    var someInternalProperty = 0                 // implicitly internal class member
+    fileprivate func someFilePrivateMethod() {}  // explicitly file-private class member
+    private func somePrivateMethod() {}          // explicitly private class member
 }
 
 class SomeInternalClass {                       // implicitly internal class
-   var someInternalProperty = 0                 // implicitly internal class member
-   fileprivate func someFilePrivateMethod() {}  // explicitly file-private class member
-   private func somePrivateMethod() {}          // explicitly private class member
+    var someInternalProperty = 0                 // implicitly internal class member
+    fileprivate func someFilePrivateMethod() {}  // explicitly file-private class member
+    private func somePrivateMethod() {}          // explicitly private class member
 }
 
 fileprivate class SomeFilePrivateClass {        // explicitly file-private class
-   func someFilePrivateMethod() {}              // implicitly file-private class member
-   private func somePrivateMethod() {}          // explicitly private class member
+    func someFilePrivateMethod() {}              // implicitly file-private class member
+    private func somePrivateMethod() {}          // explicitly private class member
 }
 
 private class SomePrivateClass {                // explicitly private class
-   func somePrivateMethod() {}                  // implicitly private class member
+    func somePrivateMethod() {}                  // implicitly private class member
 }
 ```
 
@@ -378,7 +378,7 @@ In fact, `someFunction()` won't compile as written below:
 
 ```swift
 func someFunction() -> (SomeInternalClass, SomePrivateClass) {
-   // function implementation goes here
+    // function implementation goes here
 }
 ```
 
@@ -410,7 +410,7 @@ for the function declaration to be valid:
 
 ```swift
 private func someFunction() -> (SomeInternalClass, SomePrivateClass) {
-   // function implementation goes here
+    // function implementation goes here
 }
 ```
 
@@ -445,10 +445,10 @@ therefore also have an access level of public:
 
 ```swift
 public enum CompassPoint {
-   case north
-   case south
-   case east
-   case west
+    case north
+    case south
+    case east
+    case west
 }
 ```
 
@@ -668,11 +668,11 @@ the original implementation of `someMethod()`:
 
 ```swift
 public class A {
-   fileprivate func someMethod() {}
+    fileprivate func someMethod() {}
 }
 
 internal class B: A {
-   override internal func someMethod() {}
+    override internal func someMethod() {}
 }
 ```
 
@@ -700,13 +700,13 @@ or within the same module as the superclass for an internal member call):
 
 ```swift
 public class A {
-   fileprivate func someMethod() {}
+    fileprivate func someMethod() {}
 }
 
 internal class B: A {
-   override internal func someMethod() {
-      super.someMethod()
-   }
+    override internal func someMethod() {
+        super.someMethod()
+    }
 }
 ```
 
@@ -811,12 +811,12 @@ which keeps track of the number of times a string property is modified:
 
 ```swift
 struct TrackedString {
-   private(set) var numberOfEdits = 0
-   var value: String = "" {
-      didSet {
-         numberOfEdits += 1
-      }
-   }
+    private(set) var numberOfEdits = 0
+    var value: String = "" {
+        didSet {
+            numberOfEdits += 1
+        }
+    }
 }
 ```
 
@@ -923,13 +923,13 @@ by combining the `public` and `private(set)` access-level modifiers:
 
 ```swift
 public struct TrackedString {
-   public private(set) var numberOfEdits = 0
-   public var value: String = "" {
-      didSet {
-         numberOfEdits += 1
-      }
-   }
-   public init() {}
+    public private(set) var numberOfEdits = 0
+    public var value: String = "" {
+        didSet {
+            numberOfEdits += 1
+        }
+    }
+    public init() {}
 }
 ```
 

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/AdvancedOperators.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/AdvancedOperators.md
@@ -715,7 +715,7 @@ to add together instances of the `Vector2D` structure:
 
 ```swift
 struct Vector2D {
-   var x = 0.0, y = 0.0
+    var x = 0.0, y = 0.0
 }
 
 extension Vector2D {
@@ -989,7 +989,7 @@ You can now use this operator to check whether two `Vector2D` instances are equi
 let twoThree = Vector2D(x: 2.0, y: 3.0)
 let anotherTwoThree = Vector2D(x: 2.0, y: 3.0)
 if twoThree == anotherTwoThree {
-   print("These two vectors are equivalent.")
+    print("These two vectors are equivalent.")
 }
 // Prints "These two vectors are equivalent."
 ```
@@ -1047,10 +1047,10 @@ you add a type method called `+++` to `Vector2D` as follows:
 
 ```swift
 extension Vector2D {
-   static prefix func +++ (vector: inout Vector2D) -> Vector2D {
-      vector += vector
-      return vector
-   }
+    static prefix func +++ (vector: inout Vector2D) -> Vector2D {
+        vector += vector
+        return vector
+    }
 }
 
 var toBeDoubled = Vector2D(x: 1.0, y: 4.0)
@@ -1099,9 +1099,9 @@ which belongs to the precedence group `AdditionPrecedence`:
 ```swift
 infix operator +-: AdditionPrecedence
 extension Vector2D {
-   static func +- (left: Vector2D, right: Vector2D) -> Vector2D {
-      return Vector2D(x: left.x + right.x, y: left.y - right.y)
-   }
+    static func +- (left: Vector2D, right: Vector2D) -> Vector2D {
+        return Vector2D(x: left.x + right.x, y: left.y - right.y)
+    }
 }
 let firstVector = Vector2D(x: 1.0, y: 2.0)
 let secondVector = Vector2D(x: 3.0, y: 4.0)

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/AutomaticReferenceCounting.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/AutomaticReferenceCounting.md
@@ -61,14 +61,14 @@ which defines a stored constant property called `name`:
 
 ```swift
 class Person {
-   let name: String
-   init(name: String) {
-      self.name = name
-      print("\(name) is being initialized")
-   }
-   deinit {
-      print("\(name) is being deinitialized")
-   }
+    let name: String
+    init(name: String) {
+        self.name = name
+        print("\(name) is being initialized")
+    }
+    deinit {
+        print("\(name) is being deinitialized")
+    }
 }
 ```
 
@@ -231,17 +231,17 @@ which model a block of apartments and its residents:
 
 ```swift
 class Person {
-   let name: String
-   init(name: String) { self.name = name }
-   var apartment: Apartment?
-   deinit { print("\(name) is being deinitialized") }
+    let name: String
+    init(name: String) { self.name = name }
+    var apartment: Apartment?
+    deinit { print("\(name) is being deinitialized") }
 }
 
 class Apartment {
-   let unit: String
-   init(unit: String) { self.unit = unit }
-   var tenant: Person?
-   deinit { print("Apartment \(unit) is being deinitialized") }
+    let unit: String
+    init(unit: String) { self.unit = unit }
+    var tenant: Person?
+    deinit { print("Apartment \(unit) is being deinitialized") }
 }
 ```
 
@@ -465,17 +465,17 @@ is declared as a weak reference:
 
 ```swift
 class Person {
-   let name: String
-   init(name: String) { self.name = name }
-   var apartment: Apartment?
-   deinit { print("\(name) is being deinitialized") }
+    let name: String
+    init(name: String) { self.name = name }
+    var apartment: Apartment?
+    deinit { print("\(name) is being deinitialized") }
 }
 
 class Apartment {
-   let unit: String
-   init(unit: String) { self.unit = unit }
-   weak var tenant: Person?
-   deinit { print("Apartment \(unit) is being deinitialized") }
+    let unit: String
+    init(unit: String) { self.unit = unit }
+    weak var tenant: Person?
+    deinit { print("Apartment \(unit) is being deinitialized") }
 }
 ```
 
@@ -661,22 +661,22 @@ to avoid a strong reference cycle:
 
 ```swift
 class Customer {
-   let name: String
-   var card: CreditCard?
-   init(name: String) {
-      self.name = name
-   }
-   deinit { print("\(name) is being deinitialized") }
+    let name: String
+    var card: CreditCard?
+    init(name: String) {
+        self.name = name
+    }
+    deinit { print("\(name) is being deinitialized") }
 }
 
 class CreditCard {
-   let number: UInt64
-   unowned let customer: Customer
-   init(number: UInt64, customer: Customer) {
-      self.number = number
-      self.customer = customer
-   }
-   deinit { print("Card #\(number) is being deinitialized") }
+    let number: UInt64
+    unowned let customer: Customer
+    init(number: UInt64, customer: Customer) {
+        self.number = number
+        self.customer = customer
+    }
+    deinit { print("Card #\(number) is being deinitialized") }
 }
 ```
 
@@ -1008,21 +1008,21 @@ and the `City` class has a `country` property:
 
 ```swift
 class Country {
-   let name: String
-   var capitalCity: City!
-   init(name: String, capitalName: String) {
-      self.name = name
-      self.capitalCity = City(name: capitalName, country: self)
-   }
+    let name: String
+    var capitalCity: City!
+    init(name: String, capitalName: String) {
+        self.name = name
+        self.capitalCity = City(name: capitalName, country: self)
+    }
 }
 
 class City {
-   let name: String
-   unowned let country: Country
-   init(name: String, country: Country) {
-      self.name = name
-      self.country = country
-   }
+    let name: String
+    unowned let country: Country
+    init(name: String, country: Country) {
+        self.name = name
+        self.country = country
+    }
 }
 ```
 
@@ -1143,25 +1143,25 @@ which provides a simple model for an individual element within an HTML document:
 ```swift
 class HTMLElement {
 
-   let name: String
-   let text: String?
+    let name: String
+    let text: String?
 
-   lazy var asHTML: () -> String = {
-      if let text = self.text {
-         return "<\(self.name)>\(text)</\(self.name)>"
-      } else {
-         return "<\(self.name) />"
-      }
-   }
+    lazy var asHTML: () -> String = {
+        if let text = self.text {
+            return "<\(self.name)>\(text)</\(self.name)>"
+        } else {
+            return "<\(self.name) />"
+        }
+    }
 
-   init(name: String, text: String? = nil) {
-      self.name = name
-      self.text = text
-   }
+    init(name: String, text: String? = nil) {
+        self.name = name
+        self.text = text
+    }
 
-   deinit {
-      print("\(name) is being deinitialized")
-   }
+    deinit {
+        print("\(name) is being deinitialized")
+    }
 
 }
 ```
@@ -1233,7 +1233,7 @@ in order to prevent the representation from returning an empty HTML tag:
 let heading = HTMLElement(name: "h1")
 let defaultText = "some default text"
 heading.asHTML = {
-   return "<\(heading.name)>\(heading.text ?? defaultText)</\(heading.name)>"
+    return "<\(heading.name)>\(heading.text ?? defaultText)</\(heading.name)>"
 }
 print(heading.asHTML())
 // Prints "<h1>some default text</h1>"
@@ -1361,9 +1361,9 @@ if they're provided:
 
 ```swift
 lazy var someClosure = {
-      [unowned self, weak delegate = self.delegate]
-      (index: Int, stringToProcess: String) -> String in
-   // closure body goes here
+        [unowned self, weak delegate = self.delegate]
+        (index: Int, stringToProcess: String) -> String in
+    // closure body goes here
 }
 ```
 
@@ -1391,8 +1391,8 @@ followed by the `in` keyword:
 
 ```swift
 lazy var someClosure = {
-      [unowned self, weak delegate = self.delegate] in
-   // closure body goes here
+        [unowned self, weak delegate = self.delegate] in
+    // closure body goes here
 }
 ```
 
@@ -1440,26 +1440,26 @@ Here's how you write the `HTMLElement` class to avoid the cycle:
 ```swift
 class HTMLElement {
 
-   let name: String
-   let text: String?
+    let name: String
+    let text: String?
 
-   lazy var asHTML: () -> String = {
-         [unowned self] in
-      if let text = self.text {
-         return "<\(self.name)>\(text)</\(self.name)>"
-      } else {
-         return "<\(self.name) />"
-      }
-   }
+    lazy var asHTML: () -> String = {
+            [unowned self] in
+        if let text = self.text {
+            return "<\(self.name)>\(text)</\(self.name)>"
+        } else {
+            return "<\(self.name) />"
+        }
+    }
 
-   init(name: String, text: String? = nil) {
-      self.name = name
-      self.text = text
-   }
+    init(name: String, text: String? = nil) {
+        self.name = name
+        self.text = text
+    }
 
-   deinit {
-      print("\(name) is being deinitialized")
-   }
+    deinit {
+        print("\(name) is being deinitialized")
+    }
 
 }
 ```

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/BasicOperators.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/BasicOperators.md
@@ -115,7 +115,7 @@ The following statement isn't valid:
 
 ```swift
 if x = y {
-   // This isn't valid, because x = y doesn't return a value.
+    // This isn't valid, because x = y doesn't return a value.
 }
 ```
 
@@ -437,9 +437,9 @@ such as the `if` statement:
 ```swift
 let name = "world"
 if name == "world" {
-   print("hello, world")
+    print("hello, world")
 } else {
-   print("I'm sorry \(name), but I don't recognize you")
+    print("I'm sorry \(name), but I don't recognize you")
 }
 // Prints "hello, world", because name is indeed equal to "world".
 ```
@@ -579,9 +579,9 @@ The ternary conditional operator is shorthand for the code below:
 
 ```swift
 if question {
-   answer1
+    answer1
 } else {
-   answer2
+    answer2
 }
 ```
 
@@ -643,9 +643,9 @@ let contentHeight = 40
 let hasHeader = true
 let rowHeight: Int
 if hasHeader {
-   rowHeight = contentHeight + 50
+    rowHeight = contentHeight + 50
 } else {
-   rowHeight = contentHeight + 20
+    rowHeight = contentHeight + 20
 }
 // rowHeight is equal to 90
 ```
@@ -818,7 +818,7 @@ such as with a `for`-`in` loop:
 
 ```swift
 for index in 1...5 {
-   print("\(index) times 5 is \(index * 5)")
+    print("\(index) times 5 is \(index * 5)")
 }
 // 1 times 5 is 5
 // 2 times 5 is 10
@@ -892,7 +892,7 @@ where it's useful to count up to (but not including) the length of the list:
 let names = ["Anna", "Alex", "Brian", "Jack"]
 let count = names.count
 for i in 0..<count {
-   print("Person \(i + 1) is called \(names[i])")
+    print("Person \(i + 1) is called \(names[i])")
 }
 // Person 1 is called Anna
 // Person 2 is called Alex
@@ -1061,7 +1061,7 @@ It can be read as “not `a`”, as seen in the following example:
 ```swift
 let allowedEntry = false
 if !allowedEntry {
-   print("ACCESS DENIED")
+    print("ACCESS DENIED")
 }
 // Prints "ACCESS DENIED"
 ```
@@ -1107,9 +1107,9 @@ and only allows access if both values are `true`:
 let enteredDoorCode = true
 let passedRetinaScan = false
 if enteredDoorCode && passedRetinaScan {
-   print("Welcome!")
+    print("Welcome!")
 } else {
-   print("ACCESS DENIED")
+    print("ACCESS DENIED")
 }
 // Prints "ACCESS DENIED"
 ```
@@ -1155,9 +1155,9 @@ and access is allowed:
 let hasDoorKey = false
 let knowsOverridePassword = true
 if hasDoorKey || knowsOverridePassword {
-   print("Welcome!")
+    print("Welcome!")
 } else {
-   print("ACCESS DENIED")
+    print("ACCESS DENIED")
 }
 // Prints "Welcome!"
 ```
@@ -1184,9 +1184,9 @@ You can combine multiple logical operators to create longer compound expressions
 
 ```swift
 if enteredDoorCode && passedRetinaScan || hasDoorKey || knowsOverridePassword {
-   print("Welcome!")
+    print("Welcome!")
 } else {
-   print("ACCESS DENIED")
+    print("ACCESS DENIED")
 }
 // Prints "Welcome!"
 ```
@@ -1234,9 +1234,9 @@ to make its intent explicit:
 
 ```swift
 if (enteredDoorCode && passedRetinaScan) || hasDoorKey || knowsOverridePassword {
-   print("Welcome!")
+    print("Welcome!")
 } else {
-   print("ACCESS DENIED")
+    print("ACCESS DENIED")
 }
 // Prints "Welcome!"
 ```

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/ClassesAndStructures.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/ClassesAndStructures.md
@@ -70,10 +70,10 @@ Both place their entire definition within a pair of braces:
 
 ```swift
 struct SomeStructure {
-   // structure definition goes here
+    // structure definition goes here
 }
 class SomeClass {
-   // class definition goes here
+    // class definition goes here
 }
 ```
 
@@ -105,14 +105,14 @@ Here's an example of a structure definition and a class definition:
 
 ```swift
 struct Resolution {
-   var width = 0
-   var height = 0
+    var width = 0
+    var height = 0
 }
 class VideoMode {
-   var resolution = Resolution()
-   var interlaced = false
-   var frameRate = 0.0
-   var name: String?
+    var resolution = Resolution()
+    var interlaced = false
+    var frameRate = 0.0
+    var name: String?
 }
 ```
 
@@ -423,10 +423,10 @@ The same behavior applies to enumerations:
 
 ```swift
 enum CompassPoint {
-   case north, south, east, west
-   mutating func turnNorth() {
-      self = .north
-   }
+    case north, south, east, west
+    mutating func turnNorth() {
+        self = .north
+    }
 }
 var currentDirection = CompassPoint.west
 let rememberedDirection = currentDirection
@@ -640,7 +640,7 @@ Use these operators to check whether two constants or variables refer to the sam
 
 ```swift
 if tenEighty === alsoTenEighty {
-   print("tenEighty and alsoTenEighty refer to the same VideoMode instance.")
+    print("tenEighty and alsoTenEighty refer to the same VideoMode instance.")
 }
 // Prints "tenEighty and alsoTenEighty refer to the same VideoMode instance."
 ```

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Closures.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Closures.md
@@ -95,7 +95,7 @@ and to pass it in as an argument to the `sorted(by:)` method:
 
 ```swift
 func backward(_ s1: String, _ s2: String) -> Bool {
-   return s1 > s2
+    return s1 > s2
 }
 var reversedNames = names.sorted(by: backward)
 // reversedNames is equal to ["Ewa", "Daniella", "Chris", "Barry", "Alex"]
@@ -152,7 +152,7 @@ from above:
 
 ```swift
 reversedNames = names.sorted(by: { (s1: String, s2: String) -> Bool in
-   return s1 > s2
+    return s1 > s2
 })
 ```
 
@@ -359,19 +359,19 @@ however, the first few examples below use a single trailing closure.
 
 ```swift
 func someFunctionThatTakesAClosure(closure: () -> Void) {
-   // function body goes here
+    // function body goes here
 }
 
 // Here's how you call this function without using a trailing closure:
 
 someFunctionThatTakesAClosure(closure: {
-   // closure's body goes here
+    // closure's body goes here
 })
 
 // Here's how you call this function with a trailing closure instead:
 
 someFunctionThatTakesAClosure() {
-   // trailing closure's body goes here
+    // trailing closure's body goes here
 }
 ```
 
@@ -455,8 +455,8 @@ The array `[16, 58, 510]` is used to create the new array
 
 ```swift
 let digitNames = [
-   0: "Zero", 1: "One", 2: "Two",   3: "Three", 4: "Four",
-   5: "Five", 6: "Six", 7: "Seven", 8: "Eight", 9: "Nine"
+    0: "Zero", 1: "One", 2: "Two",   3: "Three", 4: "Four",
+    5: "Five", 6: "Six", 7: "Seven", 8: "Eight", 9: "Nine"
 ]
 let numbers = [16, 58, 510]
 ```
@@ -483,13 +483,13 @@ by passing a closure expression to the array's `map(_:)` method as a trailing cl
 
 ```swift
 let strings = numbers.map { (number) -> String in
-   var number = number
-   var output = ""
-   repeat {
-      output = digitNames[number % 10]! + output
-      number /= 10
-   } while number > 0
-   return output
+    var number = number
+    var output = ""
+    repeat {
+        output = digitNames[number % 10]! + output
+        number /= 10
+    } while number > 0
+    return output
 }
 // strings is inferred to be of type [String]
 // its value is ["OneSix", "FiveEight", "FiveOneZero"]
@@ -668,12 +668,12 @@ that increments `runningTotal` by `amount` each time it's called.
 
 ```swift
 func makeIncrementer(forIncrement amount: Int) -> () -> Int {
-   var runningTotal = 0
-   func incrementer() -> Int {
-      runningTotal += amount
-      return runningTotal
-   }
-   return incrementer
+    var runningTotal = 0
+    func incrementer() -> Int {
+        runningTotal += amount
+        return runningTotal
+    }
+    return incrementer
 }
 ```
 
@@ -718,8 +718,8 @@ the nested `incrementer()` function might seem unusual:
 
 ```swift
 func incrementer() -> Int {
-   runningTotal += amount
-   return runningTotal
+    runningTotal += amount
+    return runningTotal
 }
 ```
 

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/CollectionTypes.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/CollectionTypes.md
@@ -280,9 +280,9 @@ as a shortcut for checking whether the `count` property is equal to `0`:
 
 ```swift
 if shoppingList.isEmpty {
-   print("The shopping list is empty.")
+    print("The shopping list is empty.")
 } else {
-   print("The shopping list isn't empty.")
+    print("The shopping list isn't empty.")
 }
 // Prints "The shopping list isn't empty."
 ```
@@ -529,7 +529,7 @@ You can iterate over the entire set of values in an array with the `for`-`in` lo
 
 ```swift
 for item in shoppingList {
-   print(item)
+    print(item)
 }
 // Six eggs
 // Milk
@@ -567,7 +567,7 @@ as part of the iteration:
 
 ```swift
 for (index, value) in shoppingList.enumerated() {
-   print("Item \(index + 1): \(value)")
+    print("Item \(index + 1): \(value)")
 }
 // Item 1: Six eggs
 // Item 2: Milk
@@ -770,9 +770,9 @@ as a shortcut for checking whether the `count` property is equal to `0`:
 
 ```swift
 if favoriteGenres.isEmpty {
-   print("As far as music goes, I'm not picky.")
+    print("As far as music goes, I'm not picky.")
 } else {
-   print("I have particular music preferences.")
+    print("I have particular music preferences.")
 }
 // Prints "I have particular music preferences."
 ```
@@ -817,9 +817,9 @@ Alternatively, all items in a set can be removed with its `removeAll()` method.
 
 ```swift
 if let removedGenre = favoriteGenres.remove("Rock") {
-   print("\(removedGenre)? I'm over it.")
+    print("\(removedGenre)? I'm over it.")
 } else {
-   print("I never much cared for that.")
+    print("I never much cared for that.")
 }
 // Prints "Rock? I'm over it."
 ```
@@ -869,7 +869,7 @@ You can iterate over the values in a set with a `for`-`in` loop.
 
 ```swift
 for genre in favoriteGenres {
-   print("\(genre)")
+    print("\(genre)")
 }
 // Classical
 // [Tool J]
@@ -900,7 +900,7 @@ sorted using the `<` operator.
 
 ```swift
 for genre in favoriteGenres.sorted() {
-   print("\(genre)")
+    print("\(genre)")
 }
 // Classical
 // Hip hop
@@ -1234,9 +1234,9 @@ as a shortcut for checking whether the `count` property is equal to `0`:
 
 ```swift
 if airports.isEmpty {
-   print("The airports dictionary is empty.")
+    print("The airports dictionary is empty.")
 } else {
-   print("The airports dictionary isn't empty.")
+    print("The airports dictionary isn't empty.")
 }
 // Prints "The airports dictionary isn't empty."
 ```
@@ -1313,7 +1313,7 @@ or `nil` if no value existed:
 
 ```swift
 if let oldValue = airports.updateValue("Dublin Airport", forKey: "DUB") {
-   print("The old value for DUB was \(oldValue).")
+    print("The old value for DUB was \(oldValue).")
 }
 // Prints "The old value for DUB was Dublin."
 ```
@@ -1339,9 +1339,9 @@ Otherwise, the subscript returns `nil`:
 
 ```swift
 if let airportName = airports["DUB"] {
-   print("The name of the airport is \(airportName).")
+    print("The name of the airport is \(airportName).")
 } else {
-   print("That airport isn't in the airports dictionary.")
+    print("That airport isn't in the airports dictionary.")
 }
 // Prints "The name of the airport is Dublin Airport."
 ```
@@ -1397,9 +1397,9 @@ or returns `nil` if no value existed:
 
 ```swift
 if let removedValue = airports.removeValue(forKey: "DUB") {
-   print("The removed airport's name is \(removedValue).")
+    print("The removed airport's name is \(removedValue).")
 } else {
-   print("The airports dictionary doesn't contain a value for DUB.")
+    print("The airports dictionary doesn't contain a value for DUB.")
 }
 // Prints "The removed airport's name is Dublin Airport."
 ```
@@ -1427,7 +1427,7 @@ as part of the iteration:
 
 ```swift
 for (airportCode, airportName) in airports {
-   print("\(airportCode): \(airportName)")
+    print("\(airportCode): \(airportName)")
 }
 // LHR: London Heathrow
 // YYZ: Toronto Pearson
@@ -1453,13 +1453,13 @@ by accessing its `keys` and `values` properties:
 
 ```swift
 for airportCode in airports.keys {
-   print("Airport code: \(airportCode)")
+    print("Airport code: \(airportCode)")
 }
 // Airport code: LHR
 // Airport code: YYZ
 
 for airportName in airports.values {
-   print("Airport name: \(airportName)")
+    print("Airport name: \(airportName)")
 }
 // Airport name: London Heathrow
 // Airport name: Toronto Pearson

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/ControlFlow.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/ControlFlow.md
@@ -796,13 +796,13 @@ one or more values of the same type.
 
 ```
 switch <#some value to consider#> {
-   case <#value 1#>:
-      <#respond to value 1#>
-   case <#value 2#>,
-       <#value 3#>:
-      <#respond to value 2 or 3#>
-   default:
-      <#otherwise, do something else#>
+case <#value 1#>:
+    <#respond to value 1#>
+case <#value 2#>,
+    <#value 3#>:
+    <#respond to value 2 or 3#>
+default:
+    <#otherwise, do something else#>
 }
 ```
 
@@ -832,12 +832,12 @@ a single lowercase character called `someCharacter`:
 ```swift
 let someCharacter: Character = "z"
 switch someCharacter {
-    case "a":
-        print("The first letter of the alphabet")
-    case "z":
-        print("The last letter of the alphabet")
-    default:
-        print("Some other character")
+case "a":
+    print("The first letter of the alphabet")
+case "z":
+    print("The last letter of the alphabet")
+default:
+    print("Some other character")
 }
 // Prints "The last letter of the alphabet"
 ```
@@ -891,11 +891,11 @@ It isn't valid to write the following code, because the first case is empty:
 ```swift
 let anotherCharacter: Character = "a"
 switch anotherCharacter {
-    case "a": // Invalid, the case has an empty body
-    case "A":
-        print("The letter A")
-    default:
-        print("Not the letter A")
+case "a": // Invalid, the case has an empty body
+case "A":
+    print("The letter A")
+default:
+    print("Not the letter A")
 }
 // This will report a compile-time error.
 ```
@@ -936,10 +936,10 @@ separating the values with commas.
 ```swift
 let anotherCharacter: Character = "a"
 switch anotherCharacter {
-    case "a", "A":
-        print("The letter A")
-    default:
-        print("Not the letter A")
+case "a", "A":
+    print("The letter A")
+default:
+    print("Not the letter A")
 }
 // Prints "The letter A"
 ```
@@ -1050,16 +1050,16 @@ and categorizes it on the graph that follows the example.
 ```swift
 let somePoint = (1, 1)
 switch somePoint {
-    case (0, 0):
-        print("\(somePoint) is at the origin")
-    case (_, 0):
-        print("\(somePoint) is on the x-axis")
-    case (0, _):
-        print("\(somePoint) is on the y-axis")
-    case (-2...2, -2...2):
-        print("\(somePoint) is inside the box")
-    default:
-        print("\(somePoint) is outside of the box")
+case (0, 0):
+    print("\(somePoint) is at the origin")
+case (_, 0):
+    print("\(somePoint) is on the x-axis")
+case (0, _):
+    print("\(somePoint) is on the y-axis")
+case (-2...2, -2...2):
+    print("\(somePoint) is inside the box")
+default:
+    print("\(somePoint) is outside of the box")
 }
 // Prints "(1, 1) is inside the box"
 ```
@@ -1117,12 +1117,12 @@ and categorizes it on the graph that follows:
 ```swift
 let anotherPoint = (2, 0)
 switch anotherPoint {
-    case (let x, 0):
-        print("on the x-axis with an x value of \(x)")
-    case (0, let y):
-        print("on the y-axis with a y value of \(y)")
-    case let (x, y):
-        print("somewhere else at (\(x), \(y))")
+case (let x, 0):
+    print("on the x-axis with an x value of \(x)")
+case (0, let y):
+    print("on the y-axis with a y value of \(y)")
+case let (x, y):
+    print("somewhere else at (\(x), \(y))")
 }
 // Prints "on the x-axis with an x value of 2"
 ```
@@ -1182,12 +1182,12 @@ The example below categorizes an (x, y) point on the following graph:
 ```swift
 let yetAnotherPoint = (1, -1)
 switch yetAnotherPoint {
-    case let (x, y) where x == y:
-        print("(\(x), \(y)) is on the line x == y")
-    case let (x, y) where x == -y:
-        print("(\(x), \(y)) is on the line x == -y")
-    case let (x, y):
-        print("(\(x), \(y)) is just some arbitrary point")
+case let (x, y) where x == y:
+    print("(\(x), \(y)) is on the line x == y")
+case let (x, y) where x == -y:
+    print("(\(x), \(y)) is on the line x == -y")
+case let (x, y):
+    print("(\(x), \(y)) is just some arbitrary point")
 }
 // Prints "(1, -1) is on the line x == -y"
 ```
@@ -1240,13 +1240,13 @@ For example:
 ```swift
 let someCharacter: Character = "e"
 switch someCharacter {
-    case "a", "e", "i", "o", "u":
-        print("\(someCharacter) is a vowel")
-    case "b", "c", "d", "f", "g", "h", "j", "k", "l", "m",
-        "n", "p", "q", "r", "s", "t", "v", "w", "x", "y", "z":
-        print("\(someCharacter) is a consonant")
-    default:
-        print("\(someCharacter) isn't a vowel or a consonant")
+case "a", "e", "i", "o", "u":
+    print("\(someCharacter) is a vowel")
+case "b", "c", "d", "f", "g", "h", "j", "k", "l", "m",
+    "n", "p", "q", "r", "s", "t", "v", "w", "x", "y", "z":
+    print("\(someCharacter) is a consonant")
+default:
+    print("\(someCharacter) isn't a vowel or a consonant")
 }
 // Prints "e is a vowel"
 ```
@@ -1289,10 +1289,10 @@ and that the value always has the same type.
 ```swift
 let stillAnotherPoint = (9, 0)
 switch stillAnotherPoint {
-    case (let distance, 0), (0, let distance):
-        print("On an axis, \(distance) from the origin")
-    default:
-        print("Not on an axis")
+case (let distance, 0), (0, let distance):
+    print("On an axis, \(distance) from the origin")
+default:
+    print("Not on an axis")
 }
 // Prints "On an axis, 9 from the origin"
 ```
@@ -1431,16 +1431,16 @@ For brevity, multiple values are covered in a single `switch` case.
 let numberSymbol: Character = "三"  // Chinese symbol for the number 3
 var possibleIntegerValue: Int?
 switch numberSymbol {
-    case "1", "١", "一", "๑":
-        possibleIntegerValue = 1
-    case "2", "٢", "二", "๒":
-        possibleIntegerValue = 2
-    case "3", "٣", "三", "๓":
-        possibleIntegerValue = 3
-    case "4", "٤", "四", "๔":
-        possibleIntegerValue = 4
-    default:
-        break
+case "1", "١", "一", "๑":
+    possibleIntegerValue = 1
+case "2", "٢", "二", "๒":
+    possibleIntegerValue = 2
+case "3", "٣", "三", "๓":
+    possibleIntegerValue = 3
+case "4", "٤", "四", "๔":
+    possibleIntegerValue = 4
+default:
+    break
 }
 if let integerValue = possibleIntegerValue {
     print("The integer value of \(numberSymbol) is \(integerValue).")
@@ -1520,11 +1520,11 @@ The example below uses `fallthrough` to create a textual description of a number
 let integerToDescribe = 5
 var description = "The number \(integerToDescribe) is"
 switch integerToDescribe {
-    case 2, 3, 5, 7, 11, 13, 17, 19:
-        description += " a prime number, and also"
-        fallthrough
-    default:
-        description += " an integer."
+case 2, 3, 5, 7, 11, 13, 17, 19:
+    description += " a prime number, and also"
+    fallthrough
+default:
+    description += " an integer."
 }
 print(description)
 // Prints "The number 5 is a prime number, and also an integer."
@@ -1664,16 +1664,16 @@ gameLoop: while square != finalSquare {
     diceRoll += 1
     if diceRoll == 7 { diceRoll = 1 }
     switch square + diceRoll {
-        case finalSquare:
-            // diceRoll will move us to the final square, so the game is over
-            break gameLoop
-        case let newSquare where newSquare > finalSquare:
-            // diceRoll will move us beyond the final square, so roll again
-            continue gameLoop
-        default:
-            // this is a valid move, so find out its effect
-            square += diceRoll
-            square += board[square]
+    case finalSquare:
+        // diceRoll will move us to the final square, so the game is over
+        break gameLoop
+    case let newSquare where newSquare > finalSquare:
+        // diceRoll will move us beyond the final square, so roll again
+        continue gameLoop
+    default:
+        // this is a valid move, so find out its effect
+        square += diceRoll
+        square += board[square]
     }
 }
 print("Game over!")

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/ControlFlow.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/ControlFlow.md
@@ -30,7 +30,7 @@ This example uses a `for`-`in` loop to iterate over the items in an array:
 ```swift
 let names = ["Anna", "Alex", "Brian", "Jack"]
 for name in names {
-   print("Hello, \(name)!")
+    print("Hello, \(name)!")
 }
 // Hello, Anna!
 // Hello, Alex!
@@ -65,7 +65,7 @@ and the dictionary's values are decomposed into a constant called `legCount`.
 ```swift
 let numberOfLegs = ["spider": 8, "ant": 6, "cat": 4]
 for (animalName, legCount) in numberOfLegs {
-   print("\(animalName)s have \(legCount) legs")
+    print("\(animalName)s have \(legCount) legs")
 }
 // cats have 4 legs
 // ants have 6 legs
@@ -105,7 +105,7 @@ This example prints the first few entries in a five-times table:
 
 ```swift
 for index in 1...5 {
-   print("\(index) times 5 is \(index * 5)")
+    print("\(index) times 5 is \(index * 5)")
 }
 // 1 times 5 is 5
 // 2 times 5 is 10
@@ -156,7 +156,7 @@ let base = 3
 let power = 10
 var answer = 1
 for _ in 1...power {
-   answer *= base
+    answer *= base
 }
 print("\(base) to the power of \(power) is \(answer)")
 // Prints "3 to the power of 10 is 59049"
@@ -202,7 +202,7 @@ For more about ranges, see <doc:BasicOperators#Range-Operators>.
 ```swift
 let minutes = 60
 for tickMark in 0..<minutes {
-   // render the tick mark each minute (60 times)
+    // render the tick mark each minute (60 times)
 }
 ```
 
@@ -229,7 +229,7 @@ Use the `stride(from:to:by:)` function to skip the unwanted marks.
 ```swift
 let minuteInterval = 5
 for tickMark in stride(from: 0, to: minutes, by: minuteInterval) {
-   // render the tick mark every 5 minutes (0, 5, 10, 15 ... 45, 50, 55)
+    // render the tick mark every 5 minutes (0, 5, 10, 15 ... 45, 50, 55)
 }
 ```
 
@@ -255,7 +255,7 @@ Closed ranges are also available, by using `stride(from:through:by:)` instead:
 let hours = 12
 let hourInterval = 3
 for tickMark in stride(from: 3, through: hours, by: hourInterval) {
-   // render the tick mark every 3 hours (3, 6, 9, 12)
+    // render the tick mark every 3 hours (3, 6, 9, 12)
 }
 ```
 
@@ -394,15 +394,15 @@ but they lead to neater code.)
 var square = 0
 var diceRoll = 0
 while square < finalSquare {
-   // roll the dice
-   diceRoll += 1
-   if diceRoll == 7 { diceRoll = 1 }
-   // move by the rolled amount
-   square += diceRoll
-   if square < board.count {
-      // if we're still on the board, move up or down for a snake or a ladder
-      square += board[square]
-   }
+    // roll the dice
+    diceRoll += 1
+    if diceRoll == 7 { diceRoll = 1 }
+    // move by the rolled amount
+    square += diceRoll
+    if square < board.count {
+        // if we're still on the board, move up or down for a snake or a ladder
+        square += board[square]
+    }
 }
 print("Game over!")
 ```
@@ -555,13 +555,13 @@ At the start of the game, the player is on “square zero”.
 
 ```swift
 repeat {
-   // move up or down for a snake or ladder
-   square += board[square]
-   // roll the dice
-   diceRoll += 1
-   if diceRoll == 7 { diceRoll = 1 }
-   // move by the rolled amount
-   square += diceRoll
+    // move up or down for a snake or ladder
+    square += board[square]
+    // roll the dice
+    diceRoll += 1
+    if diceRoll == 7 { diceRoll = 1 }
+    // move by the rolled amount
+    square += diceRoll
 } while square < finalSquare
 print("Game over!")
 ```
@@ -657,7 +657,7 @@ It executes a set of statements only if that condition is `true`.
 ```swift
 var temperatureInFahrenheit = 30
 if temperatureInFahrenheit <= 32 {
-   print("It's very cold. Consider wearing a scarf.")
+    print("It's very cold. Consider wearing a scarf.")
 }
 // Prints "It's very cold. Consider wearing a scarf."
 ```
@@ -690,9 +690,9 @@ These statements are indicated by the `else` keyword.
 ```swift
 temperatureInFahrenheit = 40
 if temperatureInFahrenheit <= 32 {
-   print("It's very cold. Consider wearing a scarf.")
+    print("It's very cold. Consider wearing a scarf.")
 } else {
-   print("It's not that cold. Wear a t-shirt.")
+    print("It's not that cold. Wear a t-shirt.")
 }
 // Prints "It's not that cold. Wear a t-shirt."
 ```
@@ -723,11 +723,11 @@ to consider additional clauses.
 ```swift
 temperatureInFahrenheit = 90
 if temperatureInFahrenheit <= 32 {
-   print("It's very cold. Consider wearing a scarf.")
+    print("It's very cold. Consider wearing a scarf.")
 } else if temperatureInFahrenheit >= 86 {
-   print("It's really warm. Don't forget to wear sunscreen.")
+    print("It's really warm. Don't forget to wear sunscreen.")
 } else {
-   print("It's not that cold. Wear a t-shirt.")
+    print("It's not that cold. Wear a t-shirt.")
 }
 // Prints "It's really warm. Don't forget to wear sunscreen."
 ```
@@ -759,9 +759,9 @@ and can be excluded if the set of conditions doesn't need to be complete.
 ```swift
 temperatureInFahrenheit = 72
 if temperatureInFahrenheit <= 32 {
-   print("It's very cold. Consider wearing a scarf.")
+    print("It's very cold. Consider wearing a scarf.")
 } else if temperatureInFahrenheit >= 86 {
-   print("It's really warm. Don't forget to wear sunscreen.")
+    print("It's really warm. Don't forget to wear sunscreen.")
 }
 ```
 
@@ -832,12 +832,12 @@ a single lowercase character called `someCharacter`:
 ```swift
 let someCharacter: Character = "z"
 switch someCharacter {
-   case "a":
-      print("The first letter of the alphabet")
-   case "z":
-      print("The last letter of the alphabet")
-   default:
-      print("Some other character")
+    case "a":
+        print("The first letter of the alphabet")
+    case "z":
+        print("The last letter of the alphabet")
+    default:
+        print("Some other character")
 }
 // Prints "The last letter of the alphabet"
 ```
@@ -891,11 +891,11 @@ It isn't valid to write the following code, because the first case is empty:
 ```swift
 let anotherCharacter: Character = "a"
 switch anotherCharacter {
-   case "a": // Invalid, the case has an empty body
-   case "A":
-      print("The letter A")
-   default:
-      print("Not the letter A")
+    case "a": // Invalid, the case has an empty body
+    case "A":
+        print("The letter A")
+    default:
+        print("Not the letter A")
 }
 // This will report a compile-time error.
 ```
@@ -936,10 +936,10 @@ separating the values with commas.
 ```swift
 let anotherCharacter: Character = "a"
 switch anotherCharacter {
-   case "a", "A":
-      print("The letter A")
-   default:
-      print("Not the letter A")
+    case "a", "A":
+        print("The letter A")
+    default:
+        print("Not the letter A")
 }
 // Prints "The letter A"
 ```
@@ -1050,16 +1050,16 @@ and categorizes it on the graph that follows the example.
 ```swift
 let somePoint = (1, 1)
 switch somePoint {
-   case (0, 0):
-      print("\(somePoint) is at the origin")
-   case (_, 0):
-      print("\(somePoint) is on the x-axis")
-   case (0, _):
-      print("\(somePoint) is on the y-axis")
-   case (-2...2, -2...2):
-      print("\(somePoint) is inside the box")
-   default:
-      print("\(somePoint) is outside of the box")
+    case (0, 0):
+        print("\(somePoint) is at the origin")
+    case (_, 0):
+        print("\(somePoint) is on the x-axis")
+    case (0, _):
+        print("\(somePoint) is on the y-axis")
+    case (-2...2, -2...2):
+        print("\(somePoint) is inside the box")
+    default:
+        print("\(somePoint) is outside of the box")
 }
 // Prints "(1, 1) is inside the box"
 ```
@@ -1117,12 +1117,12 @@ and categorizes it on the graph that follows:
 ```swift
 let anotherPoint = (2, 0)
 switch anotherPoint {
-   case (let x, 0):
-      print("on the x-axis with an x value of \(x)")
-   case (0, let y):
-      print("on the y-axis with a y value of \(y)")
-   case let (x, y):
-      print("somewhere else at (\(x), \(y))")
+    case (let x, 0):
+        print("on the x-axis with an x value of \(x)")
+    case (0, let y):
+        print("on the y-axis with a y value of \(y)")
+    case let (x, y):
+        print("somewhere else at (\(x), \(y))")
 }
 // Prints "on the x-axis with an x value of 2"
 ```
@@ -1182,12 +1182,12 @@ The example below categorizes an (x, y) point on the following graph:
 ```swift
 let yetAnotherPoint = (1, -1)
 switch yetAnotherPoint {
-   case let (x, y) where x == y:
-      print("(\(x), \(y)) is on the line x == y")
-   case let (x, y) where x == -y:
-      print("(\(x), \(y)) is on the line x == -y")
-   case let (x, y):
-      print("(\(x), \(y)) is just some arbitrary point")
+    case let (x, y) where x == y:
+        print("(\(x), \(y)) is on the line x == y")
+    case let (x, y) where x == -y:
+        print("(\(x), \(y)) is on the line x == -y")
+    case let (x, y):
+        print("(\(x), \(y)) is just some arbitrary point")
 }
 // Prints "(1, -1) is on the line x == -y"
 ```
@@ -1352,10 +1352,10 @@ let puzzleInput = "great minds think alike"
 var puzzleOutput = ""
 let charactersToRemove: [Character] = ["a", "e", "i", "o", "u", " "]
 for character in puzzleInput {
-   if charactersToRemove.contains(character) {
-      continue
-   }
-   puzzleOutput.append(character)
+    if charactersToRemove.contains(character) {
+        continue
+    }
+    puzzleOutput.append(character)
 }
 print(puzzleOutput)
 // Prints "grtmndsthnklk"
@@ -1431,21 +1431,21 @@ For brevity, multiple values are covered in a single `switch` case.
 let numberSymbol: Character = "三"  // Chinese symbol for the number 3
 var possibleIntegerValue: Int?
 switch numberSymbol {
-   case "1", "١", "一", "๑":
-      possibleIntegerValue = 1
-   case "2", "٢", "二", "๒":
-      possibleIntegerValue = 2
-   case "3", "٣", "三", "๓":
-      possibleIntegerValue = 3
-   case "4", "٤", "四", "๔":
-      possibleIntegerValue = 4
-   default:
-      break
+    case "1", "١", "一", "๑":
+        possibleIntegerValue = 1
+    case "2", "٢", "二", "๒":
+        possibleIntegerValue = 2
+    case "3", "٣", "三", "๓":
+        possibleIntegerValue = 3
+    case "4", "٤", "四", "๔":
+        possibleIntegerValue = 4
+    default:
+        break
 }
 if let integerValue = possibleIntegerValue {
-   print("The integer value of \(numberSymbol) is \(integerValue).")
+    print("The integer value of \(numberSymbol) is \(integerValue).")
 } else {
-   print("An integer value couldn't be found for \(numberSymbol).")
+    print("An integer value couldn't be found for \(numberSymbol).")
 }
 // Prints "The integer value of 三 is 3."
 ```
@@ -1520,11 +1520,11 @@ The example below uses `fallthrough` to create a textual description of a number
 let integerToDescribe = 5
 var description = "The number \(integerToDescribe) is"
 switch integerToDescribe {
-   case 2, 3, 5, 7, 11, 13, 17, 19:
-      description += " a prime number, and also"
-      fallthrough
-   default:
-      description += " an integer."
+    case 2, 3, 5, 7, 11, 13, 17, 19:
+        description += " a prime number, and also"
+        fallthrough
+    default:
+        description += " an integer."
 }
 print(description)
 // Prints "The number 5 is a prime number, and also an integer."
@@ -1661,20 +1661,20 @@ to reflect that you must land exactly on square 25.
 
 ```swift
 gameLoop: while square != finalSquare {
-   diceRoll += 1
-   if diceRoll == 7 { diceRoll = 1 }
-   switch square + diceRoll {
-      case finalSquare:
-         // diceRoll will move us to the final square, so the game is over
-         break gameLoop
-      case let newSquare where newSquare > finalSquare:
-         // diceRoll will move us beyond the final square, so roll again
-         continue gameLoop
-      default:
-         // this is a valid move, so find out its effect
-         square += diceRoll
-         square += board[square]
-   }
+    diceRoll += 1
+    if diceRoll == 7 { diceRoll = 1 }
+    switch square + diceRoll {
+        case finalSquare:
+            // diceRoll will move us to the final square, so the game is over
+            break gameLoop
+        case let newSquare where newSquare > finalSquare:
+            // diceRoll will move us beyond the final square, so roll again
+            continue gameLoop
+        default:
+            // this is a valid move, so find out its effect
+            square += diceRoll
+            square += board[square]
+    }
 }
 print("Game over!")
 ```
@@ -1942,11 +1942,11 @@ struct ColorPreference {
 }
 
 func chooseBestColor() -> String {
-   guard #available(macOS 10.12, *) else {
+    guard #available(macOS 10.12, *) else {
        return "gray"
-   }
-   let colors = ColorPreference()
-   return colors.bestColor
+    }
+    let colors = ColorPreference()
+    return colors.bestColor
 }
 ```
 
@@ -1987,11 +1987,11 @@ For example, the following two checks do the same thing:
 ```swift
 if #available(iOS 10, *) {
 } else {
-   // Fallback code
+    // Fallback code
 }
 
 if #unavailable(iOS 10) {
-   // Fallback code
+    // Fallback code
 }
 ```
 

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Deinitialization.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Deinitialization.md
@@ -26,7 +26,7 @@ and is written without parentheses:
 
 ```swift
 deinit {
-   // perform the deinitialization
+    // perform the deinitialization
 }
 ```
 
@@ -68,15 +68,15 @@ to store and manage its current state:
 
 ```swift
 class Bank {
-   static var coinsInBank = 10_000
-   static func distribute(coins numberOfCoinsRequested: Int) -> Int {
-      let numberOfCoinsToVend = min(numberOfCoinsRequested, coinsInBank)
-      coinsInBank -= numberOfCoinsToVend
-      return numberOfCoinsToVend
-   }
-   static func receive(coins: Int) {
-      coinsInBank += coins
-   }
+    static var coinsInBank = 10_000
+    static func distribute(coins numberOfCoinsRequested: Int) -> Int {
+        let numberOfCoinsToVend = min(numberOfCoinsRequested, coinsInBank)
+        coinsInBank -= numberOfCoinsToVend
+        return numberOfCoinsToVend
+    }
+    static func receive(coins: Int) {
+        coinsInBank += coins
+    }
 }
 ```
 
@@ -117,16 +117,16 @@ This is represented by the player's `coinsInPurse` property:
 
 ```swift
 class Player {
-   var coinsInPurse: Int
-   init(coins: Int) {
-      coinsInPurse = Bank.distribute(coins: coins)
-   }
-   func win(coins: Int) {
-      coinsInPurse += Bank.distribute(coins: coins)
-   }
-   deinit {
-      Bank.receive(coins: coinsInPurse)
-   }
+    var coinsInPurse: Int
+    init(coins: Int) {
+        coinsInPurse = Bank.distribute(coins: coins)
+    }
+    func win(coins: Int) {
+        coinsInPurse += Bank.distribute(coins: coins)
+    }
+    deinit {
+        Bank.receive(coins: coinsInPurse)
+    }
 }
 ```
 

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Enumerations.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Enumerations.md
@@ -45,7 +45,7 @@ and place their entire definition within a pair of braces:
 
 ```swift
 enum SomeEnumeration {
-   // enumeration definition goes here
+    // enumeration definition goes here
 }
 ```
 
@@ -64,10 +64,10 @@ Here's an example for the four main points of a compass:
 
 ```swift
 enum CompassPoint {
-   case north
-   case south
-   case east
-   case west
+    case north
+    case south
+    case east
+    case west
 }
 ```
 
@@ -103,7 +103,7 @@ Multiple cases can appear on a single line, separated by commas:
 
 ```swift
 enum Planet {
-   case mercury, venus, earth, mars, jupiter, saturn, uranus, neptune
+    case mercury, venus, earth, mars, jupiter, saturn, uranus, neptune
 }
 ```
 
@@ -167,14 +167,14 @@ You can match individual enumeration values with a `switch` statement:
 ```swift
 directionToHead = .south
 switch directionToHead {
-   case .north:
-      print("Lots of planets have a north")
-   case .south:
-      print("Watch out for penguins")
-   case .east:
-      print("Where the sun rises")
-   case .west:
-      print("Where the skies are blue")
+    case .north:
+        print("Lots of planets have a north")
+    case .south:
+        print("Watch out for penguins")
+    case .east:
+        print("Where the sun rises")
+    case .west:
+        print("Where the skies are blue")
 }
 // Prints "Watch out for penguins"
 ```
@@ -222,10 +222,10 @@ you can provide a `default` case to cover any cases that aren't addressed explic
 ```swift
 let somePlanet = Planet.earth
 switch somePlanet {
-   case .earth:
-      print("Mostly harmless")
-   default:
-      print("Not a safe place for humans")
+    case .earth:
+        print("Mostly harmless")
+    default:
+        print("Not a safe place for humans")
 }
 // Prints "Mostly harmless"
 ```
@@ -362,8 +362,8 @@ In Swift, an enumeration to define product barcodes of either type might look li
 
 ```swift
 enum Barcode {
-   case upc(Int, Int, Int, Int)
-   case qrCode(String)
+    case upc(Int, Int, Int, Int)
+    case qrCode(String)
 }
 ```
 
@@ -443,10 +443,10 @@ for use within the `switch` case's body:
 
 ```swift
 switch productBarcode {
-   case .upc(let numberSystem, let manufacturer, let product, let check):
-      print("UPC: \(numberSystem), \(manufacturer), \(product), \(check).")
-   case .qrCode(let productCode):
-      print("QR code: \(productCode).")
+    case .upc(let numberSystem, let manufacturer, let product, let check):
+        print("UPC: \(numberSystem), \(manufacturer), \(product), \(check).")
+    case .qrCode(let productCode):
+        print("QR code: \(productCode).")
 }
 // Prints "QR code: ABCDEFGHIJKLMNOP."
 ```
@@ -472,10 +472,10 @@ you can place a single `var` or `let` annotation before the case name, for brevi
 
 ```swift
 switch productBarcode {
-   case let .upc(numberSystem, manufacturer, product, check):
-      print("UPC : \(numberSystem), \(manufacturer), \(product), \(check).")
-   case let .qrCode(productCode):
-      print("QR code: \(productCode).")
+    case let .upc(numberSystem, manufacturer, product, check):
+        print("UPC : \(numberSystem), \(manufacturer), \(product), \(check).")
+    case let .qrCode(productCode):
+        print("QR code: \(productCode).")
 }
 // Prints "QR code: ABCDEFGHIJKLMNOP."
 ```
@@ -509,9 +509,9 @@ Here's an example that stores raw ASCII values alongside named enumeration cases
 
 ```swift
 enum ASCIIControlCharacter: Character {
-   case tab = "\t"
-   case lineFeed = "\n"
-   case carriageReturn = "\r"
+    case tab = "\t"
+    case lineFeed = "\n"
+    case carriageReturn = "\r"
 }
 ```
 
@@ -561,7 +561,7 @@ with integer raw values to represent each planet's order from the sun:
 
 ```swift
 enum Planet: Int {
-   case mercury = 1, venus, earth, mars, jupiter, saturn, uranus, neptune
+    case mercury = 1, venus, earth, mars, jupiter, saturn, uranus, neptune
 }
 ```
 
@@ -588,7 +588,7 @@ with string raw values to represent each direction's name:
 
 ```swift
 enum CompassPoint: String {
-   case north, south, east, west
+    case north, south, east, west
 }
 ```
 
@@ -674,14 +674,14 @@ the optional `Planet` value returned by the raw value initializer will be `nil`:
 ```swift
 let positionToFind = 11
 if let somePlanet = Planet(rawValue: positionToFind) {
-   switch somePlanet {
-      case .earth:
-         print("Mostly harmless")
-      default:
-         print("Not a safe place for humans")
-   }
+    switch somePlanet {
+        case .earth:
+            print("Mostly harmless")
+        default:
+            print("Not a safe place for humans")
+    }
 } else {
-   print("There isn't a planet at position \(positionToFind)")
+    print("There isn't a planet at position \(positionToFind)")
 }
 // Prints "There isn't a planet at position 11"
 ```
@@ -816,11 +816,11 @@ For example, here's a function that evaluates an arithmetic expression:
 func evaluate(_ expression: ArithmeticExpression) -> Int {
     switch expression {
         case let .number(value):
-            return value
+                return value
         case let .addition(left, right):
-            return evaluate(left) + evaluate(right)
+                return evaluate(left) + evaluate(right)
         case let .multiplication(left, right):
-            return evaluate(left) * evaluate(right)
+                return evaluate(left) * evaluate(right)
     }
 }
 

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Enumerations.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Enumerations.md
@@ -167,14 +167,14 @@ You can match individual enumeration values with a `switch` statement:
 ```swift
 directionToHead = .south
 switch directionToHead {
-    case .north:
-        print("Lots of planets have a north")
-    case .south:
-        print("Watch out for penguins")
-    case .east:
-        print("Where the sun rises")
-    case .west:
-        print("Where the skies are blue")
+case .north:
+    print("Lots of planets have a north")
+case .south:
+    print("Watch out for penguins")
+case .east:
+    print("Where the sun rises")
+case .west:
+    print("Where the skies are blue")
 }
 // Prints "Watch out for penguins"
 ```
@@ -222,10 +222,10 @@ you can provide a `default` case to cover any cases that aren't addressed explic
 ```swift
 let somePlanet = Planet.earth
 switch somePlanet {
-    case .earth:
-        print("Mostly harmless")
-    default:
-        print("Not a safe place for humans")
+case .earth:
+    print("Mostly harmless")
+default:
+    print("Not a safe place for humans")
 }
 // Prints "Mostly harmless"
 ```
@@ -443,10 +443,10 @@ for use within the `switch` case's body:
 
 ```swift
 switch productBarcode {
-    case .upc(let numberSystem, let manufacturer, let product, let check):
-        print("UPC: \(numberSystem), \(manufacturer), \(product), \(check).")
-    case .qrCode(let productCode):
-        print("QR code: \(productCode).")
+case .upc(let numberSystem, let manufacturer, let product, let check):
+    print("UPC: \(numberSystem), \(manufacturer), \(product), \(check).")
+case .qrCode(let productCode):
+    print("QR code: \(productCode).")
 }
 // Prints "QR code: ABCDEFGHIJKLMNOP."
 ```
@@ -472,10 +472,10 @@ you can place a single `var` or `let` annotation before the case name, for brevi
 
 ```swift
 switch productBarcode {
-    case let .upc(numberSystem, manufacturer, product, check):
-        print("UPC : \(numberSystem), \(manufacturer), \(product), \(check).")
-    case let .qrCode(productCode):
-        print("QR code: \(productCode).")
+case let .upc(numberSystem, manufacturer, product, check):
+    print("UPC : \(numberSystem), \(manufacturer), \(product), \(check).")
+case let .qrCode(productCode):
+    print("QR code: \(productCode).")
 }
 // Prints "QR code: ABCDEFGHIJKLMNOP."
 ```
@@ -675,10 +675,10 @@ the optional `Planet` value returned by the raw value initializer will be `nil`:
 let positionToFind = 11
 if let somePlanet = Planet(rawValue: positionToFind) {
     switch somePlanet {
-        case .earth:
-            print("Mostly harmless")
-        default:
-            print("Not a safe place for humans")
+    case .earth:
+        print("Mostly harmless")
+    default:
+        print("Not a safe place for humans")
     }
 } else {
     print("There isn't a planet at position \(positionToFind)")
@@ -815,12 +815,12 @@ For example, here's a function that evaluates an arithmetic expression:
 ```swift
 func evaluate(_ expression: ArithmeticExpression) -> Int {
     switch expression {
-        case let .number(value):
-            return value
-        case let .addition(left, right):
-            return evaluate(left) + evaluate(right)
-        case let .multiplication(left, right):
-            return evaluate(left) * evaluate(right)
+    case let .number(value):
+        return value
+    case let .addition(left, right):
+        return evaluate(left) + evaluate(right)
+    case let .multiplication(left, right):
+        return evaluate(left) * evaluate(right)
     }
 }
 

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Enumerations.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Enumerations.md
@@ -816,11 +816,11 @@ For example, here's a function that evaluates an arithmetic expression:
 func evaluate(_ expression: ArithmeticExpression) -> Int {
     switch expression {
         case let .number(value):
-                return value
+            return value
         case let .addition(left, right):
-                return evaluate(left) + evaluate(right)
+            return evaluate(left) + evaluate(right)
         case let .multiplication(left, right):
-                return evaluate(left) * evaluate(right)
+            return evaluate(left) * evaluate(right)
     }
 }
 

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/ErrorHandling.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/ErrorHandling.md
@@ -214,15 +214,15 @@ class VendingMachine {
 
     func vend(itemNamed name: String) throws {
         guard let item = inventory[name] else {
-                throw VendingMachineError.invalidSelection
+            throw VendingMachineError.invalidSelection
         }
 
         guard item.count > 0 else {
-                throw VendingMachineError.outOfStock
+            throw VendingMachineError.outOfStock
         }
 
         guard item.price <= coinsDeposited else {
-                throw VendingMachineError.insufficientFunds(coinsNeeded: item.price - coinsDeposited)
+            throw VendingMachineError.insufficientFunds(coinsNeeded: item.price - coinsDeposited)
         }
 
         coinsDeposited -= item.price

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/ErrorHandling.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/ErrorHandling.md
@@ -200,8 +200,8 @@ or has a cost that exceeds the current deposited amount:
 
 ```swift
 struct Item {
-   var price: Int
-   var count: Int
+    var price: Int
+    var count: Int
 }
 
 class VendingMachine {
@@ -214,15 +214,15 @@ class VendingMachine {
 
     func vend(itemNamed name: String) throws {
         guard let item = inventory[name] else {
-            throw VendingMachineError.invalidSelection
+                throw VendingMachineError.invalidSelection
         }
 
         guard item.count > 0 else {
-            throw VendingMachineError.outOfStock
+                throw VendingMachineError.outOfStock
         }
 
         guard item.price <= coinsDeposited else {
-            throw VendingMachineError.insufficientFunds(coinsNeeded: item.price - coinsDeposited)
+                throw VendingMachineError.insufficientFunds(coinsNeeded: item.price - coinsDeposited)
         }
 
         coinsDeposited -= item.price
@@ -604,7 +604,7 @@ in the following code `x` and `y` have the same value and behavior:
 
 ```swift
 func someThrowingFunction() throws -> Int {
-   // ...
+    // ...
 }
 
 let x = try? someThrowingFunction()
@@ -740,16 +740,16 @@ The last `defer` statement in source code order executes first.
 
 ```swift
 func processFile(filename: String) throws {
-   if exists(filename) {
-      let file = open(filename)
-      defer {
-         close(file)
-      }
-      while let line = try file.readline() {
-         // Work with the file.
-      }
-      // close(file) is called here, at the end of the scope.
-   }
+    if exists(filename) {
+        let file = open(filename)
+        defer {
+            close(file)
+        }
+        while let line = try file.readline() {
+            // Work with the file.
+        }
+        // close(file) is called here, at the end of the scope.
+    }
 }
 ```
 

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Extensions.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Extensions.md
@@ -81,7 +81,7 @@ Declare extensions with the `extension` keyword:
 
 ```swift
 extension SomeType {
-   // new functionality to add to SomeType goes here
+    // new functionality to add to SomeType goes here
 }
 ```
 
@@ -104,7 +104,7 @@ the same way as you write them for a class or structure:
 
 ```swift
 extension SomeType: SomeProtocol, AnotherProtocol {
-   // implementation of protocol requirements goes here
+    // implementation of protocol requirements goes here
 }
 ```
 
@@ -141,11 +141,11 @@ to provide basic support for working with distance units:
 
 ```swift
 extension Double {
-   var km: Double { return self * 1_000.0 }
-   var m: Double { return self }
-   var cm: Double { return self / 100.0 }
-   var mm: Double { return self / 1_000.0 }
-   var ft: Double { return self / 3.28084 }
+    var km: Double { return self * 1_000.0 }
+    var m: Double { return self }
+    var cm: Double { return self / 100.0 }
+    var mm: Double { return self / 1_000.0 }
+    var ft: Double { return self / 3.28084 }
 }
 let oneInch = 25.4.mm
 print("One inch is \(oneInch) meters")
@@ -269,14 +269,14 @@ both of which provide default values of `0.0` for all of their properties:
 
 ```swift
 struct Size {
-   var width = 0.0, height = 0.0
+    var width = 0.0, height = 0.0
 }
 struct Point {
-   var x = 0.0, y = 0.0
+    var x = 0.0, y = 0.0
 }
 struct Rect {
-   var origin = Point()
-   var size = Size()
+    var origin = Point()
+    var size = Size()
 }
 ```
 
@@ -306,7 +306,7 @@ These initializers can be used to create new `Rect` instances:
 ```swift
 let defaultRect = Rect()
 let memberwiseRect = Rect(origin: Point(x: 2.0, y: 2.0),
-   size: Size(width: 5.0, height: 5.0))
+    size: Size(width: 5.0, height: 5.0))
 ```
 
 
@@ -325,11 +325,11 @@ that takes a specific center point and size:
 
 ```swift
 extension Rect {
-   init(center: Point, size: Size) {
-      let originX = center.x - (size.width / 2)
-      let originY = center.y - (size.height / 2)
-      self.init(origin: Point(x: originX, y: originY), size: size)
-   }
+    init(center: Point, size: Size) {
+        let originX = center.x - (size.width / 2)
+        let originY = center.y - (size.height / 2)
+        self.init(origin: Point(x: originX, y: originY), size: size)
+    }
 }
 ```
 
@@ -356,7 +356,7 @@ in the appropriate properties:
 
 ```swift
 let centerRect = Rect(center: Point(x: 4.0, y: 4.0),
-   size: Size(width: 3.0, height: 3.0))
+    size: Size(width: 3.0, height: 3.0))
 // centerRect's origin is (2.5, 2.5) and its size is (3.0, 3.0)
 ```
 
@@ -383,11 +383,11 @@ The following example adds a new instance method called `repetitions` to the `In
 
 ```swift
 extension Int {
-   func repetitions(task: () -> Void) {
-      for _ in 0..<self {
-         task()
-      }
-   }
+    func repetitions(task: () -> Void) {
+        for _ in 0..<self {
+            task()
+        }
+    }
 }
 ```
 
@@ -415,7 +415,7 @@ to perform a task that many number of times:
 
 ```swift
 3.repetitions {
-   print("Hello!")
+    print("Hello!")
 }
 // Hello!
 // Hello!
@@ -448,9 +448,9 @@ which squares the original value:
 
 ```swift
 extension Int {
-   mutating func square() {
-      self = self * self
-   }
+    mutating func square() {
+        self = self * self
+    }
 }
 var someInt = 3
 someInt.square()
@@ -488,13 +488,13 @@ from the right of the number:
 
 ```swift
 extension Int {
-   subscript(digitIndex: Int) -> Int {
-      var decimalBase = 1
-      for _ in 0..<digitIndex {
-         decimalBase *= 10
-      }
-      return (self / decimalBase) % 10
-   }
+    subscript(digitIndex: Int) -> Int {
+        var decimalBase = 1
+        for _ in 0..<digitIndex {
+            decimalBase *= 10
+        }
+        return (self / decimalBase) % 10
+    }
 }
 746381295[0]
 // returns 5
@@ -589,19 +589,19 @@ Extensions can add new nested types to existing classes, structures, and enumera
 
 ```swift
 extension Int {
-   enum Kind {
-      case negative, zero, positive
-   }
-   var kind: Kind {
-      switch self {
-         case 0:
-            return .zero
-         case let x where x > 0:
-            return .positive
-         default:
-            return .negative
-      }
-   }
+    enum Kind {
+        case negative, zero, positive
+    }
+    var kind: Kind {
+        switch self {
+            case 0:
+                return .zero
+            case let x where x > 0:
+                return .positive
+            default:
+                return .negative
+        }
+    }
 }
 ```
 
@@ -642,17 +642,17 @@ The nested enumeration can now be used with any `Int` value:
 
 ```swift
 func printIntegerKinds(_ numbers: [Int]) {
-   for number in numbers {
-      switch number.kind {
-         case .negative:
-            print("- ", terminator: "")
-         case .zero:
-            print("0 ", terminator: "")
-         case .positive:
-            print("+ ", terminator: "")
-      }
-   }
-   print("")
+    for number in numbers {
+        switch number.kind {
+            case .negative:
+                print("- ", terminator: "")
+            case .zero:
+                print("0 ", terminator: "")
+            case .positive:
+                print("+ ", terminator: "")
+        }
+    }
+    print("")
 }
 printIntegerKinds([3, 19, -27, 0, -6, 0, 7])
 // Prints "+ + - 0 - 0 + "

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Extensions.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Extensions.md
@@ -594,12 +594,12 @@ extension Int {
     }
     var kind: Kind {
         switch self {
-            case 0:
-                return .zero
-            case let x where x > 0:
-                return .positive
-            default:
-                return .negative
+        case 0:
+            return .zero
+        case let x where x > 0:
+            return .positive
+        default:
+            return .negative
         }
     }
 }
@@ -644,12 +644,12 @@ The nested enumeration can now be used with any `Int` value:
 func printIntegerKinds(_ numbers: [Int]) {
     for number in numbers {
         switch number.kind {
-            case .negative:
-                print("- ", terminator: "")
-            case .zero:
-                print("0 ", terminator: "")
-            case .positive:
-                print("+ ", terminator: "")
+        case .negative:
+            print("- ", terminator: "")
+        case .zero:
+            print("0 ", terminator: "")
+        case .positive:
+            print("+ ", terminator: "")
         }
     }
     print("")

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Functions.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Functions.md
@@ -49,8 +49,8 @@ which will contain a greeting for that person:
 
 ```swift
 func greet(person: String) -> String {
-   let greeting = "Hello, " + person + "!"
-   return greeting
+    let greeting = "Hello, " + person + "!"
+    return greeting
 }
 ```
 
@@ -128,7 +128,7 @@ you can combine the message creation and the return statement into one line:
 
 ```swift
 func greetAgain(person: String) -> String {
-   return "Hello again, " + person + "!"
+    return "Hello again, " + person + "!"
 }
 print(greetAgain(person: "Anna"))
 // Prints "Hello again, Anna!"
@@ -161,7 +161,7 @@ which always returns the same `String` message whenever it's called:
 
 ```swift
 func sayHelloWorld() -> String {
-   return "hello, world"
+    return "hello, world"
 }
 print(sayHelloWorld())
 // Prints "hello, world"
@@ -241,7 +241,7 @@ which prints its own `String` value rather than returning it:
 
 ```swift
 func greet(person: String) {
-   print("Hello, \(person)!")
+    print("Hello, \(person)!")
 }
 greet(person: "Dave")
 // Prints "Hello, Dave!"
@@ -274,11 +274,11 @@ The return value of a function can be ignored when it's called:
 
 ```swift
 func printAndCount(string: String) -> Int {
-   print(string)
-   return string.count
+    print(string)
+    return string.count
 }
 func printWithoutCounting(string: String) {
-   let _ = printAndCount(string: string)
+    let _ = printAndCount(string: string)
 }
 printAndCount(string: "hello, world")
 // prints "hello, world" and returns a value of 12
@@ -344,16 +344,16 @@ which finds the smallest and largest numbers in an array of `Int` values:
 
 ```swift
 func minMax(array: [Int]) -> (min: Int, max: Int) {
-   var currentMin = array[0]
-   var currentMax = array[0]
-   for value in array[1..<array.count] {
-      if value < currentMin {
-         currentMin = value
-      } else if value > currentMax {
-         currentMax = value
-      }
-   }
-   return (currentMin, currentMax)
+    var currentMin = array[0]
+    var currentMax = array[0]
+    for value in array[1..<array.count] {
+        if value < currentMin {
+            currentMin = value
+        } else if value > currentMax {
+            currentMax = value
+        }
+    }
+    return (currentMin, currentMax)
 }
 ```
 
@@ -442,17 +442,17 @@ and return a value of `nil` when the array is empty:
 
 ```swift
 func minMax(array: [Int]) -> (min: Int, max: Int)? {
-   if array.isEmpty { return nil }
-   var currentMin = array[0]
-   var currentMax = array[0]
-   for value in array[1..<array.count] {
-      if value < currentMin {
-         currentMin = value
-      } else if value > currentMax {
-         currentMax = value
-      }
-   }
-   return (currentMin, currentMax)
+    if array.isEmpty { return nil }
+    var currentMin = array[0]
+    var currentMax = array[0]
+    for value in array[1..<array.count] {
+        if value < currentMin {
+            currentMin = value
+        } else if value > currentMax {
+            currentMax = value
+        }
+    }
+    return (currentMin, currentMax)
 }
 ```
 
@@ -482,7 +482,7 @@ returns an actual tuple value or `nil`:
 
 ```swift
 if let bounds = minMax(array: [8, -6, 2, 109, 3, 71]) {
-   print("min is \(bounds.min) and max is \(bounds.max)")
+    print("min is \(bounds.min) and max is \(bounds.max)")
 }
 // Prints "min is -6 and max is 109"
 ```
@@ -508,13 +508,13 @@ both functions below have the same behavior:
 
 ```swift
 func greeting(for person: String) -> String {
-   "Hello, " + person + "!"
+    "Hello, " + person + "!"
 }
 print(greeting(for: "Dave"))
 // Prints "Hello, Dave!"
 
 func anotherGreeting(for person: String) -> String {
-   return "Hello, " + person + "!"
+    return "Hello, " + person + "!"
 }
 print(anotherGreeting(for: "Dave"))
 // Prints "Hello, Dave!"
@@ -590,8 +590,8 @@ use their parameter name as their argument label.
 
 ```swift
 func someFunction(firstParameterName: Int, secondParameterName: Int) {
-   // In the function body, firstParameterName and secondParameterName
-   // refer to the argument values for the first and second parameters.
+    // In the function body, firstParameterName and secondParameterName
+    // refer to the argument values for the first and second parameters.
 }
 someFunction(firstParameterName: 1, secondParameterName: 2)
 ```
@@ -630,8 +630,8 @@ separated by a space:
 
 ```swift
 func someFunction(argumentLabel parameterName: Int) {
-   // In the function body, parameterName refers to the argument value
-   // for that parameter.
+    // In the function body, parameterName refers to the argument value
+    // for that parameter.
 }
 ```
 
@@ -683,8 +683,8 @@ write an underscore (`_`) instead of an explicit argument label for that paramet
 
 ```swift
 func someFunction(_ firstParameterName: Int, secondParameterName: Int) {
-   // In the function body, firstParameterName and secondParameterName
-   // refer to the argument values for the first and second parameters.
+    // In the function body, firstParameterName and secondParameterName
+    // refer to the argument values for the first and second parameters.
 }
 someFunction(1, secondParameterName: 2)
 ```
@@ -713,8 +713,8 @@ If a default value is defined, you can omit that parameter when calling the func
 
 ```swift
 func someFunction(parameterWithoutDefault: Int, parameterWithDefault: Int = 12) {
-   // If you omit the second argument when calling this function, then
-   // the value of parameterWithDefault is 12 inside the function body.
+    // If you omit the second argument when calling this function, then
+    // the value of parameterWithDefault is 12 inside the function body.
 }
 someFunction(parameterWithoutDefault: 3, parameterWithDefault: 6) // parameterWithDefault is 6
 someFunction(parameterWithoutDefault: 4) // parameterWithDefault is 12
@@ -762,11 +762,11 @@ The example below calculates the *arithmetic mean*
 
 ```swift
 func arithmeticMean(_ numbers: Double...) -> Double {
-   var total: Double = 0
-   for number in numbers {
-      total += number
-   }
-   return total / Double(numbers.count)
+    var total: Double = 0
+    for number in numbers {
+        total += number
+    }
+    return total / Double(numbers.count)
 }
 arithmeticMean(1, 2, 3, 4, 5)
 // returns 3.0, which is the arithmetic mean of these five numbers
@@ -871,9 +871,9 @@ which has two in-out integer parameters called `a` and `b`:
 
 ```swift
 func swapTwoInts(_ a: inout Int, _ b: inout Int) {
-   let temporaryA = a
-   a = b
-   b = temporaryA
+    let temporaryA = a
+    a = b
+    b = temporaryA
 }
 ```
 
@@ -947,10 +947,10 @@ For example:
 
 ```swift
 func addTwoInts(_ a: Int, _ b: Int) -> Int {
-   return a + b
+    return a + b
 }
 func multiplyTwoInts(_ a: Int, _ b: Int) -> Int {
-   return a * b
+    return a * b
 }
 ```
 
@@ -988,7 +988,7 @@ Here's another example, for a function with no parameters or return value:
 
 ```swift
 func printHelloWorld() {
-   print("hello, world")
+    print("hello, world")
 }
 ```
 
@@ -1110,7 +1110,7 @@ Here's an example to print the results of the math functions from above:
 
 ```swift
 func printMathResult(_ mathFunction: (Int, Int) -> Int, _ a: Int, _ b: Int) {
-   print("Result: \(mathFunction(a, b))")
+    print("Result: \(mathFunction(a, b))")
 }
 printMathResult(addTwoInts, 3, 5)
 // Prints "Result: 8"
@@ -1159,10 +1159,10 @@ Both functions have a type of `(Int) -> Int`:
 
 ```swift
 func stepForward(_ input: Int) -> Int {
-   return input + 1
+    return input + 1
 }
 func stepBackward(_ input: Int) -> Int {
-   return input - 1
+    return input - 1
 }
 ```
 
@@ -1187,7 +1187,7 @@ or the `stepBackward(_:)` function based on a Boolean parameter called `backward
 
 ```swift
 func chooseStepFunction(backward: Bool) -> (Int) -> Int {
-   return backward ? stepBackward : stepForward
+    return backward ? stepBackward : stepForward
 }
 ```
 
@@ -1238,8 +1238,8 @@ it can be used to count to zero:
 print("Counting to zero:")
 // Counting to zero:
 while currentValue != 0 {
-   print("\(currentValue)... ")
-   currentValue = moveNearerToZero(currentValue)
+    print("\(currentValue)... ")
+    currentValue = moveNearerToZero(currentValue)
 }
 print("zero!")
 // 3...
@@ -1284,16 +1284,16 @@ to use and return nested functions:
 
 ```swift
 func chooseStepFunction(backward: Bool) -> (Int) -> Int {
-   func stepForward(input: Int) -> Int { return input + 1 }
-   func stepBackward(input: Int) -> Int { return input - 1 }
-   return backward ? stepBackward : stepForward
+    func stepForward(input: Int) -> Int { return input + 1 }
+    func stepBackward(input: Int) -> Int { return input - 1 }
+    return backward ? stepBackward : stepForward
 }
 var currentValue = -4
 let moveNearerToZero = chooseStepFunction(backward: currentValue > 0)
 // moveNearerToZero now refers to the nested stepForward() function
 while currentValue != 0 {
-   print("\(currentValue)... ")
-   currentValue = moveNearerToZero(currentValue)
+    print("\(currentValue)... ")
+    currentValue = moveNearerToZero(currentValue)
 }
 print("zero!")
 // -4...

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Generics.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Generics.md
@@ -1158,7 +1158,7 @@ extension Stack: SuffixableContainer {
     func suffix(_ size: Int) -> Stack {
         var result = Stack()
         for index in (count-size)..<count {
-                result.append(self[index])
+            result.append(self[index])
         }
         return result
     }
@@ -1215,7 +1215,7 @@ extension IntStack: SuffixableContainer {
     func suffix(_ size: Int) -> Stack<Int> {
         var result = Stack<Int>()
         for index in (count-size)..<count {
-                result.append(self[index])
+            result.append(self[index])
         }
         return result
     }
@@ -1436,7 +1436,7 @@ to add an `isTop(_:)` method.
 extension Stack where Element: Equatable {
     func isTop(_ item: Element) -> Bool {
         guard let topItem = items.last else {
-                return false
+            return false
         }
         return topItem == item
     }
@@ -1601,7 +1601,7 @@ extension Container where Item == Double {
     func average() -> Double {
         var sum = 0.0
         for index in 0..<count {
-                sum += self[index]
+            sum += self[index]
         }
         return sum / Double(count)
     }
@@ -1666,7 +1666,7 @@ extension Container {
     func average() -> Double where Item == Int {
         var sum = 0.0
         for index in 0..<count {
-                sum += Double(self[index])
+            sum += Double(self[index])
         }
         return sum / Double(count)
     }
@@ -1723,7 +1723,7 @@ extension Container where Item == Int {
     func average() -> Double {
         var sum = 0.0
         for index in 0..<count {
-                sum += Double(self[index])
+            sum += Double(self[index])
         }
         return sum / Double(count)
     }
@@ -1911,10 +1911,10 @@ For example:
 ```swift
 extension Container {
     subscript<Indices: Sequence>(indices: Indices) -> [Item]
-                where Indices.Iterator.Element == Int {
+            where Indices.Iterator.Element == Int {
         var result: [Item] = []
         for index in indices {
-                result.append(self[index])
+            result.append(self[index])
         }
         return result
     }

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Generics.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Generics.md
@@ -26,9 +26,9 @@ which swaps two `Int` values:
 
 ```swift
 func swapTwoInts(_ a: inout Int, _ b: inout Int) {
-   let temporaryA = a
-   a = b
-   b = temporaryA
+    let temporaryA = a
+    a = b
+    b = temporaryA
 }
 ```
 
@@ -81,15 +81,15 @@ such as the `swapTwoStrings(_:_:)` and `swapTwoDoubles(_:_:)` functions shown be
 
 ```swift
 func swapTwoStrings(_ a: inout String, _ b: inout String) {
-   let temporaryA = a
-   a = b
-   b = temporaryA
+    let temporaryA = a
+    a = b
+    b = temporaryA
 }
 
 func swapTwoDoubles(_ a: inout Double, _ b: inout Double) {
-   let temporaryA = a
-   a = b
-   b = temporaryA
+    let temporaryA = a
+    a = b
+    b = temporaryA
 }
 ```
 
@@ -140,9 +140,9 @@ called `swapTwoValues(_:_:)`:
 
 ```swift
 func swapTwoValues<T>(_ a: inout T, _ b: inout T) {
-   let temporaryA = a
-   a = b
-   b = temporaryA
+    let temporaryA = a
+    a = b
+    b = temporaryA
 }
 ```
 
@@ -338,13 +338,13 @@ in this case for a stack of `Int` values:
 
 ```swift
 struct IntStack {
-   var items: [Int] = []
-   mutating func push(_ item: Int) {
-      items.append(item)
-   }
-   mutating func pop() -> Int {
-      return items.removeLast()
-   }
+    var items: [Int] = []
+    mutating func push(_ item: Int) {
+        items.append(item)
+    }
+    mutating func pop() -> Int {
+        return items.removeLast()
+    }
 }
 ```
 
@@ -386,13 +386,13 @@ Here's a generic version of the same code:
 
 ```swift
 struct Stack<Element> {
-   var items: [Element] = []
-   mutating func push(_ item: Element) {
-      items.append(item)
-   }
-   mutating func pop() -> Element {
-      return items.removeLast()
-   }
+    var items: [Element] = []
+    mutating func push(_ item: Element) {
+        items.append(item)
+    }
+    mutating func pop() -> Element {
+        return items.removeLast()
+    }
 }
 ```
 
@@ -509,9 +509,9 @@ which returns the top item on the stack without popping it from the stack:
 
 ```swift
 extension Stack {
-   var topItem: Element? {
-      return items.isEmpty ? nil : items[items.count - 1]
-   }
+    var topItem: Element? {
+        return items.isEmpty ? nil : items[items.count - 1]
+    }
 }
 ```
 
@@ -542,7 +542,7 @@ to access and query its top item without removing it.
 
 ```swift
 if let topItem = stackOfStrings.topItem {
-   print("The top item on the stack is \(topItem).")
+    print("The top item on the stack is \(topItem).")
 }
 // Prints "The top item on the stack is tres."
 ```
@@ -611,7 +611,7 @@ The basic syntax for type constraints on a generic function is shown below
 
 ```swift
 func someFunction<T: SomeClass, U: SomeProtocol>(someT: T, someU: U) {
-   // function body goes here
+    // function body goes here
 }
 ```
 
@@ -645,12 +645,12 @@ or `nil` if the string can't be found:
 
 ```swift
 func findIndex(ofString valueToFind: String, in array: [String]) -> Int? {
-   for (index, value) in array.enumerated() {
-      if value == valueToFind {
-         return index
-      }
-   }
-   return nil
+    for (index, value) in array.enumerated() {
+        if value == valueToFind {
+            return index
+        }
+    }
+    return nil
 }
 ```
 
@@ -675,7 +675,7 @@ The `findIndex(ofString:in:)` function can be used to find a string value in an 
 ```swift
 let strings = ["cat", "dog", "llama", "parakeet", "terrapin"]
 if let foundIndex = findIndex(ofString: "llama", in: strings) {
-   print("The index of llama is \(foundIndex)")
+    print("The index of llama is \(foundIndex)")
 }
 // Prints "The index of llama is 2"
 ```
@@ -707,12 +707,12 @@ for reasons explained after the example:
 
 ```swift
 func findIndex<T>(of valueToFind: T, in array:[T]) -> Int? {
-   for (index, value) in array.enumerated() {
-      if value == valueToFind {
-         return index
-      }
-   }
-   return nil
+    for (index, value) in array.enumerated() {
+        if value == valueToFind {
+            return index
+        }
+    }
+    return nil
 }
 ```
 
@@ -767,12 +767,12 @@ as part of the type parameter's definition when you define the function:
 
 ```swift
 func findIndex<T: Equatable>(of valueToFind: T, in array:[T]) -> Int? {
-   for (index, value) in array.enumerated() {
-      if value == valueToFind {
-         return index
-      }
-   }
-   return nil
+    for (index, value) in array.enumerated() {
+        if value == valueToFind {
+            return index
+        }
+    }
+    return nil
 }
 ```
 
@@ -845,10 +845,10 @@ which declares an associated type called `Item`:
 
 ```swift
 protocol Container {
-   associatedtype Item
-   mutating func append(_ item: Item)
-   var count: Int { get }
-   subscript(i: Int) -> Item { get }
+    associatedtype Item
+    mutating func append(_ item: Item)
+    var count: Int { get }
+    subscript(i: Int) -> Item { get }
 }
 ```
 
@@ -914,25 +914,25 @@ adapted to conform to the `Container` protocol:
 
 ```swift
 struct IntStack: Container {
-   // original IntStack implementation
-   var items: [Int] = []
-   mutating func push(_ item: Int) {
-      items.append(item)
-   }
-   mutating func pop() -> Int {
-      return items.removeLast()
-   }
-   // conformance to the Container protocol
-   typealias Item = Int
-   mutating func append(_ item: Int) {
-      self.push(item)
-   }
-   var count: Int {
-      return items.count
-   }
-   subscript(i: Int) -> Int {
-      return items[i]
-   }
+    // original IntStack implementation
+    var items: [Int] = []
+    mutating func push(_ item: Int) {
+        items.append(item)
+    }
+    mutating func pop() -> Int {
+        return items.removeLast()
+    }
+    // conformance to the Container protocol
+    typealias Item = Int
+    mutating func append(_ item: Int) {
+        self.push(item)
+    }
+    var count: Int {
+        return items.count
+    }
+    subscript(i: Int) -> Int {
+        return items[i]
+    }
 }
 ```
 
@@ -988,24 +988,24 @@ You can also make the generic `Stack` type conform to the `Container` protocol:
 
 ```swift
 struct Stack<Element>: Container {
-   // original Stack<Element> implementation
-   var items: [Element] = []
-   mutating func push(_ item: Element) {
-      items.append(item)
-   }
-   mutating func pop() -> Element {
-      return items.removeLast()
-   }
-   // conformance to the Container protocol
-   mutating func append(_ item: Element) {
-      self.push(item)
-   }
-   var count: Int {
-      return items.count
-   }
-   subscript(i: Int) -> Element {
-      return items[i]
-   }
+    // original Stack<Element> implementation
+    var items: [Element] = []
+    mutating func push(_ item: Element) {
+        items.append(item)
+    }
+    mutating func pop() -> Element {
+        return items.removeLast()
+    }
+    // conformance to the Container protocol
+    mutating func append(_ item: Element) {
+        self.push(item)
+    }
+    var count: Int {
+        return items.count
+    }
+    subscript(i: Int) -> Element {
+        return items[i]
+    }
 }
 ```
 
@@ -1085,10 +1085,10 @@ that requires the items in the container to be equatable.
 
 ```swift
 protocol Container {
-   associatedtype Item: Equatable
-   mutating func append(_ item: Item)
-   var count: Int { get }
-   subscript(i: Int) -> Item { get }
+    associatedtype Item: Equatable
+    mutating func append(_ item: Item)
+    var count: Int { get }
+    subscript(i: Int) -> Item { get }
 }
 ```
 
@@ -1158,7 +1158,7 @@ extension Stack: SuffixableContainer {
     func suffix(_ size: Int) -> Stack {
         var result = Stack()
         for index in (count-size)..<count {
-            result.append(self[index])
+                result.append(self[index])
         }
         return result
     }
@@ -1215,7 +1215,7 @@ extension IntStack: SuffixableContainer {
     func suffix(_ size: Int) -> Stack<Int> {
         var result = Stack<Int>()
         for index in (count-size)..<count {
-            result.append(self[index])
+                result.append(self[index])
         }
         return result
     }
@@ -1278,23 +1278,23 @@ and a generic `where` clause:
 
 ```swift
 func allItemsMatch<C1: Container, C2: Container>
-      (_ someContainer: C1, _ anotherContainer: C2) -> Bool
-      where C1.Item == C2.Item, C1.Item: Equatable {
+        (_ someContainer: C1, _ anotherContainer: C2) -> Bool
+        where C1.Item == C2.Item, C1.Item: Equatable {
 
-   // Check that both containers contain the same number of items.
-   if someContainer.count != anotherContainer.count {
-      return false
-   }
+    // Check that both containers contain the same number of items.
+    if someContainer.count != anotherContainer.count {
+        return false
+    }
 
-   // Check each pair of items to see if they're equivalent.
-   for i in 0..<someContainer.count {
-      if someContainer[i] != anotherContainer[i] {
-         return false
-      }
-   }
+    // Check each pair of items to see if they're equivalent.
+    for i in 0..<someContainer.count {
+        if someContainer[i] != anotherContainer[i] {
+            return false
+        }
+    }
 
-   // All items match, so return true.
-   return true
+    // All items match, so return true.
+    return true
 }
 ```
 
@@ -1385,9 +1385,9 @@ stackOfStrings.push("tres")
 var arrayOfStrings = ["uno", "dos", "tres"]
 
 if allItemsMatch(stackOfStrings, arrayOfStrings) {
-   print("All items match.")
+    print("All items match.")
 } else {
-   print("Not all items match.")
+    print("Not all items match.")
 }
 // Prints "All items match."
 ```
@@ -1436,7 +1436,7 @@ to add an `isTop(_:)` method.
 extension Stack where Element: Equatable {
     func isTop(_ item: Element) -> Bool {
         guard let topItem = items.last else {
-            return false
+                return false
         }
         return topItem == item
     }
@@ -1478,9 +1478,9 @@ Here's how the `isTop(_:)` method looks in action:
 
 ```swift
 if stackOfStrings.isTop("tres") {
-   print("Top element is tres.")
+    print("Top element is tres.")
 } else {
-   print("Top element is something else.")
+    print("Top element is something else.")
 }
 // Prints "Top element is tres."
 ```
@@ -1533,9 +1533,9 @@ to add a `startsWith(_:)` method.
 
 ```swift
 extension Container where Item: Equatable {
-   func startsWith(_ item: Item) -> Bool {
-      return count >= 1 && self[0] == item
-   }
+    func startsWith(_ item: Item) -> Bool {
+        return count >= 1 && self[0] == item
+    }
 }
 ```
 
@@ -1569,9 +1569,9 @@ as long as the container's items are equatable.
 
 ```swift
 if [9, 9, 9].startsWith(42) {
-   print("Starts with 42.")
+    print("Starts with 42.")
 } else {
-   print("Starts with something else.")
+    print("Starts with something else.")
 }
 // Prints "Starts with something else."
 ```
@@ -1601,7 +1601,7 @@ extension Container where Item == Double {
     func average() -> Double {
         var sum = 0.0
         for index in 0..<count {
-            sum += self[index]
+                sum += self[index]
         }
         return sum / Double(count)
     }
@@ -1666,7 +1666,7 @@ extension Container {
     func average() -> Double where Item == Int {
         var sum = 0.0
         for index in 0..<count {
-            sum += Double(self[index])
+                sum += Double(self[index])
         }
         return sum / Double(count)
     }
@@ -1723,7 +1723,7 @@ extension Container where Item == Int {
     func average() -> Double {
         var sum = 0.0
         for index in 0..<count {
-            sum += Double(self[index])
+                sum += Double(self[index])
         }
         return sum / Double(count)
     }
@@ -1777,13 +1777,13 @@ Here's how you write that:
 
 ```swift
 protocol Container {
-   associatedtype Item
-   mutating func append(_ item: Item)
-   var count: Int { get }
-   subscript(i: Int) -> Item { get }
+    associatedtype Item
+    mutating func append(_ item: Item)
+    var count: Int { get }
+    subscript(i: Int) -> Item { get }
 
-   associatedtype Iterator: IteratorProtocol where Iterator.Element == Item
-   func makeIterator() -> Iterator
+    associatedtype Iterator: IteratorProtocol where Iterator.Element == Item
+    func makeIterator() -> Iterator
 }
 ```
 
@@ -1911,10 +1911,10 @@ For example:
 ```swift
 extension Container {
     subscript<Indices: Sequence>(indices: Indices) -> [Item]
-            where Indices.Iterator.Element == Int {
+                where Indices.Iterator.Element == Int {
         var result: [Item] = []
         for index in indices {
-            result.append(self[index])
+                result.append(self[index])
         }
         return result
     }

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Inheritance.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Inheritance.md
@@ -43,13 +43,13 @@ but will be customized by subclasses of `Vehicle` later on:
 
 ```swift
 class Vehicle {
-   var currentSpeed = 0.0
-   var description: String {
-      return "traveling at \(currentSpeed) miles per hour"
-   }
-   func makeNoise() {
-      // do nothing - an arbitrary vehicle doesn't necessarily make a noise
-   }
+    var currentSpeed = 0.0
+    var description: String {
+        return "traveling at \(currentSpeed) miles per hour"
+    }
+    func makeNoise() {
+        // do nothing - an arbitrary vehicle doesn't necessarily make a noise
+    }
 }
 ```
 
@@ -122,7 +122,7 @@ separated by a colon:
 
 ```swift
 class SomeSubclass: SomeSuperclass {
-   // subclass definition goes here
+    // subclass definition goes here
 }
 ```
 
@@ -143,7 +143,7 @@ with a superclass of `Vehicle`:
 
 ```swift
 class Bicycle: Vehicle {
-   var hasBasket = false
+    var hasBasket = false
 }
 ```
 
@@ -211,7 +211,7 @@ known as a “tandem”:
 
 ```swift
 class Tandem: Bicycle {
-   var currentNumberOfPassengers = 0
+    var currentNumberOfPassengers = 0
 }
 ```
 
@@ -307,9 +307,9 @@ which overrides the `makeNoise()` method that `Train` inherits from `Vehicle`:
 
 ```swift
 class Train: Vehicle {
-   override func makeNoise() {
-      print("Choo Choo")
-   }
+    override func makeNoise() {
+        print("Choo Choo")
+    }
 }
 ```
 
@@ -385,10 +385,10 @@ to provide a custom description that includes the current gear:
 
 ```swift
 class Car: Vehicle {
-   var gear = 1
-   override var description: String {
-      return super.description + " in gear \(gear)"
-   }
+    var gear = 1
+    override var description: String {
+        return super.description + " in gear \(gear)"
+    }
 }
 ```
 
@@ -461,11 +461,11 @@ which automatically selects an appropriate gear to use based on the current spee
 
 ```swift
 class AutomaticCar: Car {
-   override var currentSpeed: Double {
-      didSet {
-         gear = Int(currentSpeed / 10.0) + 1
-      }
-   }
+    override var currentSpeed: Double {
+        didSet {
+            gear = Int(currentSpeed / 10.0) + 1
+        }
+    }
 }
 ```
 

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Initialization.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Initialization.md
@@ -2010,14 +2010,14 @@ enum TemperatureUnit {
     case kelvin, celsius, fahrenheit
     init?(symbol: Character) {
         switch symbol {
-            case "K":
-                self = .kelvin
-            case "C":
-                self = .celsius
-            case "F":
-                self = .fahrenheit
-            default:
-                return nil
+        case "K":
+            self = .kelvin
+        case "C":
+            self = .celsius
+        case "F":
+            self = .fahrenheit
+        default:
+            return nil
         }
     }
 }

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Initialization.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Initialization.md
@@ -43,7 +43,7 @@ written using the `init` keyword:
 
 ```swift
 init() {
-   // perform some initialization here
+    // perform some initialization here
 }
 ```
 
@@ -67,10 +67,10 @@ The `Fahrenheit` structure has one stored property,
 
 ```swift
 struct Fahrenheit {
-   var temperature: Double
-   init() {
-      temperature = 32.0
-   }
+    var temperature: Double
+    init() {
+        temperature = 32.0
+    }
 }
 var f = Fahrenheit()
 print("The default temperature is \(f.temperature)° Fahrenheit")
@@ -123,7 +123,7 @@ at the point that the property is declared:
 
 ```swift
 struct Fahrenheit {
-   var temperature = 32.0
+    var temperature = 32.0
 }
 ```
 
@@ -161,13 +161,13 @@ with a value from a different temperature scale:
 
 ```swift
 struct Celsius {
-   var temperatureInCelsius: Double
-   init(fromFahrenheit fahrenheit: Double) {
-      temperatureInCelsius = (fahrenheit - 32.0) / 1.8
-   }
-   init(fromKelvin kelvin: Double) {
-      temperatureInCelsius = kelvin - 273.15
-   }
+    var temperatureInCelsius: Double
+    init(fromFahrenheit fahrenheit: Double) {
+        temperatureInCelsius = (fahrenheit - 32.0) / 1.8
+    }
+    init(fromKelvin kelvin: Double) {
+        temperatureInCelsius = kelvin - 273.15
+    }
 }
 let boilingPointOfWater = Celsius(fromFahrenheit: 212.0)
 // boilingPointOfWater.temperatureInCelsius is 100.0
@@ -238,17 +238,17 @@ which is used to provide the same value for all three color components.
 
 ```swift
 struct Color {
-   let red, green, blue: Double
-   init(red: Double, green: Double, blue: Double) {
-      self.red   = red
-      self.green = green
-      self.blue  = blue
-   }
-   init(white: Double) {
-      red   = white
-      green = white
-      blue  = white
-   }
+    let red, green, blue: Double
+    init(red: Double, green: Double, blue: Double) {
+        self.red   = red
+        self.green = green
+        self.blue  = blue
+    }
+    init(white: Double) {
+        red   = white
+        green = white
+        blue  = white
+    }
 }
 ```
 
@@ -331,16 +331,16 @@ from a `Double` value that's already in the Celsius scale:
 
 ```swift
 struct Celsius {
-   var temperatureInCelsius: Double
-   init(fromFahrenheit fahrenheit: Double) {
-      temperatureInCelsius = (fahrenheit - 32.0) / 1.8
-   }
-   init(fromKelvin kelvin: Double) {
-      temperatureInCelsius = kelvin - 273.15
-   }
-   init(_ celsius: Double) {
-      temperatureInCelsius = celsius
-   }
+    var temperatureInCelsius: Double
+    init(fromFahrenheit fahrenheit: Double) {
+        temperatureInCelsius = (fahrenheit - 32.0) / 1.8
+    }
+    init(fromKelvin kelvin: Double) {
+        temperatureInCelsius = kelvin - 273.15
+    }
+    init(_ celsius: Double) {
+        temperatureInCelsius = celsius
+    }
 }
 let bodyTemperature = Celsius(37.0)
 // bodyTemperature.temperatureInCelsius is 37.0
@@ -389,14 +389,14 @@ with an optional `String` property called `response`:
 
 ```swift
 class SurveyQuestion {
-   var text: String
-   var response: String?
-   init(text: String) {
-      self.text = text
-   }
-   func ask() {
-      print(text)
-   }
+    var text: String
+    var response: String?
+    init(text: String) {
+        self.text = text
+    }
+    func ask() {
+        print(text)
+    }
 }
 let cheeseQuestion = SurveyQuestion(text: "Do you like cheese?")
 cheeseQuestion.ask()
@@ -497,14 +497,14 @@ it can still be set within the class's initializer:
 
 ```swift
 class SurveyQuestion {
-   let text: String
-   var response: String?
-   init(text: String) {
-      self.text = text
-   }
-   func ask() {
-      print(text)
-   }
+    let text: String
+    var response: String?
+    init(text: String) {
+        self.text = text
+    }
+    func ask() {
+        print(text)
+    }
 }
 let beetsQuestion = SurveyQuestion(text: "How about beets?")
 beetsQuestion.ask()
@@ -563,9 +563,9 @@ of an item in a shopping list:
 
 ```swift
 class ShoppingListItem {
-   var name: String?
-   var quantity = 1
-   var purchased = false
+    var name: String?
+    var quantity = 1
+    var purchased = false
 }
 var item = ShoppingListItem()
 ```
@@ -632,7 +632,7 @@ which you can use to initialize a new `Size` instance:
 
 ```swift
 struct Size {
-   var width = 0.0, height = 0.0
+    var width = 0.0, height = 0.0
 }
 let twoByTwo = Size(width: 2.0, height: 2.0)
 ```
@@ -727,10 +727,10 @@ both of which provide default values of `0.0` for all of their properties:
 
 ```swift
 struct Size {
-   var width = 0.0, height = 0.0
+    var width = 0.0, height = 0.0
 }
 struct Point {
-   var x = 0.0, y = 0.0
+    var x = 0.0, y = 0.0
 }
 ```
 
@@ -757,18 +757,18 @@ three custom initializers that are part of the `Rect` structure's definition:
 
 ```swift
 struct Rect {
-   var origin = Point()
-   var size = Size()
-   init() {}
-   init(origin: Point, size: Size) {
-      self.origin = origin
-      self.size = size
-   }
-   init(center: Point, size: Size) {
-      let originX = center.x - (size.width / 2)
-      let originY = center.y - (size.height / 2)
-      self.init(origin: Point(x: originX, y: originY), size: size)
-   }
+    var origin = Point()
+    var size = Size()
+    init() {}
+    init(origin: Point, size: Size) {
+        self.origin = origin
+        self.size = size
+    }
+    init(center: Point, size: Size) {
+        let originX = center.x - (size.width / 2)
+        let originY = center.y - (size.height / 2)
+        self.init(origin: Point(x: originX, y: originY), size: size)
+    }
 }
 ```
 
@@ -829,7 +829,7 @@ the appropriate stored properties:
 
 ```swift
 let originRect = Rect(origin: Point(x: 2.0, y: 2.0),
-   size: Size(width: 5.0, height: 5.0))
+    size: Size(width: 5.0, height: 5.0))
 // originRect's origin is (2.0, 2.0) and its size is (5.0, 5.0)
 ```
 
@@ -853,7 +853,7 @@ which stores the new origin and size values in the appropriate properties:
 
 ```swift
 let centerRect = Rect(center: Point(x: 4.0, y: 4.0),
-   size: Size(width: 3.0, height: 3.0))
+    size: Size(width: 3.0, height: 3.0))
 // centerRect's origin is (2.5, 2.5) and its size is (3.0, 3.0)
 ```
 
@@ -1242,10 +1242,10 @@ to create a `String` description of the vehicle's characteristics:
 
 ```swift
 class Vehicle {
-   var numberOfWheels = 0
-   var description: String {
-      return "\(numberOfWheels) wheel(s)"
-   }
+    var numberOfWheels = 0
+    var description: String {
+        return "\(numberOfWheels) wheel(s)"
+    }
 }
 ```
 
@@ -1291,10 +1291,10 @@ The next example defines a subclass of `Vehicle` called `Bicycle`:
 
 ```swift
 class Bicycle: Vehicle {
-   override init() {
-      super.init()
-      numberOfWheels = 2
-   }
+    override init() {
+        super.init()
+        numberOfWheels = 2
+    }
 }
 ```
 
@@ -1500,13 +1500,13 @@ and provides two initializers for creating `Food` instances:
 
 ```swift
 class Food {
-   var name: String
-   init(name: String) {
-      self.name = name
-   }
-   convenience init() {
-      self.init(name: "[Unnamed]")
-   }
+    var name: String
+    init(name: String) {
+        self.name = name
+    }
+    convenience init() {
+        self.init(name: "[Unnamed]")
+    }
 }
 ```
 
@@ -1590,14 +1590,14 @@ and defines two initializers for creating `RecipeIngredient` instances:
 
 ```swift
 class RecipeIngredient: Food {
-   var quantity: Int
-   init(name: String, quantity: Int) {
-      self.quantity = quantity
-      super.init(name: name)
-   }
-   override convenience init(name: String) {
-      self.init(name: name, quantity: 1)
-   }
+    var quantity: Int
+    init(name: String, quantity: Int) {
+        self.quantity = quantity
+        super.init(name: name)
+    }
+    override convenience init(name: String) {
+        self.init(name: name, quantity: 1)
+    }
 }
 ```
 
@@ -1698,12 +1698,12 @@ which provides a textual description of a `ShoppingListItem` instance:
 
 ```swift
 class ShoppingListItem: RecipeIngredient {
-   var purchased = false
-   var description: String {
-      var output = "\(quantity) x \(name)"
-      output += purchased ? " ✔" : " ✘"
-      return output
-   }
+    var purchased = false
+    var description: String {
+        var output = "\(quantity) x \(name)"
+        output += purchased ? " ✔" : " ✘"
+        return output
+    }
 }
 ```
 
@@ -1742,14 +1742,14 @@ to create a new `ShoppingListItem` instance:
 
 ```swift
 var breakfastList = [
-   ShoppingListItem(),
-   ShoppingListItem(name: "Bacon"),
-   ShoppingListItem(name: "Eggs", quantity: 6),
+    ShoppingListItem(),
+    ShoppingListItem(name: "Bacon"),
+    ShoppingListItem(name: "Eggs", quantity: 6),
 ]
 breakfastList[0].name = "Orange juice"
 breakfastList[0].purchased = true
 for item in breakfastList {
-   print(item.description)
+    print(item.description)
 }
 // 1 x Orange juice ✔
 // 1 x Bacon ✘
@@ -1906,11 +1906,11 @@ Otherwise, the `species` property's value is set, and initialization succeeds:
 
 ```swift
 struct Animal {
-   let species: String
-   init?(species: String) {
-      if species.isEmpty { return nil }
-      self.species = species
-   }
+    let species: String
+    init?(species: String) {
+        if species.isEmpty { return nil }
+        self.species = species
+    }
 }
 ```
 
@@ -1937,7 +1937,7 @@ let someCreature = Animal(species: "Giraffe")
 // someCreature is of type Animal?, not Animal
 
 if let giraffe = someCreature {
-   print("An animal was initialized with a species of \(giraffe.species)")
+    print("An animal was initialized with a species of \(giraffe.species)")
 }
 // Prints "An animal was initialized with a species of Giraffe"
 ```
@@ -1965,7 +1965,7 @@ let anonymousCreature = Animal(species: "")
 // anonymousCreature is of type Animal?, not Animal
 
 if anonymousCreature == nil {
-   print("The anonymous creature couldn't be initialized")
+    print("The anonymous creature couldn't be initialized")
 }
 // Prints "The anonymous creature couldn't be initialized"
 ```
@@ -2007,19 +2007,19 @@ for a `Character` value representing a temperature symbol:
 
 ```swift
 enum TemperatureUnit {
-   case kelvin, celsius, fahrenheit
-   init?(symbol: Character) {
-      switch symbol {
-         case "K":
-            self = .kelvin
-         case "C":
-            self = .celsius
-         case "F":
-            self = .fahrenheit
-         default:
-            return nil
-      }
-   }
+    case kelvin, celsius, fahrenheit
+    init?(symbol: Character) {
+        switch symbol {
+            case "K":
+                self = .kelvin
+            case "C":
+                self = .celsius
+            case "F":
+                self = .fahrenheit
+            default:
+                return nil
+        }
+    }
 }
 ```
 
@@ -2054,13 +2054,13 @@ states:
 ```swift
 let fahrenheitUnit = TemperatureUnit(symbol: "F")
 if fahrenheitUnit != nil {
-   print("This is a defined temperature unit, so initialization succeeded.")
+    print("This is a defined temperature unit, so initialization succeeded.")
 }
 // Prints "This is a defined temperature unit, so initialization succeeded."
 
 let unknownUnit = TemperatureUnit(symbol: "X")
 if unknownUnit == nil {
-   print("This isn't a defined temperature unit, so initialization failed.")
+    print("This isn't a defined temperature unit, so initialization failed.")
 }
 // Prints "This isn't a defined temperature unit, so initialization failed."
 ```
@@ -2098,18 +2098,18 @@ and to take advantage of the `init?(rawValue:)` initializer:
 
 ```swift
 enum TemperatureUnit: Character {
-   case kelvin = "K", celsius = "C", fahrenheit = "F"
+    case kelvin = "K", celsius = "C", fahrenheit = "F"
 }
 
 let fahrenheitUnit = TemperatureUnit(rawValue: "F")
 if fahrenheitUnit != nil {
-   print("This is a defined temperature unit, so initialization succeeded.")
+    print("This is a defined temperature unit, so initialization succeeded.")
 }
 // Prints "This is a defined temperature unit, so initialization succeeded."
 
 let unknownUnit = TemperatureUnit(rawValue: "X")
 if unknownUnit == nil {
-   print("This isn't a defined temperature unit, so initialization failed.")
+    print("This isn't a defined temperature unit, so initialization failed.")
 }
 // Prints "This isn't a defined temperature unit, so initialization failed."
 ```
@@ -2208,20 +2208,20 @@ and ensures that this property always has a value of at least `1`:
 
 ```swift
 class Product {
-   let name: String
-   init?(name: String) {
-      if name.isEmpty { return nil }
-      self.name = name
-   }
+    let name: String
+    init?(name: String) {
+        if name.isEmpty { return nil }
+        self.name = name
+    }
 }
 
 class CartItem: Product {
-   let quantity: Int
-   init?(name: String, quantity: Int) {
-      if quantity < 1 { return nil }
-      self.quantity = quantity
-      super.init(name: name)
-   }
+    let quantity: Int
+    init?(name: String, quantity: Int) {
+        if quantity < 1 { return nil }
+        self.quantity = quantity
+        super.init(name: name)
+    }
 }
 ```
 
@@ -2265,7 +2265,7 @@ initialization succeeds:
 
 ```swift
 if let twoSocks = CartItem(name: "sock", quantity: 2) {
-   print("Item: \(twoSocks.name), quantity: \(twoSocks.quantity)")
+    print("Item: \(twoSocks.name), quantity: \(twoSocks.quantity)")
 }
 // Prints "Item: sock, quantity: 2"
 ```
@@ -2287,9 +2287,9 @@ the `CartItem` initializer causes initialization to fail:
 
 ```swift
 if let zeroShirts = CartItem(name: "shirt", quantity: 0) {
-   print("Item: \(zeroShirts.name), quantity: \(zeroShirts.quantity)")
+    print("Item: \(zeroShirts.name), quantity: \(zeroShirts.quantity)")
 } else {
-   print("Unable to initialize zero shirts")
+    print("Unable to initialize zero shirts")
 }
 // Prints "Unable to initialize zero shirts"
 ```
@@ -2313,9 +2313,9 @@ the superclass `Product` initializer causes initialization to fail:
 
 ```swift
 if let oneUnnamed = CartItem(name: "", quantity: 1) {
-   print("Item: \(oneUnnamed.name), quantity: \(oneUnnamed.quantity)")
+    print("Item: \(oneUnnamed.name), quantity: \(oneUnnamed.quantity)")
 } else {
-   print("Unable to initialize one unnamed product")
+    print("Unable to initialize one unnamed product")
 }
 // Prints "Unable to initialize one unnamed product"
 ```
@@ -2376,14 +2376,14 @@ but can't be an empty string:
 
 ```swift
 class Document {
-   var name: String?
-   // this initializer creates a document with a nil name value
-   init() {}
-   // this initializer creates a document with a nonempty name value
-   init?(name: String) {
-      if name.isEmpty { return nil }
-      self.name = name
-   }
+    var name: String?
+    // this initializer creates a document with a nil name value
+    init() {}
+    // this initializer creates a document with a nonempty name value
+    init?(name: String) {
+        if name.isEmpty { return nil }
+        self.name = name
+    }
 }
 ```
 
@@ -2415,18 +2415,18 @@ or if an empty string is passed to the `init(name:)` initializer:
 
 ```swift
 class AutomaticallyNamedDocument: Document {
-   override init() {
-      super.init()
-      self.name = "[Untitled]"
-   }
-   override init(name: String) {
-      super.init()
-      if name.isEmpty {
-         self.name = "[Untitled]"
-      } else {
-         self.name = name
-      }
-   }
+    override init() {
+        super.init()
+        self.name = "[Untitled]"
+    }
+    override init(name: String) {
+        super.init()
+        if name.isEmpty {
+            self.name = "[Untitled]"
+        } else {
+            self.name = name
+        }
+    }
 }
 ```
 
@@ -2468,9 +2468,9 @@ from its superclass during initialization.
 
 ```swift
 class UntitledDocument: Document {
-   override init() {
-      super.init(name: "[Untitled]")!
-   }
+    override init() {
+        super.init(name: "[Untitled]")!
+    }
 }
 ```
 
@@ -2689,9 +2689,9 @@ to indicate that every subclass of the class must implement that initializer:
 
 ```swift
 class SomeClass {
-   required init() {
-      // initializer implementation goes here
-   }
+    required init() {
+        // initializer implementation goes here
+    }
 }
 ```
 
@@ -2756,9 +2756,9 @@ You don't write the `override` modifier when overriding a required designated in
 
 ```swift
 class SomeSubclass: SomeClass {
-   required init() {
-      // subclass implementation of the required initializer goes here
-   }
+    required init() {
+        // subclass implementation of the required initializer goes here
+    }
 }
 ```
 
@@ -2858,11 +2858,11 @@ to provide a default property value:
 
 ```swift
 class SomeClass {
-   let someProperty: SomeType = {
-      // create a default value for someProperty inside this closure
-      // someValue must be of the same type as SomeType
-      return someValue
-   }()
+    let someProperty: SomeType = {
+        // create a default value for someProperty inside this closure
+        // someValue must be of the same type as SomeType
+        return someValue
+    }()
 }
 ```
 
@@ -2925,21 +2925,21 @@ The `boardColors` array is initialized with a closure to set up its color values
 
 ```swift
 struct Chessboard {
-   let boardColors: [Bool] = {
-      var temporaryBoard: [Bool] = []
-      var isBlack = false
-      for i in 1...8 {
-         for j in 1...8 {
-            temporaryBoard.append(isBlack)
+    let boardColors: [Bool] = {
+        var temporaryBoard: [Bool] = []
+        var isBlack = false
+        for i in 1...8 {
+            for j in 1...8 {
+                temporaryBoard.append(isBlack)
+                isBlack = !isBlack
+            }
             isBlack = !isBlack
-         }
-         isBlack = !isBlack
-      }
-      return temporaryBoard
-   }()
-   func squareIsBlackAt(row: Int, column: Int) -> Bool {
-      return boardColors[(row * 8) + column]
-   }
+        }
+        return temporaryBoard
+    }()
+    func squareIsBlackAt(row: Int, column: Int) -> Bool {
+        return boardColors[(row * 8) + column]
+    }
 }
 ```
 

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Methods.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Methods.md
@@ -35,16 +35,16 @@ which can be used to count the number of times an action occurs:
 
 ```swift
 class Counter {
-   var count = 0
-   func increment() {
-      count += 1
-   }
-   func increment(by amount: Int) {
-      count += amount
-   }
-   func reset() {
-      count = 0
-   }
+    var count = 0
+    func increment() {
+        count += 1
+    }
+    func increment(by amount: Int) {
+        count += amount
+    }
+    func reset() {
+        count = 0
+    }
 }
 ```
 
@@ -127,7 +127,7 @@ The `increment()` method in the example above could have been written like this:
 
 ```swift
 func increment() {
-   self.count += 1
+    self.count += 1
 }
 ```
 
@@ -168,14 +168,14 @@ a method parameter called `x` and an instance property that's also called `x`:
 
 ```swift
 struct Point {
-   var x = 0.0, y = 0.0
-   func isToTheRightOf(x: Double) -> Bool {
-      return self.x > x
-   }
+    var x = 0.0, y = 0.0
+    func isToTheRightOf(x: Double) -> Bool {
+        return self.x > x
+    }
 }
 let somePoint = Point(x: 4.0, y: 5.0)
 if somePoint.isToTheRightOf(x: 1.0) {
-   print("This point is to the right of the line where x == 1.0")
+    print("This point is to the right of the line where x == 1.0")
 }
 // Prints "This point is to the right of the line where x == 1.0"
 ```
@@ -225,11 +225,11 @@ before the `func` keyword for that method:
 
 ```swift
 struct Point {
-   var x = 0.0, y = 0.0
-   mutating func moveBy(x deltaX: Double, y deltaY: Double) {
-      x += deltaX
-      y += deltaY
-   }
+    var x = 0.0, y = 0.0
+    mutating func moveBy(x deltaX: Double, y deltaY: Double) {
+        x += deltaX
+        y += deltaY
+    }
 }
 var somePoint = Point(x: 1.0, y: 1.0)
 somePoint.moveBy(x: 2.0, y: 3.0)
@@ -312,10 +312,10 @@ The `Point` example shown above could have been written in the following way ins
 
 ```swift
 struct Point {
-   var x = 0.0, y = 0.0
-   mutating func moveBy(x deltaX: Double, y deltaY: Double) {
-      self = Point(x: x + deltaX, y: y + deltaY)
-   }
+    var x = 0.0, y = 0.0
+    mutating func moveBy(x deltaX: Double, y deltaY: Double) {
+        self = Point(x: x + deltaX, y: y + deltaY)
+    }
 }
 ```
 
@@ -347,17 +347,17 @@ a different case from the same enumeration:
 
 ```swift
 enum TriStateSwitch {
-   case off, low, high
-   mutating func next() {
-      switch self {
-         case .off:
-            self = .low
-         case .low:
-            self = .high
-         case .high:
-            self = .off
-      }
-   }
+    case off, low, high
+    mutating func next() {
+        switch self {
+            case .off:
+                self = .low
+            case .low:
+                self = .high
+            case .high:
+                self = .off
+        }
+    }
 }
 var ovenLight = TriStateSwitch.low
 ovenLight.next()
@@ -418,9 +418,9 @@ Here's how you call a type method on a class called `SomeClass`:
 
 ```swift
 class SomeClass {
-   class func someTypeMethod() {
-      // type method implementation goes here
-   }
+    class func someTypeMethod() {
+        // type method implementation goes here
+    }
 }
 SomeClass.someTypeMethod()
 ```
@@ -467,26 +467,26 @@ It also tracks the current level for an individual player.
 
 ```swift
 struct LevelTracker {
-   static var highestUnlockedLevel = 1
-   var currentLevel = 1
+    static var highestUnlockedLevel = 1
+    var currentLevel = 1
 
-   static func unlock(_ level: Int) {
-      if level > highestUnlockedLevel { highestUnlockedLevel = level }
-   }
+    static func unlock(_ level: Int) {
+        if level > highestUnlockedLevel { highestUnlockedLevel = level }
+    }
 
-   static func isUnlocked(_ level: Int) -> Bool {
-      return level <= highestUnlockedLevel
-   }
+    static func isUnlocked(_ level: Int) -> Bool {
+        return level <= highestUnlockedLevel
+    }
 
-   @discardableResult
-   mutating func advance(to level: Int) -> Bool {
-      if LevelTracker.isUnlocked(level) {
-         currentLevel = level
-         return true
-      } else {
-         return false
-      }
-   }
+    @discardableResult
+    mutating func advance(to level: Int) -> Bool {
+        if LevelTracker.isUnlocked(level) {
+            currentLevel = level
+            return true
+        } else {
+            return false
+        }
+    }
 }
 ```
 
@@ -555,15 +555,15 @@ to track and update the progress of an individual player:
 
 ```swift
 class Player {
-   var tracker = LevelTracker()
-   let playerName: String
-   func complete(level: Int) {
-      LevelTracker.unlock(level + 1)
-      tracker.advance(to: level + 1)
-   }
-   init(name: String) {
-      playerName = name
-   }
+    var tracker = LevelTracker()
+    let playerName: String
+    func complete(level: Int) {
+        LevelTracker.unlock(level + 1)
+        tracker.advance(to: level + 1)
+    }
+    init(name: String) {
+        playerName = name
+    }
 }
 ```
 
@@ -625,9 +625,9 @@ the attempt to set the player's current level fails:
 ```swift
 player = Player(name: "Beto")
 if player.tracker.advance(to: 6) {
-   print("player is now on level 6")
+    print("player is now on level 6")
 } else {
-   print("level 6 hasn't yet been unlocked")
+    print("level 6 hasn't yet been unlocked")
 }
 // Prints "level 6 hasn't yet been unlocked"
 ```

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Methods.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Methods.md
@@ -350,12 +350,12 @@ enum TriStateSwitch {
     case off, low, high
     mutating func next() {
         switch self {
-            case .off:
-                self = .low
-            case .low:
-                self = .high
-            case .high:
-                self = .off
+        case .off:
+            self = .low
+        case .low:
+            self = .high
+        case .high:
+            self = .off
         }
     }
 }

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/NestedTypes.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/NestedTypes.md
@@ -27,40 +27,40 @@ which is nested within the `Rank` enumeration:
 ```swift
 struct BlackjackCard {
 
-   // nested Suit enumeration
-   enum Suit: Character {
-      case spades = "♠", hearts = "♡", diamonds = "♢", clubs = "♣"
-   }
+    // nested Suit enumeration
+    enum Suit: Character {
+        case spades = "♠", hearts = "♡", diamonds = "♢", clubs = "♣"
+    }
 
-   // nested Rank enumeration
-   enum Rank: Int {
-      case two = 2, three, four, five, six, seven, eight, nine, ten
-      case jack, queen, king, ace
-      struct Values {
-         let first: Int, second: Int?
-      }
-      var values: Values {
-         switch self {
-            case .ace:
-               return Values(first: 1, second: 11)
-            case .jack, .queen, .king:
-               return Values(first: 10, second: nil)
-            default:
-               return Values(first: self.rawValue, second: nil)
-         }
-      }
-   }
+    // nested Rank enumeration
+    enum Rank: Int {
+        case two = 2, three, four, five, six, seven, eight, nine, ten
+        case jack, queen, king, ace
+        struct Values {
+            let first: Int, second: Int?
+        }
+        var values: Values {
+            switch self {
+                case .ace:
+                    return Values(first: 1, second: 11)
+                case .jack, .queen, .king:
+                    return Values(first: 10, second: nil)
+                default:
+                    return Values(first: self.rawValue, second: nil)
+            }
+        }
+    }
 
-   // BlackjackCard properties and methods
-   let rank: Rank, suit: Suit
-   var description: String {
-      var output = "suit is \(suit.rawValue),"
-      output += " value is \(rank.values.first)"
-      if let second = rank.values.second {
-         output += " or \(second)"
-      }
-      return output
-   }
+    // BlackjackCard properties and methods
+    let rank: Rank, suit: Suit
+    var description: String {
+        var output = "suit is \(suit.rawValue),"
+        output += " value is \(rank.values.first)"
+        if let second = rank.values.second {
+            output += " or \(second)"
+        }
+        return output
+    }
 }
 ```
 

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/NestedTypes.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/NestedTypes.md
@@ -41,12 +41,12 @@ struct BlackjackCard {
         }
         var values: Values {
             switch self {
-                case .ace:
-                    return Values(first: 1, second: 11)
-                case .jack, .queen, .king:
-                    return Values(first: 10, second: nil)
-                default:
-                    return Values(first: self.rawValue, second: nil)
+            case .ace:
+                return Values(first: 1, second: 11)
+            case .jack, .queen, .king:
+                return Values(first: 10, second: nil)
+            default:
+                return Values(first: self.rawValue, second: nil)
             }
         }
     }

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/OpaqueTypes.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/OpaqueTypes.md
@@ -29,14 +29,14 @@ protocol Shape {
 }
 
 struct Triangle: Shape {
-   var size: Int
-   func draw() -> String {
+    var size: Int
+    func draw() -> String {
        var result: [String] = []
        for length in 1...size {
            result.append(String(repeating: "*", count: length))
        }
        return result.joined(separator: "\n")
-   }
+    }
 }
 let smallTriangle = Triangle(size: 3)
 print(smallTriangle.draw())
@@ -120,11 +120,11 @@ from joining a flipped triangle with another triangle.
 
 ```swift
 struct JoinedShape<T: Shape, U: Shape>: Shape {
-   var top: T
-   var bottom: U
-   func draw() -> String {
+    var top: T
+    var bottom: U
+    func draw() -> String {
        return top.draw() + "\n" + bottom.draw()
-   }
+    }
 }
 let joinedTriangles = JoinedShape(top: smallTriangle, bottom: flippedTriangle)
 print(joinedTriangles.draw())
@@ -515,7 +515,7 @@ instead of an opaque return type:
 
 ```swift
 func protoFlip<T: Shape>(_ shape: T) -> Shape {
-   return FlippedShape(shape: shape)
+    return FlippedShape(shape: shape)
 }
 ```
 
@@ -559,11 +559,11 @@ It reserves the flexibility to return values of multiple types:
 
 ```swift
 func protoFlip<T: Shape>(_ shape: T) -> Shape {
-   if shape is Square {
-      return shape
-   }
+    if shape is Square {
+        return shape
+    }
 
-   return FlippedShape(shape: shape)
+    return FlippedShape(shape: shape)
 }
 ```
 

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/OptionalChaining.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/OptionalChaining.md
@@ -45,11 +45,11 @@ First, two classes called `Person` and `Residence` are defined:
 
 ```swift
 class Person {
-   var residence: Residence?
+    var residence: Residence?
 }
 
 class Residence {
-   var numberOfRooms = 1
+    var numberOfRooms = 1
 }
 ```
 
@@ -121,9 +121,9 @@ To use optional chaining, use a question mark in place of the exclamation point:
 
 ```swift
 if let roomCount = john.residence?.numberOfRooms {
-   print("John's residence has \(roomCount) room(s).")
+    print("John's residence has \(roomCount) room(s).")
 } else {
-   print("Unable to retrieve the number of rooms.")
+    print("Unable to retrieve the number of rooms.")
 }
 // Prints "Unable to retrieve the number of rooms."
 ```
@@ -182,9 +182,9 @@ the default `numberOfRooms` value of `1`:
 
 ```swift
 if let roomCount = john.residence?.numberOfRooms {
-   print("John's residence has \(roomCount) room(s).")
+    print("John's residence has \(roomCount) room(s).")
 } else {
-   print("Unable to retrieve the number of rooms.")
+    print("Unable to retrieve the number of rooms.")
 }
 // Prints "John's residence has 1 room(s)."
 ```
@@ -223,7 +223,7 @@ The `Person` class is defined in the same way as before:
 
 ```swift
 class Person {
-   var residence: Residence?
+    var residence: Residence?
 }
 ```
 
@@ -244,22 +244,22 @@ which is initialized with an empty array of type `[Room]`:
 
 ```swift
 class Residence {
-   var rooms: [Room] = []
-   var numberOfRooms: Int {
-      return rooms.count
-   }
-   subscript(i: Int) -> Room {
-      get {
-         return rooms[i]
-      }
-      set {
-         rooms[i] = newValue
-      }
-   }
-   func printNumberOfRooms() {
-      print("The number of rooms is \(numberOfRooms)")
-   }
-   var address: Address?
+    var rooms: [Room] = []
+    var numberOfRooms: Int {
+        return rooms.count
+    }
+    subscript(i: Int) -> Room {
+        get {
+            return rooms[i]
+        }
+        set {
+            rooms[i] = newValue
+        }
+    }
+    func printNumberOfRooms() {
+        print("The number of rooms is \(numberOfRooms)")
+    }
+    var address: Address?
 }
 ```
 
@@ -312,8 +312,8 @@ and an initializer to set that property to a suitable room name:
 
 ```swift
 class Room {
-   let name: String
-   init(name: String) { self.name = name }
+    let name: String
+    init(name: String) { self.name = name }
 }
 ```
 
@@ -337,18 +337,18 @@ The third property, `street`, is used to name the street for that address:
 
 ```swift
 class Address {
-   var buildingName: String?
-   var buildingNumber: String?
-   var street: String?
-   func buildingIdentifier() -> String? {
-      if let buildingNumber = buildingNumber, let street = street {
+    var buildingName: String?
+    var buildingNumber: String?
+    var street: String?
+    func buildingIdentifier() -> String? {
+        if let buildingNumber = buildingNumber, let street = street {
           return "\(buildingNumber) \(street)"
-      } else if buildingName != nil {
+        } else if buildingName != nil {
           return buildingName
-      } else {
+        } else {
           return nil
-      }
-   }
+        }
+    }
 }
 ```
 
@@ -393,9 +393,9 @@ and try to access its `numberOfRooms` property as before:
 ```swift
 let john = Person()
 if let roomCount = john.residence?.numberOfRooms {
-   print("John's residence has \(roomCount) room(s).")
+    print("John's residence has \(roomCount) room(s).")
 } else {
-   print("Unable to retrieve the number of rooms.")
+    print("Unable to retrieve the number of rooms.")
 }
 // Prints "Unable to retrieve the number of rooms."
 ```
@@ -503,7 +503,7 @@ Here's how the method looks:
 
 ```swift
 func printNumberOfRooms() {
-   print("The number of rooms is \(numberOfRooms)")
+    print("The number of rooms is \(numberOfRooms)")
 }
 ```
 
@@ -535,9 +535,9 @@ to see if the method call was successful:
 
 ```swift
 if john.residence?.printNumberOfRooms() != nil {
-   print("It was possible to print the number of rooms.")
+    print("It was possible to print the number of rooms.")
 } else {
-   print("It was not possible to print the number of rooms.")
+    print("It was not possible to print the number of rooms.")
 }
 // Prints "It was not possible to print the number of rooms."
 ```
@@ -565,9 +565,9 @@ which enables you to compare against `nil` to see if the property was set succes
 
 ```swift
 if (john.residence?.address = someAddress) != nil {
-   print("It was possible to set the address.")
+    print("It was possible to set the address.")
 } else {
-   print("It was not possible to set the address.")
+    print("It was not possible to set the address.")
 }
 // Prints "It was not possible to set the address."
 ```
@@ -605,9 +605,9 @@ the subscript call fails:
 
 ```swift
 if let firstRoomName = john.residence?[0].name {
-   print("The first room name is \(firstRoomName).")
+    print("The first room name is \(firstRoomName).")
 } else {
-   print("Unable to retrieve the first room name.")
+    print("Unable to retrieve the first room name.")
 }
 // Prints "Unable to retrieve the first room name."
 ```
@@ -660,9 +660,9 @@ johnsHouse.rooms.append(Room(name: "Kitchen"))
 john.residence = johnsHouse
 
 if let firstRoomName = john.residence?[0].name {
-   print("The first room name is \(firstRoomName).")
+    print("The first room name is \(firstRoomName).")
 } else {
-   print("Unable to retrieve the first room name.")
+    print("Unable to retrieve the first room name.")
 }
 // Prints "The first room name is Living Room."
 ```
@@ -758,9 +758,9 @@ both of which are of optional type:
 
 ```swift
 if let johnsStreet = john.residence?.address?.street {
-   print("John's street name is \(johnsStreet).")
+    print("John's street name is \(johnsStreet).")
 } else {
-   print("Unable to retrieve the address.")
+    print("Unable to retrieve the address.")
 }
 // Prints "Unable to retrieve the address."
 ```
@@ -801,9 +801,9 @@ johnsAddress.street = "Laurel Street"
 john.residence?.address = johnsAddress
 
 if let johnsStreet = john.residence?.address?.street {
-   print("John's street name is \(johnsStreet).")
+    print("John's street name is \(johnsStreet).")
 } else {
-   print("Unable to retrieve the address.")
+    print("Unable to retrieve the address.")
 }
 // Prints "John's street name is Laurel Street."
 ```
@@ -846,7 +846,7 @@ is also `String?`:
 
 ```swift
 if let buildingIdentifier = john.residence?.address?.buildingIdentifier() {
-   print("John's building identifier is \(buildingIdentifier).")
+    print("John's building identifier is \(buildingIdentifier).")
 }
 // Prints "John's building identifier is The Larches."
 ```
@@ -868,12 +868,12 @@ place the optional chaining question mark *after* the method's parentheses:
 
 ```swift
 if let beginsWithThe =
-   john.residence?.address?.buildingIdentifier()?.hasPrefix("The") {
-   if beginsWithThe {
-      print("John's building identifier begins with \"The\".")
-   } else {
-      print("John's building identifier doesn't begin with \"The\".")
-   }
+    john.residence?.address?.buildingIdentifier()?.hasPrefix("The") {
+    if beginsWithThe {
+        print("John's building identifier begins with \"The\".")
+    } else {
+        print("John's building identifier doesn't begin with \"The\".")
+    }
 }
 // Prints "John's building identifier begins with "The"."
 ```

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Properties.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Properties.md
@@ -78,8 +78,8 @@ whose range length can't be changed after it's created:
 
 ```swift
 struct FixedLengthRange {
-   var firstValue: Int
-   let length: Int
+    var firstValue: Int
+    let length: Int
 }
 var rangeOfThreeItems = FixedLengthRange(firstValue: 0, length: 3)
 // the range represents integer values 0, 1, and 2
@@ -207,18 +207,18 @@ neither of which is shown in full:
 
 ```swift
 class DataImporter {
-   /*
-   DataImporter is a class to import data from an external file.
-   The class is assumed to take a nontrivial amount of time to initialize.
-   */
-   var filename = "data.txt"
-   // the DataImporter class would provide data importing functionality here
+    /*
+    DataImporter is a class to import data from an external file.
+    The class is assumed to take a nontrivial amount of time to initialize.
+    */
+    var filename = "data.txt"
+    // the DataImporter class would provide data importing functionality here
 }
 
 class DataManager {
-   lazy var importer = DataImporter()
-   var data: [String] = []
-   // the DataManager class would provide data management functionality here
+    lazy var importer = DataImporter()
+    var data: [String] = []
+    // the DataManager class would provide data management functionality here
 }
 
 let manager = DataManager()
@@ -340,28 +340,28 @@ to retrieve and set other properties and values indirectly.
 
 ```swift
 struct Point {
-   var x = 0.0, y = 0.0
+    var x = 0.0, y = 0.0
 }
 struct Size {
-   var width = 0.0, height = 0.0
+    var width = 0.0, height = 0.0
 }
 struct Rect {
-   var origin = Point()
-   var size = Size()
-   var center: Point {
-      get {
-         let centerX = origin.x + (size.width / 2)
-         let centerY = origin.y + (size.height / 2)
-         return Point(x: centerX, y: centerY)
-      }
-      set(newCenter) {
-         origin.x = newCenter.x - (size.width / 2)
-         origin.y = newCenter.y - (size.height / 2)
-      }
-   }
+    var origin = Point()
+    var size = Size()
+    var center: Point {
+        get {
+            let centerX = origin.x + (size.width / 2)
+            let centerY = origin.y + (size.height / 2)
+            return Point(x: centerX, y: centerY)
+        }
+        set(newCenter) {
+            origin.x = newCenter.x - (size.width / 2)
+            origin.y = newCenter.y - (size.height / 2)
+        }
+    }
 }
 var square = Rect(origin: Point(x: 0.0, y: 0.0),
-   size: Size(width: 10.0, height: 10.0))
+    size: Size(width: 10.0, height: 10.0))
 let initialSquareCenter = square.center
 // initialSquareCenter is at (5.0, 5.0)
 square.center = Point(x: 15.0, y: 15.0)
@@ -453,19 +453,19 @@ that takes advantage of this shorthand notation:
 
 ```swift
 struct AlternativeRect {
-   var origin = Point()
-   var size = Size()
-   var center: Point {
-      get {
-         let centerX = origin.x + (size.width / 2)
-         let centerY = origin.y + (size.height / 2)
-         return Point(x: centerX, y: centerY)
-      }
-      set {
-         origin.x = newValue.x - (size.width / 2)
-         origin.y = newValue.y - (size.height / 2)
-      }
-   }
+    var origin = Point()
+    var size = Size()
+    var center: Point {
+        get {
+            let centerX = origin.x + (size.width / 2)
+            let centerY = origin.y + (size.height / 2)
+            return Point(x: centerX, y: centerY)
+        }
+        set {
+            origin.x = newValue.x - (size.width / 2)
+            origin.y = newValue.y - (size.height / 2)
+        }
+    }
 }
 ```
 
@@ -506,18 +506,18 @@ and the shorthand notation for setters:
 
 ```swift
 struct CompactRect {
-   var origin = Point()
-   var size = Size()
-   var center: Point {
-      get {
-         Point(x: origin.x + (size.width / 2),
-               y: origin.y + (size.height / 2))
-      }
-      set {
-         origin.x = newValue.x - (size.width / 2)
-         origin.y = newValue.y - (size.height / 2)
-      }
-   }
+    var origin = Point()
+    var size = Size()
+    var center: Point {
+        get {
+            Point(x: origin.x + (size.width / 2),
+                    y: origin.y + (size.height / 2))
+        }
+        set {
+            origin.x = newValue.x - (size.width / 2)
+            origin.y = newValue.y - (size.height / 2)
+        }
+    }
 }
 ```
 
@@ -583,10 +583,10 @@ by removing the `get` keyword and its braces:
 
 ```swift
 struct Cuboid {
-   var width = 0.0, height = 0.0, depth = 0.0
-   var volume: Double {
-      return width * height * depth
-   }
+    var width = 0.0, height = 0.0, depth = 0.0
+    var volume: Double {
+        return width * height * depth
+    }
 }
 let fourByFiveByTwo = Cuboid(width: 4.0, height: 5.0, depth: 2.0)
 print("the volume of fourByFiveByTwo is \(fourByFiveByTwo.volume)")
@@ -791,16 +791,16 @@ to keep track of a person's exercise during their daily routine.
 
 ```swift
 class StepCounter {
-   var totalSteps: Int = 0 {
-      willSet(newTotalSteps) {
-         print("About to set totalSteps to \(newTotalSteps)")
-      }
-      didSet {
-         if totalSteps > oldValue  {
-            print("Added \(totalSteps - oldValue) steps")
-         }
-      }
-   }
+    var totalSteps: Int = 0 {
+        willSet(newTotalSteps) {
+            print("About to set totalSteps to \(newTotalSteps)")
+        }
+        didSet {
+            if totalSteps > oldValue  {
+                print("Added \(totalSteps - oldValue) steps")
+            }
+        }
+    }
 }
 let stepCounter = StepCounter()
 stepCounter.totalSteps = 200
@@ -1484,13 +1484,13 @@ struct SmallNumber {
     var wrappedValue: Int {
         get { return number }
         set {
-            if newValue > 12 {
+                if newValue > 12 {
                 number = 12
                 projectedValue = true
-            } else {
+                } else {
                 number = newValue
                 projectedValue = false
-            }
+                }
         }
     }
 
@@ -1591,10 +1591,10 @@ struct SizedRectangle {
 
     mutating func resize(to size: Size) -> Bool {
         switch size {
-            case .small:
+                case .small:
                 height = 10
                 width = 20
-            case .large:
+                case .large:
                 height = 100
                 width = 100
         }
@@ -1810,25 +1810,25 @@ The example below shows the syntax for stored and computed type properties:
 
 ```swift
 struct SomeStructure {
-   static var storedTypeProperty = "Some value."
-   static var computedTypeProperty: Int {
-      return 1
-   }
+    static var storedTypeProperty = "Some value."
+    static var computedTypeProperty: Int {
+        return 1
+    }
 }
 enum SomeEnumeration {
-   static var storedTypeProperty = "Some value."
-   static var computedTypeProperty: Int {
-      return 6
-   }
+    static var storedTypeProperty = "Some value."
+    static var computedTypeProperty: Int {
+        return 6
+    }
 }
 class SomeClass {
-   static var storedTypeProperty = "Some value."
-   static var computedTypeProperty: Int {
-      return 27
-   }
-   class var overrideableComputedTypeProperty: Int {
-      return 107
-   }
+    static var storedTypeProperty = "Some value."
+    static var computedTypeProperty: Int {
+        return 27
+    }
+    class var overrideableComputedTypeProperty: Int {
+        return 107
+    }
 }
 ```
 
@@ -1945,20 +1945,20 @@ instances of the `AudioChannel` structure:
 
 ```swift
 struct AudioChannel {
-   static let thresholdLevel = 10
-   static var maxInputLevelForAllChannels = 0
-   var currentLevel: Int = 0 {
-      didSet {
-         if currentLevel > AudioChannel.thresholdLevel {
-            // cap the new audio level to the threshold level
-            currentLevel = AudioChannel.thresholdLevel
-         }
-         if currentLevel > AudioChannel.maxInputLevelForAllChannels {
-            // store this as the new overall maximum input level
-            AudioChannel.maxInputLevelForAllChannels = currentLevel
-         }
-      }
-   }
+    static let thresholdLevel = 10
+    static var maxInputLevelForAllChannels = 0
+    var currentLevel: Int = 0 {
+        didSet {
+            if currentLevel > AudioChannel.thresholdLevel {
+                // cap the new audio level to the threshold level
+                currentLevel = AudioChannel.thresholdLevel
+            }
+            if currentLevel > AudioChannel.maxInputLevelForAllChannels {
+                // store this as the new overall maximum input level
+                AudioChannel.maxInputLevelForAllChannels = currentLevel
+            }
+        }
+    }
 }
 ```
 

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Properties.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Properties.md
@@ -1591,12 +1591,12 @@ struct SizedRectangle {
 
     mutating func resize(to size: Size) -> Bool {
         switch size {
-            case .small:
-                height = 10
-                width = 20
-            case .large:
-                height = 100
-                width = 100
+        case .small:
+            height = 10
+            width = 20
+        case .large:
+            height = 100
+            width = 100
         }
         return $height || $width
     }

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Properties.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Properties.md
@@ -511,7 +511,7 @@ struct CompactRect {
     var center: Point {
         get {
             Point(x: origin.x + (size.width / 2),
-                    y: origin.y + (size.height / 2))
+                  y: origin.y + (size.height / 2))
         }
         set {
             origin.x = newValue.x - (size.width / 2)
@@ -1484,13 +1484,13 @@ struct SmallNumber {
     var wrappedValue: Int {
         get { return number }
         set {
-                if newValue > 12 {
+            if newValue > 12 {
                 number = 12
                 projectedValue = true
-                } else {
+            } else {
                 number = newValue
                 projectedValue = false
-                }
+            }
         }
     }
 
@@ -1591,10 +1591,10 @@ struct SizedRectangle {
 
     mutating func resize(to size: Size) -> Bool {
         switch size {
-                case .small:
+            case .small:
                 height = 10
                 width = 20
-                case .large:
+            case .large:
                 height = 100
                 width = 100
         }

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Protocols.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Protocols.md
@@ -344,7 +344,7 @@ class LinearCongruentialGenerator: RandomNumberGenerator {
     let c = 29573.0
     func random() -> Double {
         lastRandom = ((lastRandom * a + c)
-          .truncatingRemainder(dividingBy:m))
+            .truncatingRemainder(dividingBy:m))
         return lastRandom / m
     }
 }
@@ -2632,9 +2632,9 @@ you can use the `==` and `!=` operators to check for equality and inequality bet
 extension Collection where Element: Equatable {
     func allEqual() -> Bool {
         for element in self {
-                if element != self.first {
+            if element != self.first {
                 return false
-                }
+            }
         }
         return true
     }

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Protocols.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Protocols.md
@@ -444,10 +444,10 @@ enum OnOffSwitch: Togglable {
     case off, on
     mutating func toggle() {
         switch self {
-            case .off:
-                self = .on
-            case .on:
-                self = .off
+        case .off:
+            self = .on
+        case .on:
+            self = .off
         }
     }
 }
@@ -970,13 +970,13 @@ class SnakesAndLadders: DiceGame {
             let diceRoll = dice.roll()
             delegate?.game(self, didStartNewTurnWithDiceRoll: diceRoll)
             switch square + diceRoll {
-                case finalSquare:
-                    break gameLoop
-                case let newSquare where newSquare > finalSquare:
-                    continue gameLoop
-                default:
-                    square += diceRoll
-                    square += board[square]
+            case finalSquare:
+                break gameLoop
+            case let newSquare where newSquare > finalSquare:
+                continue gameLoop
+            default:
+                square += diceRoll
+                square += board[square]
             }
         }
         delegate?.gameDidEnd(self)
@@ -1699,12 +1699,12 @@ extension SnakesAndLadders: PrettyTextRepresentable {
         var output = textualDescription + ":\n"
         for index in 1...finalSquare {
             switch board[index] {
-                case let ladder where ladder > 0:
-                    output += "▲ "
-                case let snake where snake < 0:
-                    output += "▼ "
-                default:
-                    output += "○ "
+            case let ladder where ladder > 0:
+                output += "▲ "
+            case let snake where snake < 0:
+                output += "▼ "
+            default:
+                output += "○ "
             }
         }
         return output

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Protocols.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Protocols.md
@@ -31,7 +31,7 @@ You define protocols in a very similar way to classes, structures, and enumerati
 
 ```swift
 protocol SomeProtocol {
-   // protocol definition goes here
+    // protocol definition goes here
 }
 ```
 
@@ -53,7 +53,7 @@ Multiple protocols can be listed, and are separated by commas:
 
 ```swift
 struct SomeStructure: FirstProtocol, AnotherProtocol {
-   // structure definition goes here
+    // structure definition goes here
 }
 ```
 
@@ -75,7 +75,7 @@ before any protocols it adopts, followed by a comma:
 
 ```swift
 class SomeClass: SomeSuperclass, FirstProtocol, AnotherProtocol {
-   // class definition goes here
+    // class definition goes here
 }
 ```
 
@@ -117,8 +117,8 @@ and gettable properties are indicated by writing `{ get }`.
 
 ```swift
 protocol SomeProtocol {
-   var mustBeSettable: Int { get set }
-   var doesNotNeedToBeSettable: Int { get }
+    var mustBeSettable: Int { get set }
+    var doesNotNeedToBeSettable: Int { get }
 }
 ```
 
@@ -141,7 +141,7 @@ the `class` or `static` keyword when implemented by a class:
 
 ```swift
 protocol AnotherProtocol {
-   static var someTypeProperty: Int { get set }
+    static var someTypeProperty: Int { get set }
 }
 ```
 
@@ -160,7 +160,7 @@ Here's an example of a protocol with a single instance property requirement:
 
 ```swift
 protocol FullyNamed {
-   var fullName: String { get }
+    var fullName: String { get }
 }
 ```
 
@@ -186,7 +186,7 @@ the `FullyNamed` protocol:
 
 ```swift
 struct Person: FullyNamed {
-   var fullName: String
+    var fullName: String
 }
 let john = Person(fullName: "John Appleseed")
 // john.fullName is "John Appleseed"
@@ -221,15 +221,15 @@ Here's a more complex class, which also adopts and conforms to the `FullyNamed` 
 
 ```swift
 class Starship: FullyNamed {
-   var prefix: String?
-   var name: String
-   init(name: String, prefix: String? = nil) {
-      self.name = name
-      self.prefix = prefix
-   }
-   var fullName: String {
-      return (prefix != nil ? prefix! + " " : "") + name
-   }
+    var prefix: String?
+    var name: String
+    init(name: String, prefix: String? = nil) {
+        self.name = name
+        self.prefix = prefix
+    }
+    var fullName: String {
+        return (prefix != nil ? prefix! + " " : "") + name
+    }
 }
 var ncc1701 = Starship(name: "Enterprise", prefix: "USS")
 // ncc1701.fullName is "USS Enterprise"
@@ -285,7 +285,7 @@ the `class` or `static` keyword when implemented by a class:
 
 ```swift
 protocol SomeProtocol {
-   static func someTypeMethod()
+    static func someTypeMethod()
 }
 ```
 
@@ -304,7 +304,7 @@ The following example defines a protocol with a single instance method requireme
 
 ```swift
 protocol RandomNumberGenerator {
-   func random() -> Double
+    func random() -> Double
 }
 ```
 
@@ -338,15 +338,15 @@ a *linear congruential generator*:
 
 ```swift
 class LinearCongruentialGenerator: RandomNumberGenerator {
-   var lastRandom = 42.0
-   let m = 139968.0
-   let a = 3877.0
-   let c = 29573.0
-   func random() -> Double {
-      lastRandom = ((lastRandom * a + c)
+    var lastRandom = 42.0
+    let m = 139968.0
+    let a = 3877.0
+    let c = 29573.0
+    func random() -> Double {
+        lastRandom = ((lastRandom * a + c)
           .truncatingRemainder(dividingBy:m))
-      return lastRandom / m
-   }
+        return lastRandom / m
+    }
 }
 let generator = LinearCongruentialGenerator()
 print("Here's a random number: \(generator.random())")
@@ -413,7 +413,7 @@ when it's called:
 
 ```swift
 protocol Togglable {
-   mutating func toggle()
+    mutating func toggle()
 }
 ```
 
@@ -441,15 +441,15 @@ to match the `Togglable` protocol's requirements:
 
 ```swift
 enum OnOffSwitch: Togglable {
-   case off, on
-   mutating func toggle() {
-      switch self {
-         case .off:
-            self = .on
-         case .on:
-            self = .off
-      }
-   }
+    case off, on
+    mutating func toggle() {
+        switch self {
+            case .off:
+                self = .on
+            case .on:
+                self = .off
+        }
+    }
 }
 var lightSwitch = OnOffSwitch.off
 lightSwitch.toggle()
@@ -488,7 +488,7 @@ but without curly braces or an initializer body:
 
 ```swift
 protocol SomeProtocol {
-   init(someParameter: Int)
+    init(someParameter: Int)
 }
 ```
 
@@ -512,9 +512,9 @@ you must mark the initializer implementation with the `required` modifier:
 
 ```swift
 class SomeClass: SomeProtocol {
-   required init(someParameter: Int) {
-      // initializer implementation goes here
-   }
+    required init(someParameter: Int) {
+        // initializer implementation goes here
+    }
 }
 ```
 
@@ -631,20 +631,20 @@ mark the initializer implementation with both the `required` and `override` modi
 
 ```swift
 protocol SomeProtocol {
-   init()
+    init()
 }
 
 class SomeSuperClass {
-   init() {
-      // initializer implementation goes here
-   }
+    init() {
+        // initializer implementation goes here
+    }
 }
 
 class SomeSubClass: SomeSuperClass, SomeProtocol {
-   // "required" from SomeProtocol conformance; "override" from SomeSuperClass
-   required override init() {
-      // initializer implementation goes here
-   }
+    // "required" from SomeProtocol conformance; "override" from SomeSuperClass
+    required override init() {
+        // initializer implementation goes here
+    }
 }
 ```
 
@@ -787,15 +787,15 @@ Here's an example of a protocol used as a type:
 
 ```swift
 class Dice {
-   let sides: Int
-   let generator: RandomNumberGenerator
-   init(sides: Int, generator: RandomNumberGenerator) {
-      self.sides = sides
-      self.generator = generator
-   }
-   func roll() -> Int {
-      return Int(generator.random() * Double(sides)) + 1
-   }
+    let sides: Int
+    let generator: RandomNumberGenerator
+    init(sides: Int, generator: RandomNumberGenerator) {
+        self.sides = sides
+        self.generator = generator
+    }
+    func roll() -> Int {
+        return Int(generator.random() * Double(sides)) + 1
+    }
 }
 ```
 
@@ -860,7 +860,7 @@ with a `LinearCongruentialGenerator` instance as its random number generator:
 ```swift
 var d6 = Dice(sides: 6, generator: LinearCongruentialGenerator())
 for _ in 1...5 {
-   print("Random dice roll is \(d6.roll())")
+    print("Random dice roll is \(d6.roll())")
 }
 // Random dice roll is 3
 // Random dice roll is 5
@@ -903,13 +903,13 @@ The example below defines two protocols for use with dice-based board games:
 
 ```swift
 protocol DiceGame {
-   var dice: Dice { get }
-   func play()
+    var dice: Dice { get }
+    func play()
 }
 protocol DiceGameDelegate: AnyObject {
-   func gameDidStart(_ game: DiceGame)
-   func game(_ game: DiceGame, didStartNewTurnWithDiceRoll diceRoll: Int)
-   func gameDidEnd(_ game: DiceGame)
+    func gameDidStart(_ game: DiceGame)
+    func game(_ game: DiceGame, didStartNewTurnWithDiceRoll diceRoll: Int)
+    func gameDidEnd(_ game: DiceGame)
 }
 ```
 
@@ -953,34 +953,34 @@ and to notify a `DiceGameDelegate` about its progress:
 
 ```swift
 class SnakesAndLadders: DiceGame {
-   let finalSquare = 25
-   let dice = Dice(sides: 6, generator: LinearCongruentialGenerator())
-   var square = 0
-   var board: [Int]
-   init() {
-      board = Array(repeating: 0, count: finalSquare + 1)
-      board[03] = +08; board[06] = +11; board[09] = +09; board[10] = +02
-      board[14] = -10; board[19] = -11; board[22] = -02; board[24] = -08
-   }
-   weak var delegate: DiceGameDelegate?
-   func play() {
-      square = 0
-      delegate?.gameDidStart(self)
-      gameLoop: while square != finalSquare {
-         let diceRoll = dice.roll()
-         delegate?.game(self, didStartNewTurnWithDiceRoll: diceRoll)
-         switch square + diceRoll {
-            case finalSquare:
-               break gameLoop
-            case let newSquare where newSquare > finalSquare:
-               continue gameLoop
-            default:
-               square += diceRoll
-               square += board[square]
-         }
-      }
-      delegate?.gameDidEnd(self)
-   }
+    let finalSquare = 25
+    let dice = Dice(sides: 6, generator: LinearCongruentialGenerator())
+    var square = 0
+    var board: [Int]
+    init() {
+        board = Array(repeating: 0, count: finalSquare + 1)
+        board[03] = +08; board[06] = +11; board[09] = +09; board[10] = +02
+        board[14] = -10; board[19] = -11; board[22] = -02; board[24] = -08
+    }
+    weak var delegate: DiceGameDelegate?
+    func play() {
+        square = 0
+        delegate?.gameDidStart(self)
+        gameLoop: while square != finalSquare {
+            let diceRoll = dice.roll()
+            delegate?.game(self, didStartNewTurnWithDiceRoll: diceRoll)
+            switch square + diceRoll {
+                case finalSquare:
+                    break gameLoop
+                case let newSquare where newSquare > finalSquare:
+                    continue gameLoop
+                default:
+                    square += diceRoll
+                    square += board[square]
+            }
+        }
+        delegate?.gameDidEnd(self)
+    }
 }
 ```
 
@@ -1068,21 +1068,21 @@ which adopts the `DiceGameDelegate` protocol:
 
 ```swift
 class DiceGameTracker: DiceGameDelegate {
-   var numberOfTurns = 0
-   func gameDidStart(_ game: DiceGame) {
-      numberOfTurns = 0
-      if game is SnakesAndLadders {
-         print("Started a new game of Snakes and Ladders")
-      }
-      print("The game is using a \(game.dice.sides)-sided dice")
-   }
-   func game(_ game: DiceGame, didStartNewTurnWithDiceRoll diceRoll: Int) {
-      numberOfTurns += 1
-      print("Rolled a \(diceRoll)")
-   }
-   func gameDidEnd(_ game: DiceGame) {
-      print("The game lasted for \(numberOfTurns) turns")
-   }
+    var numberOfTurns = 0
+    func gameDidStart(_ game: DiceGame) {
+        numberOfTurns = 0
+        if game is SnakesAndLadders {
+            print("Started a new game of Snakes and Ladders")
+        }
+        print("The game is using a \(game.dice.sides)-sided dice")
+    }
+    func game(_ game: DiceGame, didStartNewTurnWithDiceRoll diceRoll: Int) {
+        numberOfTurns += 1
+        print("Rolled a \(diceRoll)")
+    }
+    func gameDidEnd(_ game: DiceGame) {
+        print("The game lasted for \(numberOfTurns) turns")
+    }
 }
 ```
 
@@ -1186,7 +1186,7 @@ This might be a description of itself, or a text version of its current state:
 
 ```swift
 protocol TextRepresentable {
-   var textualDescription: String { get }
+    var textualDescription: String { get }
 }
 ```
 
@@ -1211,9 +1211,9 @@ The `Dice` class from above can be extended to adopt and conform to `TextReprese
 
 ```swift
 extension Dice: TextRepresentable {
-   var textualDescription: String {
-      return "A \(sides)-sided dice"
-   }
+    var textualDescription: String {
+        return "A \(sides)-sided dice"
+    }
 }
 ```
 
@@ -1260,9 +1260,9 @@ adopt and conform to the `TextRepresentable` protocol:
 
 ```swift
 extension SnakesAndLadders: TextRepresentable {
-   var textualDescription: String {
-      return "A game of Snakes and Ladders with \(finalSquare) squares"
-   }
+    var textualDescription: String {
+        return "A game of Snakes and Ladders with \(finalSquare) squares"
+    }
 }
 print(game.textualDescription)
 // Prints "A game of Snakes and Ladders with 25 squares"
@@ -1300,10 +1300,10 @@ whenever they store elements of a type that conforms to `TextRepresentable`.
 
 ```swift
 extension Array: TextRepresentable where Element: TextRepresentable {
-   var textualDescription: String {
-      let itemsAsText = self.map { $0.textualDescription }
-      return "[" + itemsAsText.joined(separator: ", ") + "]"
-   }
+    var textualDescription: String {
+        let itemsAsText = self.map { $0.textualDescription }
+        return "[" + itemsAsText.joined(separator: ", ") + "]"
+    }
 }
 let myDice = [d6, d12]
 print(myDice.textualDescription)
@@ -1335,10 +1335,10 @@ you can make it adopt the protocol with an empty extension:
 
 ```swift
 struct Hamster {
-   var name: String
-   var textualDescription: String {
-      return "A hamster named \(name)"
-   }
+    var name: String
+    var textualDescription: String {
+        return "A hamster named \(name)"
+    }
 }
 extension Hamster: TextRepresentable {}
 ```
@@ -1436,7 +1436,7 @@ of the equivalence operators.
 
 ```swift
 struct Vector3D: Equatable {
-   var x = 0.0, y = 0.0, z = 0.0
+    var x = 0.0, y = 0.0, z = 0.0
 }
 
 let twoThreeFour = Vector3D(x: 2.0, y: 3.0, z: 4.0)
@@ -1609,7 +1609,7 @@ and print each item's textual description:
 
 ```swift
 for thing in things {
-   print(thing.textualDescription)
+    print(thing.textualDescription)
 }
 // A game of Snakes and Ladders with 25 squares
 // A 12-sided dice
@@ -1646,7 +1646,7 @@ but with the option to list multiple inherited protocols, separated by commas:
 
 ```swift
 protocol InheritingProtocol: SomeProtocol, AnotherProtocol {
-   // protocol definition goes here
+    // protocol definition goes here
 }
 ```
 
@@ -1668,7 +1668,7 @@ the `TextRepresentable` protocol from above:
 
 ```swift
 protocol PrettyTextRepresentable: TextRepresentable {
-   var prettyTextualDescription: String { get }
+    var prettyTextualDescription: String { get }
 }
 ```
 
@@ -1695,20 +1695,20 @@ The `SnakesAndLadders` class can be extended to adopt and conform to `PrettyText
 
 ```swift
 extension SnakesAndLadders: PrettyTextRepresentable {
-   var prettyTextualDescription: String {
-      var output = textualDescription + ":\n"
-      for index in 1...finalSquare {
-         switch board[index] {
-            case let ladder where ladder > 0:
-               output += "▲ "
-            case let snake where snake < 0:
-               output += "▼ "
-            default:
-               output += "○ "
-         }
-      }
-      return output
-   }
+    var prettyTextualDescription: String {
+        var output = textualDescription + ":\n"
+        for index in 1...finalSquare {
+            switch board[index] {
+                case let ladder where ladder > 0:
+                    output += "▲ "
+                case let snake where snake < 0:
+                    output += "▼ "
+                default:
+                    output += "○ "
+            }
+        }
+        return output
+    }
 }
 ```
 
@@ -1782,7 +1782,7 @@ by adding the `AnyObject` protocol to a protocol's inheritance list.
 
 ```swift
 protocol SomeClassOnlyProtocol: AnyObject, SomeInheritedProtocol {
-   // class-only protocol definition goes here
+    // class-only protocol definition goes here
 }
 ```
 
@@ -1846,17 +1846,17 @@ into a single protocol composition requirement on a function parameter:
 
 ```swift
 protocol Named {
-   var name: String { get }
+    var name: String { get }
 }
 protocol Aged {
-   var age: Int { get }
+    var age: Int { get }
 }
 struct Person: Named, Aged {
-   var name: String
-   var age: Int
+    var name: String
+    var age: Int
 }
 func wishHappyBirthday(to celebrator: Named & Aged) {
-   print("Happy birthday, \(celebrator.name), you're \(celebrator.age)!")
+    print("Happy birthday, \(celebrator.name), you're \(celebrator.age)!")
 }
 let birthdayPerson = Person(name: "Malcolm", age: 21)
 wishHappyBirthday(to: birthdayPerson)
@@ -1998,7 +1998,7 @@ with a single property requirement of a gettable `Double` property called `area`
 
 ```swift
 protocol HasArea {
-   var area: Double { get }
+    var area: Double { get }
 }
 ```
 
@@ -2018,14 +2018,14 @@ both of which conform to the `HasArea` protocol:
 
 ```swift
 class Circle: HasArea {
-   let pi = 3.1415927
-   var radius: Double
-   var area: Double { return pi * radius * radius }
-   init(radius: Double) { self.radius = radius }
+    let pi = 3.1415927
+    var radius: Double
+    var area: Double { return pi * radius * radius }
+    init(radius: Double) { self.radius = radius }
 }
 class Country: HasArea {
-   var area: Double
-   init(area: Double) { self.area = area }
+    var area: Double
+    init(area: Double) { self.area = area }
 }
 ```
 
@@ -2056,8 +2056,8 @@ Here's a class called `Animal`, which doesn't conform to the `HasArea` protocol:
 
 ```swift
 class Animal {
-   var legs: Int
-   init(legs: Int) { self.legs = legs }
+    var legs: Int
+    init(legs: Int) { self.legs = legs }
 }
 ```
 
@@ -2079,9 +2079,9 @@ can be used to initialize an array that stores values of type `AnyObject`:
 
 ```swift
 let objects: [AnyObject] = [
-   Circle(radius: 2.0),
-   Country(area: 243_610),
-   Animal(legs: 4)
+    Circle(radius: 2.0),
+    Country(area: 243_610),
+    Animal(legs: 4)
 ]
 ```
 
@@ -2110,11 +2110,11 @@ it conforms to the `HasArea` protocol:
 
 ```swift
 for object in objects {
-   if let objectWithArea = object as? HasArea {
-      print("Area is \(objectWithArea.area)")
-   } else {
-      print("Something that doesn't have an area")
-   }
+    if let objectWithArea = object as? HasArea {
+        print("Area is \(objectWithArea.area)")
+    } else {
+        print("Something that doesn't have an area")
+    }
 }
 // Area is 12.5663708
 // Area is 243610.0
@@ -2217,8 +2217,8 @@ which has two optional requirements:
 
 ```swift
 @objc protocol CounterDataSource {
-   @objc optional func increment(forCount count: Int) -> Int
-   @objc optional var fixedIncrement: Int { get }
+    @objc optional func increment(forCount count: Int) -> Int
+    @objc optional var fixedIncrement: Int { get }
 }
 ```
 
@@ -2252,15 +2252,15 @@ has an optional `dataSource` property of type `CounterDataSource?`:
 
 ```swift
 class Counter {
-   var count = 0
-   var dataSource: CounterDataSource?
-   func increment() {
-      if let amount = dataSource?.increment?(forCount: count) {
-         count += amount
-      } else if let amount = dataSource?.fixedIncrement {
-         count += amount
-      }
-   }
+    var count = 0
+    var dataSource: CounterDataSource?
+    func increment() {
+        if let amount = dataSource?.increment?(forCount: count) {
+            count += amount
+        } else if let amount = dataSource?.fixedIncrement {
+            count += amount
+        }
+    }
 }
 ```
 
@@ -2340,7 +2340,7 @@ It does this by implementing the optional `fixedIncrement` property requirement:
 
 ```swift
 class ThreeSource: NSObject, CounterDataSource {
-   let fixedIncrement = 3
+    let fixedIncrement = 3
 }
 ```
 
@@ -2361,8 +2361,8 @@ You can use an instance of `ThreeSource` as the data source for a new `Counter` 
 var counter = Counter()
 counter.dataSource = ThreeSource()
 for _ in 1...4 {
-   counter.increment()
-   print(counter.count)
+    counter.increment()
+    print(counter.count)
 }
 // 3
 // 6
@@ -2400,15 +2400,15 @@ from its current `count` value:
 
 ```swift
 class TowardsZeroSource: NSObject, CounterDataSource {
-   func increment(forCount count: Int) -> Int {
-      if count == 0 {
-         return 0
-      } else if count < 0 {
-         return 1
-      } else {
-         return -1
-      }
-   }
+    func increment(forCount count: Int) -> Int {
+        if count == 0 {
+            return 0
+        } else if count < 0 {
+            return 1
+        } else {
+            return -1
+        }
+    }
 }
 ```
 
@@ -2445,8 +2445,8 @@ Once the counter reaches zero, no more counting takes place:
 counter.count = -4
 counter.dataSource = TowardsZeroSource()
 for _ in 1...5 {
-   counter.increment()
-   print(counter.count)
+    counter.increment()
+    print(counter.count)
 }
 // -3
 // -2
@@ -2489,9 +2489,9 @@ to return a random `Bool` value:
 
 ```swift
 extension RandomNumberGenerator {
-   func randomBool() -> Bool {
-      return random() > 0.5
-   }
+    func randomBool() -> Bool {
+        return random() > 0.5
+    }
 }
 ```
 
@@ -2563,9 +2563,9 @@ to simply return the result of accessing the `textualDescription` property:
 
 ```swift
 extension PrettyTextRepresentable  {
-   var prettyTextualDescription: String {
-      return textualDescription
-   }
+    var prettyTextualDescription: String {
+        return textualDescription
+    }
 }
 ```
 
@@ -2632,9 +2632,9 @@ you can use the `==` and `!=` operators to check for equality and inequality bet
 extension Collection where Element: Equatable {
     func allEqual() -> Bool {
         for element in self {
-            if element != self.first {
+                if element != self.first {
                 return false
-            }
+                }
         }
         return true
     }

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/StringsAndCharacters.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/StringsAndCharacters.md
@@ -386,7 +386,7 @@ by checking its Boolean `isEmpty` property:
 
 ```swift
 if emptyString.isEmpty {
-   print("Nothing to see here")
+    print("Nothing to see here")
 }
 // Prints "Nothing to see here"
 ```
@@ -489,7 +489,7 @@ by iterating over the string with a `for`-`in` loop:
 
 ```swift
 for character in "Dog!🐶" {
-   print(character)
+    print(character)
 }
 // D
 // o
@@ -1100,7 +1100,7 @@ indices of individual characters in a string.
 
 ```swift
 for index in greeting.indices {
-   print("\(greeting[index]) ", terminator: "")
+    print("\(greeting[index]) ", terminator: "")
 }
 // Prints "G u t e n   T a g ! "
 ```
@@ -1304,7 +1304,7 @@ as described in <doc:BasicOperators#Comparison-Operators>:
 let quotation = "We're a lot alike, you and I."
 let sameQuotation = "We're a lot alike, you and I."
 if quotation == sameQuotation {
-   print("These two strings are considered equal")
+    print("These two strings are considered equal")
 }
 // Prints "These two strings are considered equal"
 ```
@@ -1373,7 +1373,7 @@ let eAcuteQuestion = "Voulez-vous un caf\u{E9}?"
 let combinedEAcuteQuestion = "Voulez-vous un caf\u{65}\u{301}?"
 
 if eAcuteQuestion == combinedEAcuteQuestion {
-   print("These two strings are considered equal")
+    print("These two strings are considered equal")
 }
 // Prints "These two strings are considered equal"
 ```
@@ -1409,7 +1409,7 @@ let latinCapitalLetterA: Character = "\u{41}"
 let cyrillicCapitalLetterA: Character = "\u{0410}"
 
 if latinCapitalLetterA != cyrillicCapitalLetterA {
-   print("These two characters aren't equivalent.")
+    print("These two characters aren't equivalent.")
 }
 // Prints "These two characters aren't equivalent."
 ```
@@ -1491,17 +1491,17 @@ the scene locations from the first two acts of Shakespeare's *Romeo and Juliet*:
 
 ```swift
 let romeoAndJuliet = [
-   "Act 1 Scene 1: Verona, A public place",
-   "Act 1 Scene 2: Capulet's mansion",
-   "Act 1 Scene 3: A room in Capulet's mansion",
-   "Act 1 Scene 4: A street outside Capulet's mansion",
-   "Act 1 Scene 5: The Great Hall in Capulet's mansion",
-   "Act 2 Scene 1: Outside Capulet's mansion",
-   "Act 2 Scene 2: Capulet's orchard",
-   "Act 2 Scene 3: Outside Friar Lawrence's cell",
-   "Act 2 Scene 4: A street in Verona",
-   "Act 2 Scene 5: Capulet's mansion",
-   "Act 2 Scene 6: Friar Lawrence's cell"
+    "Act 1 Scene 1: Verona, A public place",
+    "Act 1 Scene 2: Capulet's mansion",
+    "Act 1 Scene 3: A room in Capulet's mansion",
+    "Act 1 Scene 4: A street outside Capulet's mansion",
+    "Act 1 Scene 5: The Great Hall in Capulet's mansion",
+    "Act 2 Scene 1: Outside Capulet's mansion",
+    "Act 2 Scene 2: Capulet's orchard",
+    "Act 2 Scene 3: Outside Friar Lawrence's cell",
+    "Act 2 Scene 4: A street in Verona",
+    "Act 2 Scene 5: Capulet's mansion",
+    "Act 2 Scene 6: Friar Lawrence's cell"
 ]
 ```
 
@@ -1532,9 +1532,9 @@ to count the number of scenes in Act 1 of the play:
 ```swift
 var act1SceneCount = 0
 for scene in romeoAndJuliet {
-   if scene.hasPrefix("Act 1 ") {
-      act1SceneCount += 1
-   }
+    if scene.hasPrefix("Act 1 ") {
+        act1SceneCount += 1
+    }
 }
 print("There are \(act1SceneCount) scenes in Act 1")
 // Prints "There are 5 scenes in Act 1"
@@ -1563,11 +1563,11 @@ that take place in or around Capulet's mansion and Friar Lawrence's cell:
 var mansionCount = 0
 var cellCount = 0
 for scene in romeoAndJuliet {
-   if scene.hasSuffix("Capulet's mansion") {
-      mansionCount += 1
-   } else if scene.hasSuffix("Friar Lawrence's cell") {
-      cellCount += 1
-   }
+    if scene.hasSuffix("Capulet's mansion") {
+        mansionCount += 1
+    } else if scene.hasSuffix("Friar Lawrence's cell") {
+        cellCount += 1
+    }
 }
 print("\(mansionCount) mansion scenes; \(cellCount) cell scenes")
 // Prints "6 mansion scenes; 2 cell scenes"
@@ -1652,7 +1652,7 @@ one for each byte in the string's UTF-8 representation:
 
 ```swift
 for codeUnit in dogString.utf8 {
-   print("\(codeUnit) ", terminator: "")
+    print("\(codeUnit) ", terminator: "")
 }
 print("")
 // Prints "68 111 103 226 128 188 240 159 144 182 "
@@ -1708,7 +1708,7 @@ one for each 16-bit code unit in the string's UTF-16 representation:
 
 ```swift
 for codeUnit in dogString.utf16 {
-   print("\(codeUnit) ", terminator: "")
+    print("\(codeUnit) ", terminator: "")
 }
 print("")
 // Prints "68 111 103 8252 55357 56374 "
@@ -1764,7 +1764,7 @@ the scalar's 21-bit value, represented within a `UInt32` value:
 
 ```swift
 for scalar in dogString.unicodeScalars {
-   print("\(scalar.value) ", terminator: "")
+    print("\(scalar.value) ", terminator: "")
 }
 print("")
 // Prints "68 111 103 8252 128054 "
@@ -1807,7 +1807,7 @@ such as with string interpolation:
 
 ```swift
 for scalar in dogString.unicodeScalars {
-   print("\(scalar) ")
+    print("\(scalar) ")
 }
 // D
 // o

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Subscripts.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Subscripts.md
@@ -35,12 +35,12 @@ in the same way as for computed properties:
 
 ```swift
 subscript(index: Int) -> Int {
-   get {
-      // Return an appropriate subscript value here.
-   }
-   set(newValue) {
-      // Perform a suitable setting action here.
-   }
+    get {
+        // Return an appropriate subscript value here.
+    }
+    set(newValue) {
+        // Perform a suitable setting action here.
+    }
 }
 ```
 
@@ -75,7 +75,7 @@ by removing the `get` keyword and its braces:
 
 ```swift
 subscript(index: Int) -> Int {
-   // Return an appropriate subscript value here.
+    // Return an appropriate subscript value here.
 }
 ```
 
@@ -98,10 +98,10 @@ which defines a `TimesTable` structure to represent an *n*-times-table of intege
 
 ```swift
 struct TimesTable {
-   let multiplier: Int
-   subscript(index: Int) -> Int {
-      return multiplier * index
-   }
+    let multiplier: Int
+    subscript(index: Int) -> Int {
+        return multiplier * index
+    }
 }
 let threeTimesTable = TimesTable(multiplier: 3)
 print("six times three is \(threeTimesTable[6])")
@@ -231,26 +231,26 @@ The `Matrix` structure's subscript takes two integer parameters:
 
 ```swift
 struct Matrix {
-   let rows: Int, columns: Int
-   var grid: [Double]
-   init(rows: Int, columns: Int) {
-      self.rows = rows
-      self.columns = columns
-      grid = Array(repeating: 0.0, count: rows * columns)
-   }
-   func indexIsValid(row: Int, column: Int) -> Bool {
-      return row >= 0 && row < rows && column >= 0 && column < columns
-   }
-   subscript(row: Int, column: Int) -> Double {
-      get {
-         assert(indexIsValid(row: row, column: column), "Index out of range")
-         return grid[(row * columns) + column]
-      }
-      set {
-         assert(indexIsValid(row: row, column: column), "Index out of range")
-         grid[(row * columns) + column] = newValue
-      }
-   }
+    let rows: Int, columns: Int
+    var grid: [Double]
+    init(rows: Int, columns: Int) {
+        self.rows = rows
+        self.columns = columns
+        grid = Array(repeating: 0.0, count: rows * columns)
+    }
+    func indexIsValid(row: Int, column: Int) -> Bool {
+        return row >= 0 && row < rows && column >= 0 && column < columns
+    }
+    subscript(row: Int, column: Int) -> Double {
+        get {
+            assert(indexIsValid(row: row, column: column), "Index out of range")
+            return grid[(row * columns) + column]
+        }
+        set {
+            assert(indexIsValid(row: row, column: column), "Index out of range")
+            grid[(row * columns) + column] = newValue
+        }
+    }
 }
 ```
 
@@ -357,7 +357,7 @@ are inside the bounds of the matrix:
 
 ```swift
 func indexIsValid(row: Int, column: Int) -> Bool {
-   return row >= 0 && row < rows && column >= 0 && column < columns
+    return row >= 0 && row < rows && column >= 0 && column < columns
 }
 ```
 
@@ -407,10 +407,10 @@ The example below shows how you define and call a type subscript:
 
 ```swift
 enum Planet: Int {
-   case mercury = 1, venus, earth, mars, jupiter, saturn, uranus, neptune
-   static subscript(n: Int) -> Planet {
-      return Planet(rawValue: n)!
-   }
+    case mercury = 1, venus, earth, mars, jupiter, saturn, uranus, neptune
+    static subscript(n: Int) -> Planet {
+        return Planet(rawValue: n)!
+    }
 }
 let mars = Planet[4]
 print(mars)

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/TheBasics.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/TheBasics.md
@@ -393,7 +393,7 @@ The second block is then closed, followed by the first block:
 
 ```swift
 /* This is the start of the first multiline comment.
-   /* This is the second, nested multiline comment. */
+    /* This is the second, nested multiline comment. */
 This is the end of the first multiline comment. */
 ```
 
@@ -993,9 +993,9 @@ such as the `if` statement:
 
 ```swift
 if turnipsAreDelicious {
-   print("Mmm, tasty turnips!")
+    print("Mmm, tasty turnips!")
 } else {
-   print("Eww, turnips are horrible.")
+    print("Eww, turnips are horrible.")
 }
 // Prints "Eww, turnips are horrible."
 ```
@@ -1022,7 +1022,7 @@ The following example reports a compile-time error:
 ```swift
 let i = 1
 if i {
-   // this example will not compile, and will report an error
+    // this example will not compile, and will report an error
 }
 ```
 
@@ -1047,7 +1047,7 @@ However, the alternative example below is valid:
 ```swift
 let i = 1
 if i == 1 {
-   // this example will compile successfully
+    // this example will compile successfully
 }
 ```
 
@@ -1349,7 +1349,7 @@ If an optional has a value, it's considered to be “not equal to” `nil`:
 
 ```swift
 if convertedNumber != nil {
-   print("convertedNumber contains some integer value.")
+    print("convertedNumber contains some integer value.")
 }
 // Prints "convertedNumber contains some integer value."
 ```
@@ -1375,7 +1375,7 @@ This is known as *forced unwrapping* of the optional's value:
 
 ```swift
 if convertedNumber != nil {
-   print("convertedNumber has an integer value of \(convertedNumber!).")
+    print("convertedNumber has an integer value of \(convertedNumber!).")
 }
 // Prints "convertedNumber has an integer value of 123."
 ```
@@ -1424,9 +1424,9 @@ to use optional binding rather than forced unwrapping:
 
 ```swift
 if let actualNumber = Int(possibleNumber) {
-   print("The string \"\(possibleNumber)\" has an integer value of \(actualNumber)")
+    print("The string \"\(possibleNumber)\" has an integer value of \(actualNumber)")
 } else {
-   print("The string \"\(possibleNumber)\" couldn't be converted to an integer")
+    print("The string \"\(possibleNumber)\" couldn't be converted to an integer")
 }
 // Prints "The string "123" has an integer value of 123"
 ```
@@ -1541,14 +1541,14 @@ The following `if` statements are equivalent:
 
 ```swift
 if let firstNumber = Int("4"), let secondNumber = Int("42"), firstNumber < secondNumber && secondNumber < 100 {
-   print("\(firstNumber) < \(secondNumber) < 100")
+    print("\(firstNumber) < \(secondNumber) < 100")
 }
 // Prints "4 < 42 < 100"
 
 if let firstNumber = Int("4") {
     if let secondNumber = Int("42") {
         if firstNumber < secondNumber && secondNumber < 100 {
-            print("\(firstNumber) < \(secondNumber) < 100")
+                print("\(firstNumber) < \(secondNumber) < 100")
         }
     }
 }
@@ -1685,7 +1685,7 @@ the same way you check a normal optional:
 
 ```swift
 if assumedString != nil {
-   print(assumedString!)
+    print(assumedString!)
 }
 // Prints "An implicitly unwrapped optional string."
 ```
@@ -1707,7 +1707,7 @@ to check and unwrap its value in a single statement:
 
 ```swift
 if let definiteString = assumedString {
-   print(definiteString)
+    print(definiteString)
 }
 // Prints "An implicitly unwrapped optional string."
 ```
@@ -1745,7 +1745,7 @@ That function's caller can then *catch* the error and respond appropriately.
 
 ```swift
 func canThrowAnError() throws {
-   // this function may or may not throw an error
+    // this function may or may not throw an error
 }
 ```
 
@@ -1777,10 +1777,10 @@ until they're handled by a `catch` clause.
 
 ```swift
 do {
-   try canThrowAnError()
-   // no error was thrown
+    try canThrowAnError()
+    // no error was thrown
 } catch {
-   // an error was thrown
+    // an error was thrown
 }
 ```
 

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/TheBasics.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/TheBasics.md
@@ -1548,7 +1548,7 @@ if let firstNumber = Int("4"), let secondNumber = Int("42"), firstNumber < secon
 if let firstNumber = Int("4") {
     if let secondNumber = Int("42") {
         if firstNumber < secondNumber && secondNumber < 100 {
-                print("\(firstNumber) < \(secondNumber) < 100")
+            print("\(firstNumber) < \(secondNumber) < 100")
         }
     }
 }

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/TypeCasting.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/TypeCasting.md
@@ -386,26 +386,26 @@ a constant of the specified type to enable its value to be printed:
 ```swift
 for thing in things {
     switch thing {
-        case 0 as Int:
-            print("zero as an Int")
-        case 0 as Double:
-            print("zero as a Double")
-        case let someInt as Int:
-            print("an integer value of \(someInt)")
-        case let someDouble as Double where someDouble > 0:
-            print("a positive double value of \(someDouble)")
-        case is Double:
-            print("some other double value that I don't want to print")
-        case let someString as String:
-            print("a string value of \"\(someString)\"")
-        case let (x, y) as (Double, Double):
-            print("an (x, y) point at \(x), \(y)")
-        case let movie as Movie:
-            print("a movie called \(movie.name), dir. \(movie.director)")
-        case let stringConverter as (String) -> String:
-            print(stringConverter("Michael"))
-        default:
-            print("something else")
+    case 0 as Int:
+        print("zero as an Int")
+    case 0 as Double:
+        print("zero as a Double")
+    case let someInt as Int:
+        print("an integer value of \(someInt)")
+    case let someDouble as Double where someDouble > 0:
+        print("a positive double value of \(someDouble)")
+    case is Double:
+        print("some other double value that I don't want to print")
+    case let someString as String:
+        print("a string value of \"\(someString)\"")
+    case let (x, y) as (Double, Double):
+        print("an (x, y) point at \(x), \(y)")
+    case let movie as Movie:
+        print("a movie called \(movie.name), dir. \(movie.director)")
+    case let stringConverter as (String) -> String:
+        print(stringConverter("Michael"))
+    default:
+        print("something else")
     }
 }
 

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/TypeCasting.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/TypeCasting.md
@@ -31,10 +31,10 @@ and an `init name` initializer.
 
 ```swift
 class MediaItem {
-   var name: String
-   init(name: String) {
-      self.name = name
-   }
+    var name: String
+    init(name: String) {
+        self.name = name
+    }
 }
 ```
 
@@ -61,19 +61,19 @@ on top of the base class:
 
 ```swift
 class Movie: MediaItem {
-   var director: String
-   init(name: String, director: String) {
-      self.director = director
-      super.init(name: name)
-   }
+    var director: String
+    init(name: String, director: String) {
+        self.director = director
+        super.init(name: name)
+    }
 }
 
 class Song: MediaItem {
-   var artist: String
-   init(name: String, artist: String) {
-      self.artist = artist
-      super.init(name: name)
-   }
+    var artist: String
+    init(name: String, artist: String) {
+        self.artist = artist
+        super.init(name: name)
+    }
 }
 ```
 
@@ -110,11 +110,11 @@ and so it infers a type of `[MediaItem]` for the `library` array:
 
 ```swift
 let library = [
-   Movie(name: "Casablanca", director: "Michael Curtiz"),
-   Song(name: "Blue Suede Shoes", artist: "Elvis Presley"),
-   Movie(name: "Citizen Kane", director: "Orson Welles"),
-   Song(name: "The One And Only", artist: "Chesney Hawkes"),
-   Song(name: "Never Gonna Give You Up", artist: "Rick Astley")
+    Movie(name: "Casablanca", director: "Michael Curtiz"),
+    Song(name: "Blue Suede Shoes", artist: "Elvis Presley"),
+    Movie(name: "Citizen Kane", director: "Orson Welles"),
+    Song(name: "The One And Only", artist: "Chesney Hawkes"),
+    Song(name: "Never Gonna Give You Up", artist: "Rick Astley")
 ]
 // the type of "library" is inferred to be [MediaItem]
 ```
@@ -161,11 +161,11 @@ var movieCount = 0
 var songCount = 0
 
 for item in library {
-   if item is Movie {
-      movieCount += 1
-   } else if item is Song {
-      songCount += 1
-   }
+    if item is Movie {
+        movieCount += 1
+    } else if item is Song {
+        songCount += 1
+    }
 }
 
 print("Media library contains \(movieCount) movies and \(songCount) songs")
@@ -244,11 +244,11 @@ to check the downcast each time through the loop:
 
 ```swift
 for item in library {
-   if let movie = item as? Movie {
-      print("Movie: \(movie.name), dir. \(movie.director)")
-   } else if let song = item as? Song {
-      print("Song: \(song.name), by \(song.artist)")
-   }
+    if let movie = item as? Movie {
+        print("Movie: \(movie.name), dir. \(movie.director)")
+    } else if let song = item as? Song {
+        print("Song: \(song.name), by \(song.artist)")
+    }
 }
 
 // Movie: Casablanca, dir. Michael Curtiz
@@ -385,28 +385,28 @@ a constant of the specified type to enable its value to be printed:
 
 ```swift
 for thing in things {
-   switch thing {
-      case 0 as Int:
-         print("zero as an Int")
-      case 0 as Double:
-         print("zero as a Double")
-      case let someInt as Int:
-         print("an integer value of \(someInt)")
-      case let someDouble as Double where someDouble > 0:
-         print("a positive double value of \(someDouble)")
-      case is Double:
-         print("some other double value that I don't want to print")
-      case let someString as String:
-         print("a string value of \"\(someString)\"")
-      case let (x, y) as (Double, Double):
-         print("an (x, y) point at \(x), \(y)")
-      case let movie as Movie:
-         print("a movie called \(movie.name), dir. \(movie.director)")
-      case let stringConverter as (String) -> String:
-         print(stringConverter("Michael"))
-      default:
-         print("something else")
-   }
+    switch thing {
+        case 0 as Int:
+            print("zero as an Int")
+        case 0 as Double:
+            print("zero as a Double")
+        case let someInt as Int:
+            print("an integer value of \(someInt)")
+        case let someDouble as Double where someDouble > 0:
+            print("a positive double value of \(someDouble)")
+        case is Double:
+            print("some other double value that I don't want to print")
+        case let someString as String:
+            print("a string value of \"\(someString)\"")
+        case let (x, y) as (Double, Double):
+            print("an (x, y) point at \(x), \(y)")
+        case let movie as Movie:
+            print("a movie called \(movie.name), dir. \(movie.director)")
+        case let stringConverter as (String) -> String:
+            print(stringConverter("Michael"))
+        default:
+            print("something else")
+    }
 }
 
 // zero as an Int

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Attributes.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Attributes.md
@@ -132,7 +132,7 @@ including important milestones.
   ```swift
   // First release
   protocol MyProtocol {
-      // protocol definition
+        // protocol definition
   }
   ```
   
@@ -151,7 +151,7 @@ including important milestones.
   ```swift
   // Subsequent release renames MyProtocol
   protocol MyRenamedProtocol {
-      // protocol definition
+        // protocol definition
   }
   
   @available(*, unavailable, renamed: "MyRenamedProtocol")
@@ -278,9 +278,9 @@ as if it's a function that takes any number of arguments.
 struct TelephoneExchange {
     func dynamicallyCall(withArguments phoneNumber: [Int]) {
         if phoneNumber == [4, 1, 1] {
-            print("Get Swift help on forums.swift.org")
+                print("Get Swift help on forums.swift.org")
         } else {
-            print("Unrecognized number")
+                print("Unrecognized number")
         }
     }
 }
@@ -343,10 +343,10 @@ if you implement the `dynamicallyCall(withKeywordArguments:)` method.
 struct Repeater {
     func dynamicallyCall(withKeywordArguments pairs: KeyValuePairs<String, Int>) -> String {
         return pairs
-            .map { label, count in
+                .map { label, count in
                 repeatElement(label, count: count).joined(separator: " ")
-            }
-            .joined(separator: "\n")
+                }
+                .joined(separator: "\n")
     }
 }
 
@@ -1041,11 +1041,11 @@ rather than just as the name of the property itself.
 
 ```swift
 class ExampleClass: NSObject {
-   @objc var enabled: Bool {
-      @objc(isEnabled) get {
-         // Return the appropriate value
-      }
-   }
+    @objc var enabled: Bool {
+        @objc(isEnabled) get {
+            // Return the appropriate value
+        }
+    }
 }
 ```
 
@@ -1525,37 +1525,37 @@ into code that calls the static methods of the result builder type:
   
   ```swift
   protocol Drawable {
-      func draw() -> String
+        func draw() -> String
   }
   struct Text: Drawable {
-      var content: String
-      init(_ content: String) { self.content = content }
-      func draw() -> String { return content }
+        var content: String
+        init(_ content: String) { self.content = content }
+        func draw() -> String { return content }
   }
   struct Line<D: Drawable>: Drawable {
-      var elements: [D]
-      func draw() -> String {
+        var elements: [D]
+        func draw() -> String {
           return elements.map { $0.draw() }.joined(separator: "")
-      }
+        }
   }
   struct DrawEither<First: Drawable, Second: Drawable>: Drawable {
-      var content: Drawable
-      func draw() -> String { return content.draw() }
+        var content: Drawable
+        func draw() -> String { return content.draw() }
   }
   
   @resultBuilder
   struct DrawingBuilder {
-      static func buildBlock<D: Drawable>(_ components: D...) -> Line<D> {
+        static func buildBlock<D: Drawable>(_ components: D...) -> Line<D> {
           return Line(elements: components)
-      }
-      static func buildEither<First, Second>(first: First)
+        }
+        static func buildEither<First, Second>(first: First)
               -> DrawEither<First, Second> {
           return DrawEither(content: first)
-      }
-      static func buildEither<First, Second>(second: Second)
+        }
+        static func buildEither<First, Second>(second: Second)
               -> DrawEither<First, Second> {
           return DrawEither(content: second)
-      }
+        }
   }
   ```
   
@@ -1566,16 +1566,16 @@ into code that calls the static methods of the result builder type:
   ```swift
   @available(macOS 99, *)
   struct FutureText: Drawable {
-      var content: String
-      init(_ content: String) { self.content = content }
-      func draw() -> String { return content }
+        var content: String
+        init(_ content: String) { self.content = content }
+        func draw() -> String { return content }
   }
   @DrawingBuilder var brokenDrawing: Drawable {
-      if #available(macOS 99, *) {
+        if #available(macOS 99, *) {
           FutureText("Inside.future")  // Problem
-      } else {
+        } else {
           Text("Inside.present")
-      }
+        }
   }
   // The type of brokenDrawing is Line<DrawEither<Line<FutureText>, Line<Text>>>
   ```
@@ -1595,21 +1595,21 @@ into code that calls the static methods of the result builder type:
   
   ```swift
   struct AnyDrawable: Drawable {
-      var content: Drawable
-      func draw() -> String { return content.draw() }
+        var content: Drawable
+        func draw() -> String { return content.draw() }
   }
   extension DrawingBuilder {
-      static func buildLimitedAvailability(_ content: Drawable) -> AnyDrawable {
+        static func buildLimitedAvailability(_ content: Drawable) -> AnyDrawable {
           return AnyDrawable(content: content)
-      }
+        }
   }
   
   @DrawingBuilder var typeErasedDrawing: Drawable {
-      if #available(macOS 99, *) {
+        if #available(macOS 99, *) {
           FutureText("Inside.future")
-      } else {
+        } else {
           Text("Inside.present")
-      }
+        }
   }
   // The type of typeErasedDrawing is Line<DrawEither<AnyDrawable, Line<Text>>>
   ```
@@ -1634,27 +1634,27 @@ into code that calls the static methods of the result builder type:
   ```swift
   let someNumber = 19
   @ArrayBuilder var builderConditional: [Int] {
-      if someNumber < 12 {
+        if someNumber < 12 {
           31
-      } else if someNumber == 19 {
+        } else if someNumber == 19 {
           32
-      } else {
+        } else {
           33
-      }
+        }
   }
   
   var manualConditional: [Int]
   if someNumber < 12 {
-      let partialResult = ArrayBuilder.buildExpression(31)
-      let outerPartialResult = ArrayBuilder.buildEither(first: partialResult)
-      manualConditional = ArrayBuilder.buildEither(first: outerPartialResult)
+        let partialResult = ArrayBuilder.buildExpression(31)
+        let outerPartialResult = ArrayBuilder.buildEither(first: partialResult)
+        manualConditional = ArrayBuilder.buildEither(first: outerPartialResult)
   } else if someNumber == 19 {
-      let partialResult = ArrayBuilder.buildExpression(32)
-      let outerPartialResult = ArrayBuilder.buildEither(second: partialResult)
-      manualConditional = ArrayBuilder.buildEither(first: outerPartialResult)
+        let partialResult = ArrayBuilder.buildExpression(32)
+        let outerPartialResult = ArrayBuilder.buildEither(second: partialResult)
+        manualConditional = ArrayBuilder.buildEither(first: outerPartialResult)
   } else {
-      let partialResult = ArrayBuilder.buildExpression(33)
-      manualConditional = ArrayBuilder.buildEither(second: partialResult)
+        let partialResult = ArrayBuilder.buildExpression(33)
+        manualConditional = ArrayBuilder.buildEither(second: partialResult)
   }
   ```
   
@@ -1704,12 +1704,12 @@ into code that calls the static methods of the result builder type:
   
   ```swift
   @ArrayBuilder var builderOptional: [Int] {
-      if (someNumber % 2) == 1 { 20 }
+        if (someNumber % 2) == 1 { 20 }
   }
   
   var partialResult: [Int]? = nil
   if (someNumber % 2) == 1 {
-      partialResult = ArrayBuilder.buildExpression(20)
+        partialResult = ArrayBuilder.buildExpression(20)
   }
   var manualOptional = ArrayBuilder.buildOptional(partialResult)
   ```
@@ -1742,15 +1742,15 @@ into code that calls the static methods of the result builder type:
   
   ```swift
   @ArrayBuilder var builderBlock: [Int] {
-      100
-      200
-      300
+        100
+        200
+        300
   }
   
   var manualBlock = ArrayBuilder.buildBlock(
-      ArrayBuilder.buildExpression(100),
-      ArrayBuilder.buildExpression(200),
-      ArrayBuilder.buildExpression(300)
+        ArrayBuilder.buildExpression(100),
+        ArrayBuilder.buildExpression(200),
+        ArrayBuilder.buildExpression(300)
   )
   ```
   
@@ -1782,15 +1782,15 @@ into code that calls the static methods of the result builder type:
   
   ```swift
   @ArrayBuilder var builderArray: [Int] {
-      for i in 5...7 {
+        for i in 5...7 {
           100 + i
-      }
+        }
   }
   
   var temporary: [[Int]] = []
   for i in 5...7 {
-      let partialResult = ArrayBuilder.buildExpression(100 + i)
-      temporary.append(partialResult)
+        let partialResult = ArrayBuilder.buildExpression(100 + i)
+        temporary.append(partialResult)
   }
   let manualArray = ArrayBuilder.buildArray(temporary)
   ```

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Attributes.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Attributes.md
@@ -132,7 +132,7 @@ including important milestones.
   ```swift
   // First release
   protocol MyProtocol {
-        // protocol definition
+      // protocol definition
   }
   ```
   
@@ -151,7 +151,7 @@ including important milestones.
   ```swift
   // Subsequent release renames MyProtocol
   protocol MyRenamedProtocol {
-        // protocol definition
+      // protocol definition
   }
   
   @available(*, unavailable, renamed: "MyRenamedProtocol")
@@ -278,9 +278,9 @@ as if it's a function that takes any number of arguments.
 struct TelephoneExchange {
     func dynamicallyCall(withArguments phoneNumber: [Int]) {
         if phoneNumber == [4, 1, 1] {
-                print("Get Swift help on forums.swift.org")
+            print("Get Swift help on forums.swift.org")
         } else {
-                print("Unrecognized number")
+            print("Unrecognized number")
         }
     }
 }
@@ -343,10 +343,10 @@ if you implement the `dynamicallyCall(withKeywordArguments:)` method.
 struct Repeater {
     func dynamicallyCall(withKeywordArguments pairs: KeyValuePairs<String, Int>) -> String {
         return pairs
-                .map { label, count in
+            .map { label, count in
                 repeatElement(label, count: count).joined(separator: " ")
-                }
-                .joined(separator: "\n")
+            }
+            .joined(separator: "\n")
     }
 }
 
@@ -1525,37 +1525,37 @@ into code that calls the static methods of the result builder type:
   
   ```swift
   protocol Drawable {
-        func draw() -> String
+      func draw() -> String
   }
   struct Text: Drawable {
-        var content: String
-        init(_ content: String) { self.content = content }
-        func draw() -> String { return content }
+      var content: String
+      init(_ content: String) { self.content = content }
+      func draw() -> String { return content }
   }
   struct Line<D: Drawable>: Drawable {
         var elements: [D]
         func draw() -> String {
           return elements.map { $0.draw() }.joined(separator: "")
-        }
+      }
   }
   struct DrawEither<First: Drawable, Second: Drawable>: Drawable {
-        var content: Drawable
-        func draw() -> String { return content.draw() }
+      var content: Drawable
+      func draw() -> String { return content.draw() }
   }
   
   @resultBuilder
   struct DrawingBuilder {
-        static func buildBlock<D: Drawable>(_ components: D...) -> Line<D> {
+      static func buildBlock<D: Drawable>(_ components: D...) -> Line<D> {
           return Line(elements: components)
-        }
-        static func buildEither<First, Second>(first: First)
+      }
+      static func buildEither<First, Second>(first: First)
               -> DrawEither<First, Second> {
           return DrawEither(content: first)
-        }
-        static func buildEither<First, Second>(second: Second)
+      }
+      static func buildEither<First, Second>(second: Second)
               -> DrawEither<First, Second> {
           return DrawEither(content: second)
-        }
+      }
   }
   ```
   
@@ -1566,16 +1566,16 @@ into code that calls the static methods of the result builder type:
   ```swift
   @available(macOS 99, *)
   struct FutureText: Drawable {
-        var content: String
-        init(_ content: String) { self.content = content }
-        func draw() -> String { return content }
+      var content: String
+      init(_ content: String) { self.content = content }
+      func draw() -> String { return content }
   }
   @DrawingBuilder var brokenDrawing: Drawable {
-        if #available(macOS 99, *) {
+      if #available(macOS 99, *) {
           FutureText("Inside.future")  // Problem
-        } else {
+      } else {
           Text("Inside.present")
-        }
+      }
   }
   // The type of brokenDrawing is Line<DrawEither<Line<FutureText>, Line<Text>>>
   ```
@@ -1595,21 +1595,21 @@ into code that calls the static methods of the result builder type:
   
   ```swift
   struct AnyDrawable: Drawable {
-        var content: Drawable
-        func draw() -> String { return content.draw() }
+      var content: Drawable
+      func draw() -> String { return content.draw() }
   }
   extension DrawingBuilder {
-        static func buildLimitedAvailability(_ content: Drawable) -> AnyDrawable {
+      static func buildLimitedAvailability(_ content: Drawable) -> AnyDrawable {
           return AnyDrawable(content: content)
-        }
+      }
   }
   
   @DrawingBuilder var typeErasedDrawing: Drawable {
-        if #available(macOS 99, *) {
+      if #available(macOS 99, *) {
           FutureText("Inside.future")
-        } else {
+      } else {
           Text("Inside.present")
-        }
+      }
   }
   // The type of typeErasedDrawing is Line<DrawEither<AnyDrawable, Line<Text>>>
   ```
@@ -1634,27 +1634,27 @@ into code that calls the static methods of the result builder type:
   ```swift
   let someNumber = 19
   @ArrayBuilder var builderConditional: [Int] {
-        if someNumber < 12 {
+      if someNumber < 12 {
           31
-        } else if someNumber == 19 {
+      } else if someNumber == 19 {
           32
-        } else {
+      } else {
           33
-        }
+      }
   }
   
   var manualConditional: [Int]
   if someNumber < 12 {
-        let partialResult = ArrayBuilder.buildExpression(31)
-        let outerPartialResult = ArrayBuilder.buildEither(first: partialResult)
-        manualConditional = ArrayBuilder.buildEither(first: outerPartialResult)
+      let partialResult = ArrayBuilder.buildExpression(31)
+      let outerPartialResult = ArrayBuilder.buildEither(first: partialResult)
+      manualConditional = ArrayBuilder.buildEither(first: outerPartialResult)
   } else if someNumber == 19 {
-        let partialResult = ArrayBuilder.buildExpression(32)
-        let outerPartialResult = ArrayBuilder.buildEither(second: partialResult)
-        manualConditional = ArrayBuilder.buildEither(first: outerPartialResult)
+      let partialResult = ArrayBuilder.buildExpression(32)
+      let outerPartialResult = ArrayBuilder.buildEither(second: partialResult)
+      manualConditional = ArrayBuilder.buildEither(first: outerPartialResult)
   } else {
-        let partialResult = ArrayBuilder.buildExpression(33)
-        manualConditional = ArrayBuilder.buildEither(second: partialResult)
+      let partialResult = ArrayBuilder.buildExpression(33)
+      manualConditional = ArrayBuilder.buildEither(second: partialResult)
   }
   ```
   
@@ -1704,12 +1704,12 @@ into code that calls the static methods of the result builder type:
   
   ```swift
   @ArrayBuilder var builderOptional: [Int] {
-        if (someNumber % 2) == 1 { 20 }
+      if (someNumber % 2) == 1 { 20 }
   }
   
   var partialResult: [Int]? = nil
   if (someNumber % 2) == 1 {
-        partialResult = ArrayBuilder.buildExpression(20)
+      partialResult = ArrayBuilder.buildExpression(20)
   }
   var manualOptional = ArrayBuilder.buildOptional(partialResult)
   ```
@@ -1742,15 +1742,15 @@ into code that calls the static methods of the result builder type:
   
   ```swift
   @ArrayBuilder var builderBlock: [Int] {
-        100
-        200
-        300
+      100
+      200
+      300
   }
   
   var manualBlock = ArrayBuilder.buildBlock(
-        ArrayBuilder.buildExpression(100),
-        ArrayBuilder.buildExpression(200),
-        ArrayBuilder.buildExpression(300)
+      ArrayBuilder.buildExpression(100),
+      ArrayBuilder.buildExpression(200),
+      ArrayBuilder.buildExpression(300)
   )
   ```
   
@@ -1782,15 +1782,15 @@ into code that calls the static methods of the result builder type:
   
   ```swift
   @ArrayBuilder var builderArray: [Int] {
-        for i in 5...7 {
+      for i in 5...7 {
           100 + i
-        }
+      }
   }
   
   var temporary: [[Int]] = []
   for i in 5...7 {
-        let partialResult = ArrayBuilder.buildExpression(100 + i)
-        temporary.append(partialResult)
+      let partialResult = ArrayBuilder.buildExpression(100 + i)
+      temporary.append(partialResult)
   }
   let manualArray = ArrayBuilder.buildArray(temporary)
   ```

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Declarations.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Declarations.md
@@ -957,13 +957,13 @@ all mutation has finished before the function returns.
 
 ```swift
 func multithreadedFunction(queue: DispatchQueue, x: inout Int) {
-   // Make a local copy and manually copy it back.
-   var localX = x
-   defer { x = localX }
+    // Make a local copy and manually copy it back.
+    var localX = x
+    defer { x = localX }
 
-   // Operate on localX asynchronously, then wait before returning.
-   queue.async { someMutatingOperation(&localX) }
-   queue.sync {}
+    // Operate on localX asynchronously, then wait before returning.
+    queue.async { someMutatingOperation(&localX) }
+    queue.sync {}
 }
 ```
 
@@ -1349,12 +1349,12 @@ func alwaysThrows() throws {
     throw SomeError.error
 }
 func someFunction(callback: () throws -> Void) rethrows {
-   do {
-      try callback()
-      try alwaysThrows()  // Invalid, alwaysThrows() isn't a throwing parameter
-   } catch {
-      throw AnotherError.error
-   }
+    do {
+        try callback()
+        try alwaysThrows()  // Invalid, alwaysThrows() isn't a throwing parameter
+    } catch {
+        throw AnotherError.error
+    }
 }
 ```
 
@@ -1572,8 +1572,8 @@ you can get a reference to an enumeration case and apply it later in your code.
 
 ```swift
 enum Number {
-   case integer(Int)
-   case real(Double)
+    case integer(Int)
+    case real(Double)
 }
 let f = Number.integer
 // f is a function of type (Int) -> Number
@@ -1632,8 +1632,8 @@ An indirect case must have an associated value.
 
 ```swift
 enum Tree<T> {
-   case empty
-   indirect case node(value: T, left: Tree, right: Tree)
+    case empty
+    indirect case node(value: T, left: Tree, right: Tree)
 }
 ```
 
@@ -1734,7 +1734,7 @@ that's automatically incremented from the raw value of the previous case.
 
 ```swift
 enum ExampleEnum: Int {
-   case a, b, c = 5, d
+    case a, b, c = 5, d
 }
 ```
 
@@ -1760,7 +1760,7 @@ each unassigned case is implicitly assigned a string with the same text as the n
 
 ```swift
 enum GamePlayMode: String {
-   case cooperative, individual, competitive
+    case cooperative, individual, competitive
 }
 ```
 
@@ -2709,8 +2709,8 @@ struct SomeStruct {
     // produces an optional instance of 'SomeStruct'
     init?(input: String) {
         if input.isEmpty {
-            // discard 'self' and return 'nil'
-            return nil
+                // discard 'self' and return 'nil'
+                return nil
         }
         property = input
     }
@@ -2952,9 +2952,9 @@ extension Pair: TitledLoggable where T: TitledLoggable {
 }
 
 extension String: TitledLoggable {
-   static var logTitle: String {
-      return "String"
-   }
+    static var logTitle: String {
+        return "String"
+    }
 }
 ```
 
@@ -3040,7 +3040,7 @@ the default implementation provided by the `Loggable` protocol is used instead.
 
 ```swift
 func doSomething<T: Loggable>(with x: T) {
-   x.log()
+    x.log()
 }
 doSomething(with: oneAndTwo)
 // Prints "(one, two)"
@@ -3088,7 +3088,7 @@ and one for arrays with `String` elements.
 
 ```swift
 protocol Serializable {
-   func serialize() -> Any
+    func serialize() -> Any
 }
 
 extension Array: Serializable where Element == Int {
@@ -3189,21 +3189,21 @@ to both `TitledLoggable` and the new `MarkedLoggable` protocol.
 
 ```swift
 protocol MarkedLoggable: Loggable {
-   func markAndLog()
+    func markAndLog()
 }
 
 extension MarkedLoggable {
-   func markAndLog() {
-      print("----------")
-      log()
-   }
+    func markAndLog() {
+        print("----------")
+        log()
+    }
 }
 
 extension Array: Loggable where Element: Loggable { }
 extension Array: TitledLoggable where Element: TitledLoggable {
-   static var logTitle: String {
-      return "Array of '\(Element.logTitle)'"
-   }
+    static var logTitle: String {
+        return "Array of '\(Element.logTitle)'"
+    }
 }
 extension Array: MarkedLoggable where Element: MarkedLoggable { }
 ```

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Declarations.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Declarations.md
@@ -2709,8 +2709,8 @@ struct SomeStruct {
     // produces an optional instance of 'SomeStruct'
     init?(input: String) {
         if input.isEmpty {
-                // discard 'self' and return 'nil'
-                return nil
+            // discard 'self' and return 'nil'
+            return nil
         }
         property = input
     }

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Expressions.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Expressions.md
@@ -686,7 +686,7 @@ func logFunctionName(string: String = #function) {
     print(string)
 }
 func myFunction() {
-   logFunctionName() // Prints "myFunction()".
+    logFunctionName() // Prints "myFunction()".
 }
 ```
 
@@ -870,10 +870,10 @@ For example:
 
 ```swift
 struct Point {
-   var x = 0.0, y = 0.0
-   mutating func moveBy(x deltaX: Double, y deltaY: Double) {
-      self = Point(x: x + deltaX, y: y + deltaY)
-   }
+    var x = 0.0, y = 0.0
+    mutating func moveBy(x deltaX: Double, y deltaY: Double) {
+        self = Point(x: x + deltaX, y: y + deltaY)
+    }
 }
 ```
 
@@ -2177,10 +2177,10 @@ For example:
 
 ```swift
 class SomeClass: NSObject {
-   @objc var someProperty: Int
-   init(someProperty: Int) {
+    @objc var someProperty: Int
+    init(someProperty: Int) {
        self.someProperty = someProperty
-   }
+    }
 }
 
 let c = SomeClass(someProperty: 12)
@@ -2221,9 +2221,9 @@ by writing just the property name, without the class name.
 
 ```swift
 extension SomeClass {
-   func getSomeKeyPath() -> String {
-      return #keyPath(someProperty)
-   }
+    func getSomeKeyPath() -> String {
+        return #keyPath(someProperty)
+    }
 }
 print(keyPath == c.getSomeKeyPath())
 // Prints "true"
@@ -3269,7 +3269,7 @@ without using optional chaining.
 ```swift
 var result: Bool?
 if let unwrappedC = c {
-   result = unwrappedC.property.performAction()
+    result = unwrappedC.property.performAction()
 }
 ```
 
@@ -3298,7 +3298,7 @@ For example:
 
 ```swift
 func someFunctionWithSideEffects() -> Int {
-   return 42  // No actual side effects.
+    return 42  // No actual side effects.
 }
 var someDictionary = ["a": [1, 2, 3], "b": [10, 20]]
 

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/GenericParametersAndArguments.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/GenericParametersAndArguments.md
@@ -52,10 +52,10 @@ for the type parameter `T` must conform to the `Comparable` protocol.
 
 ```swift
 func simpleMax<T: Comparable>(_ x: T, _ y: T) -> T {
-   if x < y {
-      return y
-   }
-   return x
+    if x < y {
+        return y
+    }
+    return x
 }
 ```
 

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Patterns.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Patterns.md
@@ -125,9 +125,9 @@ corresponding identifier pattern.
 ```swift
 let point = (3, 2)
 switch point {
-    // Bind x and y to the elements of point.
-    case let (x, y):
-        print("The point is at (\(x), \(y)).")
+// Bind x and y to the elements of point.
+case let (x, y):
+    print("The point is at (\(x), \(y)).")
 }
 // Prints "The point is at (3, 2)."
 ```
@@ -455,12 +455,12 @@ as the following example shows.
 ```swift
 let point = (1, 2)
 switch point {
-    case (0, 0):
-        print("(0, 0) is at the origin.")
-    case (-2...2, -2...2):
-        print("(\(point.0), \(point.1)) is near the origin.")
-    default:
-        print("The point is at (\(point.0), \(point.1)).")
+case (0, 0):
+    print("(0, 0) is at the origin.")
+case (-2...2, -2...2):
+    print("(\(point.0), \(point.1)) is near the origin.")
+default:
+    print("The point is at (\(point.0), \(point.1)).")
 }
 // Prints "(1, 2) is near the origin."
 ```
@@ -493,10 +493,10 @@ func ~= (pattern: String, value: Int) -> Bool {
     return pattern == "\(value)"
 }
 switch point {
-    case ("0", "0"):
-        print("(0, 0) is at the origin.")
-    default:
-        print("The point is at (\(point.0), \(point.1)).")
+case ("0", "0"):
+    print("(0, 0) is at the origin.")
+default:
+    print("The point is at (\(point.0), \(point.1)).")
 }
 // Prints "The point is at (1, 2)."
 ```

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Patterns.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Patterns.md
@@ -54,7 +54,7 @@ ignoring the current value of the range on each iteration of the loop:
 
 ```swift
 for _ in 1...3 {
-   // Do something three times.
+    // Do something three times.
 }
 ```
 
@@ -125,9 +125,9 @@ corresponding identifier pattern.
 ```swift
 let point = (3, 2)
 switch point {
-   // Bind x and y to the elements of point.
-   case let (x, y):
-      print("The point is at (\(x), \(y)).")
+    // Bind x and y to the elements of point.
+    case let (x, y):
+        print("The point is at (\(x), \(y)).")
 }
 // Prints "The point is at (3, 2)."
 ```
@@ -188,7 +188,7 @@ an expression pattern:
 let points = [(0, 0), (1, 0), (1, 1), (2, 0), (2, 1)]
 // This code isn't valid.
 for (x, 0) in points {
-   /* ... */
+    /* ... */
 }
 ```
 
@@ -333,12 +333,12 @@ the following are equivalent:
 let someOptional: Int? = 42
 // Match using an enumeration case pattern.
 if case .some(let x) = someOptional {
-   print(x)
+    print(x)
 }
 
 // Match using an optional pattern.
 if case let x? = someOptional {
-   print(x)
+    print(x)
 }
 ```
 
@@ -370,7 +370,7 @@ executing the body of the loop only for non-`nil` elements.
 let arrayOfOptionalInts: [Int?] = [nil, 2, 3, nil, 5]
 // Match only non-nil values.
 for case let number? in arrayOfOptionalInts {
-   print("Found a \(number)")
+    print("Found a \(number)")
 }
 // Found a 2
 // Found a 3
@@ -455,12 +455,12 @@ as the following example shows.
 ```swift
 let point = (1, 2)
 switch point {
-   case (0, 0):
-      print("(0, 0) is at the origin.")
-   case (-2...2, -2...2):
-      print("(\(point.0), \(point.1)) is near the origin.")
-   default:
-      print("The point is at (\(point.0), \(point.1)).")
+    case (0, 0):
+        print("(0, 0) is at the origin.")
+    case (-2...2, -2...2):
+        print("(\(point.0), \(point.1)) is near the origin.")
+    default:
+        print("The point is at (\(point.0), \(point.1)).")
 }
 // Prints "(1, 2) is near the origin."
 ```
@@ -490,13 +490,13 @@ with a string representations of points.
 ```swift
 // Overload the ~= operator to match a string with an integer.
 func ~= (pattern: String, value: Int) -> Bool {
-   return pattern == "\(value)"
+    return pattern == "\(value)"
 }
 switch point {
-   case ("0", "0"):
-      print("(0, 0) is at the origin.")
-   default:
-      print("The point is at (\(point.0), \(point.1)).")
+    case ("0", "0"):
+        print("(0, 0) is at the origin.")
+    default:
+        print("The point is at (\(point.0), \(point.1)).")
 }
 // Prints "The point is at (1, 2)."
 ```

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Statements.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Statements.md
@@ -317,15 +317,15 @@ A `switch` statement has the following form:
 
 ```
 switch <#control expression#> {
-   case <#pattern 1#>:
-      <#statements#>
-   case <#pattern 2#> where <#condition#>:
-      <#statements#>
-   case <#pattern 3#> where <#condition#>,
-        <#pattern 4#> where <#condition#>:
-      <#statements#>
-   default:
-      <#statements#>
+case <#pattern 1#>:
+    <#statements#>
+case <#pattern 2#> where <#condition#>:
+    <#statements#>
+case <#pattern 3#> where <#condition#>,
+    <#pattern 4#> where <#condition#>:
+    <#statements#>
+default:
+    <#statements#>
 }
 ```
 

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Types.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Types.md
@@ -999,13 +999,13 @@ or the entire class marked with the `final` keyword.
 
 ```swift
 class AnotherSubClass: SomeBaseClass {
-   let string: String
-   required init(string: String) {
-      self.string = string
-   }
-   override class func printClassName() {
-      print("AnotherSubClass")
-   }
+    let string: String
+    required init(string: String) {
+        self.string = string
+    }
+    override class func printClassName() {
+        print("AnotherSubClass")
+    }
 }
 let metatype: AnotherSubClass.Type = AnotherSubClass.self
 let anotherInstance = metatype.init(string: "some string")


### PR DESCRIPTION
Some parts of the book were written before Swift style was standardized for Swift 1.  A bunch of code listings use 3 space indentation instead of 4 space indentation.  There are also some `switch` statements whose cases are indented, following an older C-like style.  In Swift, a case doesn't start a scope, so we write it at the same level of indentation.

Under the legacy Sphinx-based publication pipeline, this wasn't an issue: The publication process used SourceKit to add syntax highlighting, which also reindented the code listings, so the published version matched Swift style.  Because DocC preserves indentation, we needed to normalize these in source.

Fixes https://github.com/apple/swift-book/issues/43

Fixes rdar://96988058