### PR TITLE
Convert the formal grammar for DocC compatibility

### DIFF
--- a/Sources/TSPL/TSPL.docc/ReferenceManual/AboutTheLanguageReference.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/AboutTheLanguageReference.md
@@ -34,7 +34,7 @@ As an example, the grammar of a getter-setter block is defined as follows:
 
 > Grammar of a getter-setter block:
 >
-> *getter-setter-block* → **`{`** *getter-clause* *setter-clause* _?_ **`}`** | **`{`** *setter-clause* *getter-clause* **`}`**
+> *getter-setter-block* → **`{`** *getter-clause* *setter-clause*_?_ **`}`** | **`{`** *setter-clause* *getter-clause* **`}`**
 
 This definition indicates that a getter-setter block can consist of a getter clause
 followed by an optional setter clause, enclosed in braces,
@@ -45,9 +45,9 @@ where the alternatives are spelled out explicitly:
 > Grammar of a getter-setter block:
 >
 >
-> *getter-setter-block* → **`{`** *getter-clause* *setter-clause?* **`}`**
+> *getter-setter-block* → **`{`** *getter-clause* *setter-clause*_?_ **`}`**
 >
-> *getter-setter-block* → **`{`** setter-clause getter-clause **`}`**
+> *getter-setter-block* → **`{`** *setter-clause* *getter-clause* **`}`**
 
 @Comment {
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/AboutTheLanguageReference.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/AboutTheLanguageReference.md
@@ -32,11 +32,15 @@ follows a few conventions:
 
 As an example, the grammar of a getter-setter block is defined as follows:
 
-```
-Grammar of a getter-setter block
-
-getter-setter-block --> ``{`` getter-clause setter-clause-OPT ``}`` | ``{`` setter-clause getter-clause ``}``
-```
+> Grammar of a getter-setter block:
+>
+> getter-setter-block → `{` getter-clause setter-clause? `}` | `{` setter-clause getter-clause `}`
+>
+> getter-setter-block → `{` getter-clause setter-clause-OPT `}` | `{` setter-clause getter-clause `}`
+>
+> getter-setter-block → `{` getter-clause setter-clause OPT `}` | `{` setter-clause getter-clause `}`
+>
+> getter-setter-block → `{` getter-clause setter-clause (opt) `}` | `{` setter-clause getter-clause `}`
 
 
 This definition indicates that a getter-setter block can consist of a getter clause
@@ -45,17 +49,47 @@ followed by an optional setter clause, enclosed in braces,
 The grammar production above is equivalent to the following two productions,
 where the alternatives are spelled out explicitly:
 
-```
-Grammar of a getter-setter block
+> Grammar of a getter-setter block:
+>
+>
+> getter-setter-block → `{` getter-clause setter-clause? `}`
+>
+> getter-setter-block → `{` getter-clause setter-clause-OPT `}`
+>
+> getter-setter-block → `{` getter-clause setter-clause OPT `}`
+>
+> getter-setter-block → `{` getter-clause setter-clause (opt) `}`
+>
+> getter-setter-block → `{` setter-clause getter-clause `}`
 
-getter-setter-block --> ``{`` getter-clause setter-clause-OPT ``}``
-getter-setter-block --> ``{`` setter-clause getter-clause ``}``
-```
+> Grammar of a literal:
+>
+> literal → numeric-literal | string-literal | regular-expression-literal | boolean-literal | nil-literal
+>
+>
+> numeric-literal → `-`? integer-literal | `-`? floating-point-literal
+>
+> numeric-literal → `-`OPT integer-literal | `-`OPT floating-point-literal
+>
+> numeric-literal → `-` OPT integer-literal | `-` OPT floating-point-literal
+>
+> numeric-literal → `-` (opt) integer-literal | `-` (opt) floating-point-literal
+>
+> boolean-literal → `true` | `false`
+>
+> nil-literal → `nil`
 
 
-*getter-setter-block* → `{` *getter-clause* *setter-clause?* `}`
-
-*getter-setter-block* → `{` *setter-clause* *getter-clause* `}`
+> Grammar of a literal:
+>
+> literal → numeric-literal | string-literal | regular-expression-literal | boolean-literal | nil-literal
+>
+>
+> numeric-literal → `-`opt integer-literal | `-`OPT floating-point-literal
+>
+> boolean-literal → `true` | `false`
+>
+> nil-literal → `nil`
 
 
 @Comment {

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/AboutTheLanguageReference.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/AboutTheLanguageReference.md
@@ -49,40 +49,6 @@ where the alternatives are spelled out explicitly:
 >
 > *getter-setter-block* → **`{`** setter-clause getter-clause **`}`**
 
-> Grammar of a literal:
->
-> *literal* → *numeric-literal* | *string-literal* | *regular-expression-literal* | *boolean-literal* | *nil-literal*
->
->
-> *numeric-literal* → **`-`**_?_ *integer-literal* | **`-`**_?_ *floating-point-literal*
->
-> *boolean-literal* → **`true`** | **`false`**
->
-> *nil-literal* → **`nil`**
-
-> Grammar of an identifier (partial):
->
-> *identifier-head* → Upper- or lowercase letter A through Z
->
-> *identifier-head* → **`_`**
->
-> *identifier-head* → U+00A8, U+00AA, U+00AD, U+00AF, U+00B2--U+00B5, or U+00B7--U+00BA
->
-> *identifier-head* → U+00BC--U+00BE, U+00C0--U+00D6, U+00D8--U+00F6, or U+00F8--U+00FF
-
-@Comment {
-`_`**  Fixes runaway syntax highlight from above
-}
-
-> Grammar of an optional type:
->
-> *optional-type* → *type* **`?`**
-
-> Grammar of a conditional operator:
->
-> *conditional-operator* → **`?`** *expression* **`:`**
-
-
 @Comment {
 This source file is part of the Swift.org open source project
 

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/AboutTheLanguageReference.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/AboutTheLanguageReference.md
@@ -20,7 +20,7 @@ follows a few conventions:
 - An arrow (→) is used to mark grammar productions and can be read as "can consist of."
 - Syntactic categories are indicated by *italic* text and appear on both sides
   of a grammar production rule.
-- Literal words and punctuation are indicated by boldface `constant width` text
+- Literal words and punctuation are indicated by **`boldface constant width`** text
   and appear only on the right-hand side of a grammar production rule.
 - Alternative grammar productions are separated by vertical
   bars (|). When alternative productions are too long to read easily,

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/AboutTheLanguageReference.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/AboutTheLanguageReference.md
@@ -28,20 +28,13 @@ follows a few conventions:
 - In a few cases, regular font text is used to describe the right-hand side
   of a grammar production rule.
 - Optional syntactic categories and literals are marked by a trailing
-  subscript, *opt*.
+  question mark, *?*.
 
 As an example, the grammar of a getter-setter block is defined as follows:
 
 > Grammar of a getter-setter block:
 >
-> getter-setter-block → `{` getter-clause setter-clause? `}` | `{` setter-clause getter-clause `}`
->
-> getter-setter-block → `{` getter-clause setter-clause-OPT `}` | `{` setter-clause getter-clause `}`
->
-> getter-setter-block → `{` getter-clause setter-clause OPT `}` | `{` setter-clause getter-clause `}`
->
-> getter-setter-block → `{` getter-clause setter-clause (opt) `}` | `{` setter-clause getter-clause `}`
-
+> *getter-setter-block* → **`{`** *getter-clause* *setter-clause* _?_ **`}`** | **`{`** *setter-clause* *getter-clause* **`}`**
 
 This definition indicates that a getter-setter block can consist of a getter clause
 followed by an optional setter clause, enclosed in braces,
@@ -52,44 +45,42 @@ where the alternatives are spelled out explicitly:
 > Grammar of a getter-setter block:
 >
 >
-> getter-setter-block → `{` getter-clause setter-clause? `}`
+> *getter-setter-block* → **`{`** *getter-clause* *setter-clause?* **`}`**
 >
-> getter-setter-block → `{` getter-clause setter-clause-OPT `}`
->
-> getter-setter-block → `{` getter-clause setter-clause OPT `}`
->
-> getter-setter-block → `{` getter-clause setter-clause (opt) `}`
->
-> getter-setter-block → `{` setter-clause getter-clause `}`
+> *getter-setter-block* → **`{`** setter-clause getter-clause **`}`**
 
 > Grammar of a literal:
 >
-> literal → numeric-literal | string-literal | regular-expression-literal | boolean-literal | nil-literal
+> *literal* → *numeric-literal* | *string-literal* | *regular-expression-literal* | *boolean-literal* | *nil-literal*
 >
 >
-> numeric-literal → `-`? integer-literal | `-`? floating-point-literal
+> *numeric-literal* → **`-`**_?_ *integer-literal* | **`-`**_?_ *floating-point-literal*
 >
-> numeric-literal → `-`OPT integer-literal | `-`OPT floating-point-literal
+> *boolean-literal* → **`true`** | **`false`**
 >
-> numeric-literal → `-` OPT integer-literal | `-` OPT floating-point-literal
->
-> numeric-literal → `-` (opt) integer-literal | `-` (opt) floating-point-literal
->
-> boolean-literal → `true` | `false`
->
-> nil-literal → `nil`
+> *nil-literal* → **`nil`**
 
+> Grammar of an identifier (partial):
+>
+> *identifier-head* → Upper- or lowercase letter A through Z
+>
+> *identifier-head* → **`_`**
+>
+> *identifier-head* → U+00A8, U+00AA, U+00AD, U+00AF, U+00B2--U+00B5, or U+00B7--U+00BA
+>
+> *identifier-head* → U+00BC--U+00BE, U+00C0--U+00D6, U+00D8--U+00F6, or U+00F8--U+00FF
 
-> Grammar of a literal:
+@Comment {
+`_`**  Fixes runaway syntax highlight from above
+}
+
+> Grammar of an optional type:
 >
-> literal → numeric-literal | string-literal | regular-expression-literal | boolean-literal | nil-literal
+> *optional-type* → *type* **`?`**
+
+> Grammar of a conditional operator:
 >
->
-> numeric-literal → `-`opt integer-literal | `-`OPT floating-point-literal
->
-> boolean-literal → `true` | `false`
->
-> nil-literal → `nil`
+> *conditional-operator* → **`?`** *expression* **`:`**
 
 
 @Comment {

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Attributes.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Attributes.md
@@ -2235,21 +2235,30 @@ at the time the code is compiled.
 For an example of how to use the `unknown` attribute,
 see <doc:Statements#Switching-Over-Future-Enumeration-Cases>.
 
-```
-Grammar of an attribute
+> Grammar of an attribute:
+>
+> *attribute* → **`@`** *attribute-name* *attribute-argument-clause*_?_
+>
+> *attribute-name* → *identifier*
+>
+> *attribute-argument-clause* → **`(`** *balanced-tokens*_?_ **`)`**
+>
+> *attributes* → *attribute* *attributes*_?_
+>
+>
+>
+> *balanced-tokens* → *balanced-token* *balanced-tokens*_?_
+>
+> *balanced-token* → **`(`** *balanced-tokens*_?_ **`)`**
+>
+> *balanced-token* → **`[`** *balanced-tokens*_?_ **`]`**
+>
+> *balanced-token* → **`{`** *balanced-tokens*_?_ **`}`**
+>
+> *balanced-token* → Any identifier, keyword, literal, or operator
+>
+> *balanced-token* → Any punctuation except  **`(`**,  **`)`**,  **`[`**,  **`]`**,  **`{`**, or  **`}`**
 
-attribute --> ``@`` attribute-name attribute-argument-clause-OPT
-attribute-name --> identifier
-attribute-argument-clause --> ``(`` balanced-tokens-OPT ``)``
-attributes --> attribute attributes-OPT
-
-balanced-tokens --> balanced-token balanced-tokens-OPT
-balanced-token --> ``(`` balanced-tokens-OPT ``)``
-balanced-token --> ``[`` balanced-tokens-OPT ``]``
-balanced-token --> ``{`` balanced-tokens-OPT ``}``
-balanced-token --> Any identifier, keyword, literal, or operator
-balanced-token --> Any punctuation except ``(``, ``)``, ``[``, ``]``, ``{``, or ``}``
-```
 
 
 

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Declarations.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Declarations.md
@@ -15,27 +15,41 @@ implement their members, most protocol members are declarations only. For conven
 and because the distinction isn't that important in Swift,
 the term *declaration* covers both declarations and definitions.
 
-```
-Grammar of a declaration
-
-declaration --> import-declaration
-declaration --> constant-declaration
-declaration --> variable-declaration
-declaration --> typealias-declaration
-declaration --> function-declaration
-declaration --> enum-declaration
-declaration --> struct-declaration
-declaration --> class-declaration
-declaration --> actor-declaration
-declaration --> protocol-declaration
-declaration --> initializer-declaration
-declaration --> deinitializer-declaration
-declaration --> extension-declaration
-declaration --> subscript-declaration
-declaration --> operator-declaration
-declaration --> precedence-group-declaration
-declarations --> declaration declarations-OPT
-```
+> Grammar of a declaration:
+>
+> *declaration* → *import-declaration*
+>
+> *declaration* → *constant-declaration*
+>
+> *declaration* → *variable-declaration*
+>
+> *declaration* → *typealias-declaration*
+>
+> *declaration* → *function-declaration*
+>
+> *declaration* → *enum-declaration*
+>
+> *declaration* → *struct-declaration*
+>
+> *declaration* → *class-declaration*
+>
+> *declaration* → *actor-declaration*
+>
+> *declaration* → *protocol-declaration*
+>
+> *declaration* → *initializer-declaration*
+>
+> *declaration* → *deinitializer-declaration*
+>
+> *declaration* → *extension-declaration*
+>
+> *declaration* → *subscript-declaration*
+>
+> *declaration* → *operator-declaration*
+>
+> *declaration* → *precedence-group-declaration*
+>
+> *declarations* → *declaration* *declarations*_?_
 
 
 ## Top-Level Code
@@ -67,11 +81,9 @@ the `UIApplicationMain` attribute,
 a `main.swift` file,
 or a file that contains top-level executable code.
 
-```
-Grammar of a top-level declaration
-
-top-level-declaration --> statements-OPT
-```
+> Grammar of a top-level declaration:
+>
+> *top-level-declaration* → *statements*_?_
 
 
 ## Code Blocks
@@ -99,11 +111,9 @@ of their appearance in source code.
   TODO: Discuss scope.  I assume a code block creates a new scope?
 }
 
-```
-Grammar of a code block
-
-code-block --> ``{`` statements-OPT ``}``
-```
+> Grammar of a code block:
+>
+> *code-block* → **`{`** *statements*_?_ **`}`**
 
 
 ## Import Declaration
@@ -136,14 +146,15 @@ import <#module#>.<#submodule#>
   TODO: Need to add more to this section.
 }
 
-```
-Grammar of an import declaration
-
-import-declaration --> attributes-OPT ``import`` import-kind-OPT import-path
-
-import-kind --> ``typealias`` | ``struct`` | ``class`` | ``enum`` | ``protocol`` | ``let`` | ``var`` | ``func``
-import-path --> identifier | identifier ``.`` import-path
-```
+> Grammar of an import declaration:
+>
+> *import-declaration* → *attributes*_?_ **`import`** *import-kind*_?_ *import-path*
+>
+>
+>
+> *import-kind* → **`typealias`** | **`struct`** | **`class`** | **`enum`** | **`protocol`** | **`let`** | **`var`** | **`func`**
+>
+> *import-path* → *identifier* | *identifier* **`.`** *import-path*
 
 
 ## Constant Declaration
@@ -247,15 +258,17 @@ Type properties are discussed in <doc:Properties#Type-Properties>.
 For more information about constants and for guidance about when to use them,
 see <doc:TheBasics#Constants-and-Variables> and <doc:Properties#Stored-Properties>.
 
-```
-Grammar of a constant declaration
-
-constant-declaration --> attributes-OPT declaration-modifiers-OPT ``let`` pattern-initializer-list
-
-pattern-initializer-list --> pattern-initializer | pattern-initializer ``,`` pattern-initializer-list
-pattern-initializer --> pattern initializer-OPT
-initializer --> ``=`` expression
-```
+> Grammar of a constant declaration:
+>
+> *constant-declaration* → *attributes*_?_ *declaration-modifiers*_?_ **`let`** *pattern-initializer-list*
+>
+>
+>
+> *pattern-initializer-list* → *pattern-initializer* | *pattern-initializer* **`,`** *pattern-initializer-list*
+>
+> *pattern-initializer* → *pattern* *initializer*_?_
+>
+> *initializer* → **`=`** *expression*
 
 
 ## Variable Declaration
@@ -543,36 +556,59 @@ Classes can mark type computed properties with the `class` declaration modifier 
 to allow subclasses to override the superclass’s implementation.
 Type properties are discussed in <doc:Properties#Type-Properties>.
 
-```
-Grammar of a variable declaration
-
-variable-declaration --> variable-declaration-head pattern-initializer-list
-variable-declaration --> variable-declaration-head variable-name type-annotation code-block
-variable-declaration --> variable-declaration-head variable-name type-annotation getter-setter-block
-variable-declaration --> variable-declaration-head variable-name type-annotation getter-setter-keyword-block
-variable-declaration --> variable-declaration-head variable-name initializer willSet-didSet-block
-variable-declaration --> variable-declaration-head variable-name type-annotation initializer-OPT willSet-didSet-block
-
-variable-declaration-head --> attributes-OPT declaration-modifiers-OPT ``var``
-variable-name --> identifier
-
-getter-setter-block --> code-block
-getter-setter-block --> ``{`` getter-clause setter-clause-OPT ``}``
-getter-setter-block --> ``{`` setter-clause getter-clause ``}``
-getter-clause --> attributes-OPT mutation-modifier-OPT ``get`` code-block
-setter-clause --> attributes-OPT mutation-modifier-OPT ``set`` setter-name-OPT code-block
-setter-name --> ``(`` identifier ``)``
-
-getter-setter-keyword-block --> ``{`` getter-keyword-clause setter-keyword-clause-OPT ``}``
-getter-setter-keyword-block --> ``{`` setter-keyword-clause getter-keyword-clause ``}``
-getter-keyword-clause --> attributes-OPT mutation-modifier-OPT ``get``
-setter-keyword-clause --> attributes-OPT mutation-modifier-OPT ``set``
-
-willSet-didSet-block --> ``{`` willSet-clause didSet-clause-OPT ``}``
-willSet-didSet-block --> ``{`` didSet-clause willSet-clause-OPT ``}``
-willSet-clause --> attributes-OPT ``willSet`` setter-name-OPT code-block
-didSet-clause --> attributes-OPT ``didSet`` setter-name-OPT code-block
-```
+> Grammar of a variable declaration:
+>
+> *variable-declaration* → *variable-declaration-head* *pattern-initializer-list*
+>
+> *variable-declaration* → *variable-declaration-head* *variable-name* *type-annotation* *code-block*
+>
+> *variable-declaration* → *variable-declaration-head* *variable-name* *type-annotation* *getter-setter-block*
+>
+> *variable-declaration* → *variable-declaration-head* *variable-name* *type-annotation* *getter-setter-keyword-block*
+>
+> *variable-declaration* → *variable-declaration-head* *variable-name* *initializer* *willSet-didSet-block*
+>
+> *variable-declaration* → *variable-declaration-head* *variable-name* *type-annotation* *initializer*_?_ *willSet-didSet-block*
+>
+>
+>
+> *variable-declaration-head* → *attributes*_?_ *declaration-modifiers*_?_ **`var`**
+>
+> *variable-name* → *identifier*
+>
+>
+>
+> *getter-setter-block* → *code-block*
+>
+> *getter-setter-block* → **`{`** *getter-clause* *setter-clause*_?_ **`}`**
+>
+> *getter-setter-block* → **`{`** *setter-clause* *getter-clause* **`}`**
+>
+> *getter-clause* → *attributes*_?_ *mutation-modifier*_?_ **`get`** *code-block*
+>
+> *setter-clause* → *attributes*_?_ *mutation-modifier*_?_ **`set`** *setter-name*_?_ *code-block*
+>
+> *setter-name* → **`(`** *identifier* **`)`**
+>
+>
+>
+> *getter-setter-keyword-block* → **`{`** *getter-keyword-clause* *setter-keyword-clause*_?_ **`}`**
+>
+> *getter-setter-keyword-block* → **`{`** *setter-keyword-clause* *getter-keyword-clause* **`}`**
+>
+> *getter-keyword-clause* → *attributes*_?_ *mutation-modifier*_?_ **`get`**
+>
+> *setter-keyword-clause* → *attributes*_?_ *mutation-modifier*_?_ **`set`**
+>
+>
+>
+> *willSet-didSet-block* → **`{`** *willSet-clause* *didSet-clause*_?_ **`}`**
+>
+> *willSet-didSet-block* → **`{`** *didSet-clause* *willSet-clause*_?_ **`}`**
+>
+> *willSet-clause* → *attributes*_?_ **`willSet`** *setter-name*_?_ *code-block*
+>
+> *didSet-clause* → *attributes*_?_ **`didSet`** *setter-name*_?_ *code-block*
 
 
 @Comment {
@@ -714,13 +750,13 @@ as `T.Iterator.Element` instead of `T.Element`.
 
 See also <doc:Declarations#Protocol-Associated-Type-Declaration>.
 
-```
-Grammar of a type alias declaration
-
-typealias-declaration --> attributes-OPT access-level-modifier-OPT ``typealias`` typealias-name generic-parameter-clause-OPT typealias-assignment
-typealias-name --> identifier
-typealias-assignment --> ``=`` type
-```
+> Grammar of a type alias declaration:
+>
+> *typealias-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`typealias`** *typealias-name* *generic-parameter-clause*_?_ *typealias-assignment*
+>
+> *typealias-name* → *identifier*
+>
+> *typealias-assignment* → **`=`** *type*
 
 
 @Comment {
@@ -1478,28 +1514,43 @@ as discussed in <doc:Statements#Guard-Statement>.
 You can override a nonreturning method,
 but the new method must preserve its return type and nonreturning behavior.
 
-```
-Grammar of a function declaration
-
-function-declaration --> function-head function-name generic-parameter-clause-OPT function-signature generic-where-clause-OPT function-body-OPT
-
-function-head --> attributes-OPT declaration-modifiers-OPT ``func``
-function-name --> identifier | operator
-
-function-signature --> parameter-clause ``async``-OPT ``throws``-OPT function-result-OPT
-function-signature --> parameter-clause ``async``-OPT ``rethrows`` function-result-OPT
-function-result --> ``->`` attributes-OPT type
-function-body --> code-block
-
-parameter-clause --> ``(`` ``)`` | ``(`` parameter-list ``)``
-parameter-list --> parameter | parameter ``,`` parameter-list
-parameter --> external-parameter-name-OPT local-parameter-name type-annotation default-argument-clause-OPT
-parameter --> external-parameter-name-OPT local-parameter-name type-annotation
-parameter --> external-parameter-name-OPT local-parameter-name type-annotation ``...``
-external-parameter-name --> identifier
-local-parameter-name --> identifier
-default-argument-clause --> ``=`` expression
-```
+> Grammar of a function declaration:
+>
+> *function-declaration* → *function-head* *function-name* *generic-parameter-clause*_?_ *function-signature* *generic-where-clause*_?_ *function-body*_?_
+>
+>
+>
+> *function-head* → *attributes*_?_ *declaration-modifiers*_?_ **`func`**
+>
+> *function-name* → *identifier* | *operator*
+>
+>
+>
+> *function-signature* → *parameter-clause* **`async`**_?_ **`throws`**_?_ *function-result*_?_
+>
+> *function-signature* → *parameter-clause* **`async`**_?_ **`rethrows`** *function-result*_?_
+>
+> *function-result* → **`->`** *attributes*_?_ *type*
+>
+> *function-body* → *code-block*
+>
+>
+>
+> *parameter-clause* → **`(`** **`)`** | **`(`** *parameter-list* **`)`**
+>
+> *parameter-list* → *parameter* | *parameter* **`,`** *parameter-list*
+>
+> *parameter* → *external-parameter-name*_?_ *local-parameter-name* *type-annotation* *default-argument-clause*_?_
+>
+> *parameter* → *external-parameter-name*_?_ *local-parameter-name* *type-annotation*
+>
+> *parameter* → *external-parameter-name*_?_ *local-parameter-name* *type-annotation* **`...`**
+>
+> *external-parameter-name* → *identifier*
+>
+> *local-parameter-name* → *identifier*
+>
+> *default-argument-clause* → **`=`** *expression*
 
 
 @Comment {
@@ -1828,30 +1879,47 @@ as described in <doc:Patterns#Enumeration-Case-Pattern>.
   We removed it from our grammar, below.
 }
 
-```
-Grammar of an enumeration declaration
-
-enum-declaration --> attributes-OPT access-level-modifier-OPT union-style-enum
-enum-declaration --> attributes-OPT access-level-modifier-OPT raw-value-style-enum
-
-union-style-enum --> ``indirect``-OPT ``enum`` enum-name generic-parameter-clause-OPT type-inheritance-clause-OPT generic-where-clause-OPT ``{`` union-style-enum-members-OPT ``}``
-union-style-enum-members --> union-style-enum-member union-style-enum-members-OPT
-union-style-enum-member --> declaration | union-style-enum-case-clause | compiler-control-statement
-union-style-enum-case-clause --> attributes-OPT ``indirect``-OPT ``case`` union-style-enum-case-list
-union-style-enum-case-list --> union-style-enum-case | union-style-enum-case ``,`` union-style-enum-case-list
-union-style-enum-case --> enum-case-name tuple-type-OPT
-enum-name --> identifier
-enum-case-name --> identifier
-
-raw-value-style-enum --> ``enum`` enum-name generic-parameter-clause-OPT type-inheritance-clause generic-where-clause-OPT ``{`` raw-value-style-enum-members ``}``
-raw-value-style-enum-members --> raw-value-style-enum-member raw-value-style-enum-members-OPT
-raw-value-style-enum-member --> declaration | raw-value-style-enum-case-clause | compiler-control-statement
-raw-value-style-enum-case-clause --> attributes-OPT ``case`` raw-value-style-enum-case-list
-raw-value-style-enum-case-list --> raw-value-style-enum-case | raw-value-style-enum-case ``,`` raw-value-style-enum-case-list
-raw-value-style-enum-case --> enum-case-name raw-value-assignment-OPT
-raw-value-assignment --> ``=`` raw-value-literal
-raw-value-literal --> numeric-literal | static-string-literal | boolean-literal
-```
+> Grammar of an enumeration declaration:
+>
+> *enum-declaration* → *attributes*_?_ *access-level-modifier*_?_ *union-style-enum*
+>
+> *enum-declaration* → *attributes*_?_ *access-level-modifier*_?_ *raw-value-style-enum*
+>
+>
+>
+> *union-style-enum* → **`indirect`**_?_ **`enum`** *enum-name* *generic-parameter-clause*_?_ *type-inheritance-clause*_?_ *generic-where-clause*_?_ **`{`** *union-style-enum-members*_?_ **`}`**
+>
+> *union-style-enum-members* → *union-style-enum-member* *union-style-enum-members*_?_
+>
+> *union-style-enum-member* → *declaration* | *union-style-enum-case-clause* | *compiler-control-statement*
+>
+> *union-style-enum-case-clause* → *attributes*_?_ **`indirect`**_?_ **`case`** *union-style-enum-case-list*
+>
+> *union-style-enum-case-list* → *union-style-enum-case* | *union-style-enum-case* **`,`** *union-style-enum-case-list*
+>
+> *union-style-enum-case* → *enum-case-name* *tuple-type*_?_
+>
+> *enum-name* → *identifier*
+>
+> *enum-case-name* → *identifier*
+>
+>
+>
+> *raw-value-style-enum* → **`enum`** *enum-name* *generic-parameter-clause*_?_ *type-inheritance-clause* *generic-where-clause*_?_ **`{`** *raw-value-style-enum-members* **`}`**
+>
+> *raw-value-style-enum-members* → *raw-value-style-enum-member* *raw-value-style-enum-members*_?_
+>
+> *raw-value-style-enum-member* → *declaration* | *raw-value-style-enum-case-clause* | *compiler-control-statement*
+>
+> *raw-value-style-enum-case-clause* → *attributes*_?_ **`case`** *raw-value-style-enum-case-list*
+>
+> *raw-value-style-enum-case-list* → *raw-value-style-enum-case* | *raw-value-style-enum-case* **`,`** *raw-value-style-enum-case-list*
+>
+> *raw-value-style-enum-case* → *enum-case-name* *raw-value-assignment*_?_
+>
+> *raw-value-assignment* → **`=`** *raw-value-literal*
+>
+> *raw-value-literal* → *numeric-literal* | *static-string-literal* | *boolean-literal*
 
 
 @Comment {
@@ -1933,16 +2001,19 @@ see <doc:ClassesAndStructures#Structures-and-Enumerations-Are-Value-Types>.
 You can extend the behavior of a structure type with an extension declaration,
 as discussed in <doc:Declarations#Extension-Declaration>.
 
-```
-Grammar of a structure declaration
-
-struct-declaration --> attributes-OPT access-level-modifier-OPT ``struct`` struct-name generic-parameter-clause-OPT type-inheritance-clause-OPT generic-where-clause-OPT struct-body
-struct-name --> identifier
-struct-body --> ``{`` struct-members-OPT ``}``
-
-struct-members --> struct-member struct-members-OPT
-struct-member --> declaration | compiler-control-statement
-```
+> Grammar of a structure declaration:
+>
+> *struct-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`struct`** *struct-name* *generic-parameter-clause*_?_ *type-inheritance-clause*_?_ *generic-where-clause*_?_ *struct-body*
+>
+> *struct-name* → *identifier*
+>
+> *struct-body* → **`{`** *struct-members*_?_ **`}`**
+>
+>
+>
+> *struct-members* → *struct-member* *struct-members*_?_
+>
+> *struct-member* → *declaration* | *compiler-control-statement*
 
 
 ## Class Declaration
@@ -2027,17 +2098,21 @@ see <doc:ClassesAndStructures#Classes-Are-Reference-Types>.
 You can extend the behavior of a class type with an extension declaration,
 as discussed in <doc:Declarations#Extension-Declaration>.
 
-```
-Grammar of a class declaration
-
-class-declaration --> attributes-OPT access-level-modifier-OPT ``final``-OPT ``class`` class-name generic-parameter-clause-OPT type-inheritance-clause-OPT generic-where-clause-OPT class-body
-class-declaration --> attributes-OPT ``final`` access-level-modifier-OPT ``class`` class-name generic-parameter-clause-OPT type-inheritance-clause-OPT generic-where-clause-OPT class-body
-class-name --> identifier
-class-body --> ``{`` class-members-OPT ``}``
-
-class-members --> class-member class-members-OPT
-class-member --> declaration | compiler-control-statement
-```
+> Grammar of a class declaration:
+>
+> *class-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`final`**_?_ **`class`** *class-name* *generic-parameter-clause*_?_ *type-inheritance-clause*_?_ *generic-where-clause*_?_ *class-body*
+>
+> *class-declaration* → *attributes*_?_ **`final`** *access-level-modifier*_?_ **`class`** *class-name* *generic-parameter-clause*_?_ *type-inheritance-clause*_?_ *generic-where-clause*_?_ *class-body*
+>
+> *class-name* → *identifier*
+>
+> *class-body* → **`{`** *class-members*_?_ **`}`**
+>
+>
+>
+> *class-members* → *class-member* *class-members*_?_
+>
+> *class-member* → *declaration* | *compiler-control-statement*
 
 
 ## Actor Declaration
@@ -2119,16 +2194,19 @@ as discussed in <doc:Declarations#Extension-Declaration>.
   whose corresponding parameter is non-escaping and non-Sendable.
 }
 
-```
-Grammar of an actor declaration
-
-actor-declaration --> attributes-OPT access-level-modifier-OPT ``actor`` actor-name generic-parameter-clause-OPT type-inheritance-clause-OPT generic-where-clause-OPT actor-body
-actor-name --> identifier
-actor-body --> ``{`` actor-members-OPT ``}``
-
-actor-members --> actor-member actor-members-OPT
-actor-member --> declaration | compiler-control-statement
-```
+> Grammar of an actor declaration:
+>
+> *actor-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`actor`** *actor-name* *generic-parameter-clause*_?_ *type-inheritance-clause*_?_ *generic-where-clause*_?_ *actor-body*
+>
+> *actor-name* → *identifier*
+>
+> *actor-body* → **`{`** *actor-members*_?_ **`}`**
+>
+>
+>
+> *actor-members* → *actor-member* *actor-members*_?_
+>
+> *actor-member* → *declaration* | *compiler-control-statement*
 
 
 ## Protocol Declaration
@@ -2273,23 +2351,33 @@ they specify.
 You can use protocols to declare which methods a delegate of a class or structure
 should implement, as described in <doc:Protocols#Delegation>.
 
-```
-Grammar of a protocol declaration
-
-protocol-declaration --> attributes-OPT access-level-modifier-OPT ``protocol`` protocol-name type-inheritance-clause-OPT generic-where-clause-OPT protocol-body
-protocol-name --> identifier
-protocol-body --> ``{`` protocol-members-OPT ``}``
-
-protocol-members --> protocol-member protocol-members-OPT
-protocol-member --> protocol-member-declaration | compiler-control-statement
-
-protocol-member-declaration --> protocol-property-declaration
-protocol-member-declaration --> protocol-method-declaration
-protocol-member-declaration --> protocol-initializer-declaration
-protocol-member-declaration --> protocol-subscript-declaration
-protocol-member-declaration --> protocol-associated-type-declaration
-protocol-member-declaration --> typealias-declaration
-```
+> Grammar of a protocol declaration:
+>
+> *protocol-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`protocol`** *protocol-name* *type-inheritance-clause*_?_ *generic-where-clause*_?_ *protocol-body*
+>
+> *protocol-name* → *identifier*
+>
+> *protocol-body* → **`{`** *protocol-members*_?_ **`}`**
+>
+>
+>
+> *protocol-members* → *protocol-member* *protocol-members*_?_
+>
+> *protocol-member* → *protocol-member-declaration* | *compiler-control-statement*
+>
+>
+>
+> *protocol-member-declaration* → *protocol-property-declaration*
+>
+> *protocol-member-declaration* → *protocol-method-declaration*
+>
+> *protocol-member-declaration* → *protocol-initializer-declaration*
+>
+> *protocol-member-declaration* → *protocol-subscript-declaration*
+>
+> *protocol-member-declaration* → *protocol-associated-type-declaration*
+>
+> *protocol-member-declaration* → *typealias-declaration*
 
 
 ### Protocol Property Declaration
@@ -2368,11 +2456,9 @@ use the `static` keyword.
 
 See also <doc:Declarations#Variable-Declaration>.
 
-```
-Grammar of a protocol property declaration
-
-protocol-property-declaration --> variable-declaration-head variable-name type-annotation getter-setter-keyword-block
-```
+> Grammar of a protocol property declaration:
+>
+> *protocol-property-declaration* → *variable-declaration-head* *variable-name* *type-annotation* *getter-setter-keyword-block*
 
 
 ### Protocol Method Declaration
@@ -2402,11 +2488,9 @@ See also <doc:Declarations#Function-Declaration>.
   TODO: Talk about using ``Self`` in parameters and return types.
 }
 
-```
-Grammar of a protocol method declaration
-
-protocol-method-declaration --> function-head function-name generic-parameter-clause-OPT function-signature generic-where-clause-OPT
-```
+> Grammar of a protocol method declaration:
+>
+> *protocol-method-declaration* → *function-head* *function-name* *generic-parameter-clause*_?_ *function-signature* *generic-where-clause*_?_
 
 
 ### Protocol Initializer Declaration
@@ -2427,12 +2511,11 @@ if the class isn't already marked with the `final` declaration modifier.
 
 See also <doc:Declarations#Initializer-Declaration>.
 
-```
-Grammar of a protocol initializer declaration
-
-protocol-initializer-declaration --> initializer-head generic-parameter-clause-OPT parameter-clause ``throws``-OPT generic-where-clause-OPT
-protocol-initializer-declaration --> initializer-head generic-parameter-clause-OPT parameter-clause ``rethrows`` generic-where-clause-OPT
-```
+> Grammar of a protocol initializer declaration:
+>
+> *protocol-initializer-declaration* → *initializer-head* *generic-parameter-clause*_?_ *parameter-clause* **`throws`**_?_ *generic-where-clause*_?_
+>
+> *protocol-initializer-declaration* → *initializer-head* *generic-parameter-clause*_?_ *parameter-clause* **`rethrows`** *generic-where-clause*_?_
 
 
 ### Protocol Subscript Declaration
@@ -2467,11 +2550,9 @@ use the `static` keyword.
 
 See also <doc:Declarations#Subscript-Declaration>.
 
-```
-Grammar of a protocol subscript declaration
-
-protocol-subscript-declaration --> subscript-head subscript-result generic-where-clause-OPT getter-setter-keyword-block
-```
+> Grammar of a protocol subscript declaration:
+>
+> *protocol-subscript-declaration* → *subscript-head* *subscript-result* *generic-where-clause*_?_ *getter-setter-keyword-block*
 
 
 ### Protocol Associated Type Declaration
@@ -2601,11 +2682,9 @@ protocol SubProtocolB: SomeProtocol where SomeType: Equatable { }
 
 See also <doc:Declarations#Type-Alias-Declaration>.
 
-```
-Grammar of a protocol associated type declaration
-
-protocol-associated-type-declaration --> attributes-OPT access-level-modifier-OPT ``associatedtype`` typealias-name type-inheritance-clause-OPT typealias-assignment-OPT generic-where-clause-OPT
-```
+> Grammar of a protocol associated type declaration:
+>
+> *protocol-associated-type-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`associatedtype`** *typealias-name* *type-inheritance-clause*_?_ *typealias-assignment*_?_ *generic-where-clause*_?_
 
 
 ## Initializer Declaration
@@ -2787,16 +2866,19 @@ by a nonfailable designated initializer only.
 For more information and to see examples of failable initializers,
 see <doc:Initialization#Failable-Initializers>.
 
-```
-Grammar of an initializer declaration
-
-initializer-declaration --> initializer-head generic-parameter-clause-OPT parameter-clause ``async``-OPT ``throws``-OPT generic-where-clause-OPT initializer-body
-initializer-declaration --> initializer-head generic-parameter-clause-OPT parameter-clause ``async``-OPT ``rethrows`` generic-where-clause-OPT initializer-body
-initializer-head --> attributes-OPT declaration-modifiers-OPT ``init``
-initializer-head --> attributes-OPT declaration-modifiers-OPT ``init`` ``?``
-initializer-head --> attributes-OPT declaration-modifiers-OPT ``init`` ``!``
-initializer-body --> code-block
-```
+> Grammar of an initializer declaration:
+>
+> *initializer-declaration* → *initializer-head* *generic-parameter-clause*_?_ *parameter-clause* **`async`**_?_ **`throws`**_?_ *generic-where-clause*_?_ *initializer-body*
+>
+> *initializer-declaration* → *initializer-head* *generic-parameter-clause*_?_ *parameter-clause* **`async`**_?_ **`rethrows`** *generic-where-clause*_?_ *initializer-body*
+>
+> *initializer-head* → *attributes*_?_ *declaration-modifiers*_?_ **`init`**
+>
+> *initializer-head* → *attributes*_?_ *declaration-modifiers*_?_ **`init`** **`?`**
+>
+> *initializer-head* → *attributes*_?_ *declaration-modifiers*_?_ **`init`** **`!`**
+>
+> *initializer-body* → *code-block*
 
 
 ## Deinitializer Declaration
@@ -2827,11 +2909,9 @@ Deinitializers aren't called directly.
 For an example of how to use a deinitializer in a class declaration,
 see <doc:Deinitialization>.
 
-```
-Grammar of a deinitializer declaration
-
-deinitializer-declaration --> attributes-OPT ``deinit`` code-block
-```
+> Grammar of a deinitializer declaration:
+>
+> *deinitializer-declaration* → *attributes*_?_ **`deinit`** *code-block*
 
 
 ## Extension Declaration
@@ -3327,15 +3407,17 @@ extension Array: Loggable where Element: MarkedLoggable { }
   ```
 }
 
-```
-Grammar of an extension declaration
-
-extension-declaration --> attributes-OPT access-level-modifier-OPT ``extension`` type-identifier type-inheritance-clause-OPT generic-where-clause-OPT extension-body
-extension-body --> ``{`` extension-members-OPT ``}``
-
-extension-members --> extension-member extension-members-OPT
-extension-member --> declaration | compiler-control-statement
-```
+> Grammar of an extension declaration:
+>
+> *extension-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`extension`** *type-identifier* *type-inheritance-clause*_?_ *generic-where-clause*_?_ *extension-body*
+>
+> *extension-body* → **`{`** *extension-members*_?_ **`}`**
+>
+>
+>
+> *extension-members* → *extension-member* *extension-members*_?_
+>
+> *extension-member* → *declaration* | *compiler-control-statement*
 
 
 ## Subscript Declaration
@@ -3428,15 +3510,17 @@ with both the `class` and `final` declaration modifiers.
   ```
 }
 
-```
-Grammar of a subscript declaration
-
-subscript-declaration --> subscript-head subscript-result generic-where-clause-OPT code-block
-subscript-declaration --> subscript-head subscript-result generic-where-clause-OPT getter-setter-block
-subscript-declaration --> subscript-head subscript-result generic-where-clause-OPT getter-setter-keyword-block
-subscript-head --> attributes-OPT declaration-modifiers-OPT ``subscript`` generic-parameter-clause-OPT parameter-clause
-subscript-result --> ``->`` attributes-OPT type
-```
+> Grammar of a subscript declaration:
+>
+> *subscript-declaration* → *subscript-head* *subscript-result* *generic-where-clause*_?_ *code-block*
+>
+> *subscript-declaration* → *subscript-head* *subscript-result* *generic-where-clause*_?_ *getter-setter-block*
+>
+> *subscript-declaration* → *subscript-head* *subscript-result* *generic-where-clause*_?_ *getter-setter-keyword-block*
+>
+> *subscript-head* → *attributes*_?_ *declaration-modifiers*_?_ **`subscript`** *generic-parameter-clause*_?_ *parameter-clause*
+>
+> *subscript-result* → **`->`** *attributes*_?_ *type*
 
 
 ## Operator Declaration
@@ -3511,17 +3595,21 @@ declaration modifier.
 To see an example of how to create and implement a new operator,
 see <doc:AdvancedOperators#Custom-Operators>.
 
-```
-Grammar of an operator declaration
-
-operator-declaration --> prefix-operator-declaration | postfix-operator-declaration | infix-operator-declaration
-
-prefix-operator-declaration --> ``prefix`` ``operator`` operator
-postfix-operator-declaration --> ``postfix`` ``operator`` operator
-infix-operator-declaration --> ``infix`` ``operator`` operator infix-operator-group-OPT
-
-infix-operator-group --> ``:`` precedence-group-name
-```
+> Grammar of an operator declaration:
+>
+> *operator-declaration* → *prefix-operator-declaration* | *postfix-operator-declaration* | *infix-operator-declaration*
+>
+>
+>
+> *prefix-operator-declaration* → **`prefix`** **`operator`** *operator*
+>
+> *postfix-operator-declaration* → **`postfix`** **`operator`** *operator*
+>
+> *infix-operator-declaration* → **`infix`** **`operator`** *operator* *infix-operator-group*_?_
+>
+>
+>
+> *infix-operator-group* → **`:`** *precedence-group-name*
 
 
 ## Precedence Group Declaration
@@ -3599,28 +3687,43 @@ Otherwise, when set to `false` or omitted,
 operators in the precedence group follows the same optional chaining rules
 as operators that don't perform assignment.
 
-```
-Grammar of a precedence group declaration
-
-precedence-group-declaration --> ``precedencegroup`` precedence-group-name ``{`` precedence-group-attributes-OPT ``}``
-
-precedence-group-attributes --> precedence-group-attribute precedence-group-attributes-OPT
-precedence-group-attribute --> precedence-group-relation
-precedence-group-attribute --> precedence-group-assignment
-precedence-group-attribute --> precedence-group-associativity
-
-precedence-group-relation --> ``higherThan`` ``:`` precedence-group-names
-precedence-group-relation --> ``lowerThan`` ``:`` precedence-group-names
-
-precedence-group-assignment --> ``assignment`` ``:`` boolean-literal
-
-precedence-group-associativity --> ``associativity`` ``:`` ``left``
-precedence-group-associativity --> ``associativity`` ``:`` ``right``
-precedence-group-associativity --> ``associativity`` ``:`` ``none``
-
-precedence-group-names --> precedence-group-name | precedence-group-name ``,`` precedence-group-names
-precedence-group-name --> identifier
-```
+> Grammar of a precedence group declaration:
+>
+> *precedence-group-declaration* → **`precedencegroup`** *precedence-group-name* **`{`** *precedence-group-attributes*_?_ **`}`**
+>
+>
+>
+> *precedence-group-attributes* → *precedence-group-attribute* *precedence-group-attributes*_?_
+>
+> *precedence-group-attribute* → *precedence-group-relation*
+>
+> *precedence-group-attribute* → *precedence-group-assignment*
+>
+> *precedence-group-attribute* → *precedence-group-associativity*
+>
+>
+>
+> *precedence-group-relation* → **`higherThan`** **`:`** *precedence-group-names*
+>
+> *precedence-group-relation* → **`lowerThan`** **`:`** *precedence-group-names*
+>
+>
+>
+> *precedence-group-assignment* → **`assignment`** **`:`** *boolean-literal*
+>
+>
+>
+> *precedence-group-associativity* → **`associativity`** **`:`** **`left`**
+>
+> *precedence-group-associativity* → **`associativity`** **`:`** **`right`**
+>
+> *precedence-group-associativity* → **`associativity`** **`:`** **`none`**
+>
+>
+>
+> *precedence-group-names* → *precedence-group-name* | *precedence-group-name* **`,`** *precedence-group-names*
+>
+> *precedence-group-name* → *identifier*
 
 
 ## Declaration Modifiers
@@ -3761,25 +3864,37 @@ for the setter of a variable or subscript that's less than or equal
 to the access level of the variable or subscript itself,
 as discussed in <doc:AccessControl#Getters-and-Setters>.
 
-```
-Grammar of a declaration modifier
-
-declaration-modifier --> ``class`` | ``convenience`` | ``dynamic`` | ``final`` | ``infix`` | ``lazy`` | ``optional`` | ``override`` | ``postfix`` | ``prefix`` | ``required`` | ``static`` | ``unowned`` | ``unowned`` ``(`` ``safe`` ``)`` | ``unowned`` ``(`` ``unsafe`` ``)`` | ``weak``
-declaration-modifier --> access-level-modifier
-declaration-modifier --> mutation-modifier
-declaration-modifier --> actor-isolation-modifier
-declaration-modifiers --> declaration-modifier declaration-modifiers-OPT
-
-access-level-modifier --> ``private`` | ``private`` ``(`` ``set`` ``)``
-access-level-modifier --> ``fileprivate`` | ``fileprivate`` ``(`` ``set`` ``)``
-access-level-modifier --> ``internal`` | ``internal`` ``(`` ``set`` ``)``
-access-level-modifier --> ``public`` | ``public`` ``(`` ``set`` ``)``
-access-level-modifier --> ``open`` | ``open`` ``(`` ``set`` ``)``
-
-mutation-modifier --> ``mutating`` | ``nonmutating``
-
-actor-isolation-modifier --> ``nonisolated``
-```
+> Grammar of a declaration modifier:
+>
+> *declaration-modifier* → **`class`** | **`convenience`** | **`dynamic`** | **`final`** | **`infix`** | **`lazy`** | **`optional`** | **`override`** | **`postfix`** | **`prefix`** | **`required`** | **`static`** | **`unowned`** | **`unowned`** **`(`** **`safe`** **`)`** | **`unowned`** **`(`** **`unsafe`** **`)`** | **`weak`**
+>
+> *declaration-modifier* → *access-level-modifier*
+>
+> *declaration-modifier* → *mutation-modifier*
+>
+> *declaration-modifier* → *actor-isolation-modifier*
+>
+> *declaration-modifiers* → *declaration-modifier* *declaration-modifiers*_?_
+>
+>
+>
+> *access-level-modifier* → **`private`** | **`private`** **`(`** **`set`** **`)`**
+>
+> *access-level-modifier* → **`fileprivate`** | **`fileprivate`** **`(`** **`set`** **`)`**
+>
+> *access-level-modifier* → **`internal`** | **`internal`** **`(`** **`set`** **`)`**
+>
+> *access-level-modifier* → **`public`** | **`public`** **`(`** **`set`** **`)`**
+>
+> *access-level-modifier* → **`open`** | **`open`** **`(`** **`set`** **`)`**
+>
+>
+>
+> *mutation-modifier* → **`mutating`** | **`nonmutating`**
+>
+>
+>
+> *actor-isolation-modifier* → **`nonisolated`**
 
 
 

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Expressions.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Expressions.md
@@ -18,12 +18,11 @@ using postfixes such as function calls and member access.
 Each kind of expression is described in detail
 in the sections below.
 
-```
-Grammar of an expression
-
-expression --> try-operator-OPT await-operator-OPT prefix-expression infix-expressions-OPT
-expression-list --> expression | expression ``,`` expression-list
-```
+> Grammar of an expression:
+>
+> *expression* → *try-operator*_?_ *await-operator*_?_ *prefix-expression* *infix-expressions*_?_
+>
+> *expression-list* → *expression* | *expression* **`,`** *expression-list*
 
 
 ## Prefix Expressions
@@ -39,12 +38,11 @@ see <doc:BasicOperators> and <doc:AdvancedOperators>.
 For information about the operators provided by the Swift standard library,
 see [Operator Declarations](https://developer.apple.com/documentation/swift/operator_declarations).
 
-```
-Grammar of a prefix expression
-
-prefix-expression --> prefix-operator-OPT postfix-expression
-prefix-expression --> in-out-expression
-```
+> Grammar of a prefix expression:
+>
+> *prefix-expression* → *prefix-operator*_?_ *postfix-expression*
+>
+> *prefix-expression* → *in-out-expression*
 
 
 ### In-Out Expression
@@ -66,11 +64,9 @@ when providing a non-pointer argument
 in a context where a pointer is needed,
 as described in <doc:Expressions#Implicit-Conversion-to-a-Pointer-Type>.
 
-```
-Grammar of an in-out expression
-
-in-out-expression --> ``&`` identifier
-```
+> Grammar of an in-out expression:
+>
+> *in-out-expression* → **`&`** *identifier*
 
 
 ### Try Operator
@@ -192,11 +188,9 @@ the `try` operator must appear first.
 For more information and to see examples of how to use `try`, `try?`, and `try!`,
 see <doc:ErrorHandling>.
 
-```
-Grammar of a try expression
-
-try-operator --> ``try`` | ``try`` ``?`` | ``try`` ``!``
-```
+> Grammar of a try expression:
+>
+> *try-operator* → **`try`** | **`try`** **`?`** | **`try`** **`!`**
 
 
 ### Await Operator
@@ -302,11 +296,9 @@ the `try` operator must appear first.
   but it's important enough to be worth re-stating in prose.
 }
 
-```
-Grammar of an await expression
-
-await-operator --> ``await``
-```
+> Grammar of an await expression:
+>
+> *await-operator* → **`await`**
 
 
 ## Infix Expressions
@@ -347,15 +339,17 @@ see [Operator Declarations](https://developer.apple.com/documentation/swift/oper
 > `2`, `+`, `3`, `*`, and `5`.
 > This process transforms it into the tree (2 + (3 * 5)).
 
-```
-Grammar of an infix expression
-
-infix-expression --> infix-operator prefix-expression
-infix-expression --> assignment-operator try-operator-OPT prefix-expression
-infix-expression --> conditional-operator try-operator-OPT prefix-expression
-infix-expression --> type-casting-operator
-infix-expressions --> infix-expression infix-expressions-OPT
-```
+> Grammar of an infix expression:
+>
+> *infix-expression* → *infix-operator* *prefix-expression*
+>
+> *infix-expression* → *assignment-operator* *try-operator*_?_ *prefix-expression*
+>
+> *infix-expression* → *conditional-operator* *try-operator*_?_ *prefix-expression*
+>
+> *infix-expression* → *type-casting-operator*
+>
+> *infix-expressions* → *infix-expression* *infix-expressions*_?_
 
 
 ### Assignment Operator
@@ -398,11 +392,9 @@ For example:
 
 The assignment operator doesn't return any value.
 
-```
-Grammar of an assignment operator
-
-assignment-operator --> ``=``
-```
+> Grammar of an assignment operator:
+>
+> *assignment-operator* → **`=`**
 
 
 ### Ternary Conditional Operator
@@ -426,11 +418,9 @@ The unused expression isn't evaluated.
 For an example that uses the ternary conditional operator,
 see <doc:BasicOperators#Ternary-Conditional-Operator>.
 
-```
-Grammar of a conditional operator
-
-conditional-operator --> ``?`` expression ``:``
-```
+> Grammar of a conditional operator:
+>
+> *conditional-operator* → **`?`** *expression* **`:`**
 
 
 ### Type-Casting Operators
@@ -557,14 +547,15 @@ For more information about type casting
 and to see examples that use the type-casting operators,
 see <doc:TypeCasting>.
 
-```
-Grammar of a type-casting operator
-
-type-casting-operator --> ``is`` type
-type-casting-operator --> ``as`` type
-type-casting-operator --> ``as`` ``?`` type
-type-casting-operator --> ``as`` ``!`` type
-```
+> Grammar of a type-casting operator:
+>
+> *type-casting-operator* → **`is`** *type*
+>
+> *type-casting-operator* → **`as`** *type*
+>
+> *type-casting-operator* → **`as`** **`?`** *type*
+>
+> *type-casting-operator* → **`as`** **`!`** *type*
 
 
 ## Primary Expressions
@@ -575,22 +566,31 @@ They can be used as expressions on their own,
 and they can be combined with other tokens
 to make prefix expressions, infix expressions, and postfix expressions.
 
-```
-Grammar of a primary expression
-
-primary-expression --> identifier generic-argument-clause-OPT
-primary-expression --> literal-expression
-primary-expression --> self-expression
-primary-expression --> superclass-expression
-primary-expression --> closure-expression
-primary-expression --> parenthesized-expression
-primary-expression --> tuple-expression
-primary-expression --> implicit-member-expression
-primary-expression --> wildcard-expression
-primary-expression --> key-path-expression
-primary-expression --> selector-expression
-primary-expression --> key-path-string-expression
-```
+> Grammar of a primary expression:
+>
+> *primary-expression* → *identifier* *generic-argument-clause*_?_
+>
+> *primary-expression* → *literal-expression*
+>
+> *primary-expression* → *self-expression*
+>
+> *primary-expression* → *superclass-expression*
+>
+> *primary-expression* → *closure-expression*
+>
+> *primary-expression* → *parenthesized-expression*
+>
+> *primary-expression* → *tuple-expression*
+>
+> *primary-expression* → *implicit-member-expression*
+>
+> *primary-expression* → *wildcard-expression*
+>
+> *primary-expression* → *key-path-expression*
+>
+> *primary-expression* → *selector-expression*
+>
+> *primary-expression* → *key-path-string-expression*
 
 
 @Comment {
@@ -790,26 +790,39 @@ For information on using playground literals in Xcode,
 see [Add a color, file, or image literal](https://help.apple.com/xcode/mac/current/#/dev4c60242fc)
 in Xcode Help.
 
-```
-Grammar of a literal expression
-
-literal-expression --> literal
-literal-expression --> array-literal | dictionary-literal | playground-literal
-literal-expression --> ``#file`` | ``#fileID`` | ``#filePath``
-literal-expression --> ``#line`` | ``#column`` | ``#function`` | ``#dsohandle``
-
-array-literal --> ``[`` array-literal-items-OPT ``]``
-array-literal-items --> array-literal-item ``,``-OPT | array-literal-item ``,`` array-literal-items
-array-literal-item --> expression
-
-dictionary-literal --> ``[`` dictionary-literal-items ``]`` | ``[`` ``:`` ``]``
-dictionary-literal-items --> dictionary-literal-item ``,``-OPT | dictionary-literal-item ``,`` dictionary-literal-items
-dictionary-literal-item --> expression ``:`` expression
-
-playground-literal --> ``#colorLiteral`` ``(`` ``red`` ``:`` expression ``,`` ``green`` ``:`` expression ``,`` ``blue`` ``:`` expression ``,`` ``alpha`` ``:`` expression ``)``
-playground-literal --> ``#fileLiteral`` ``(`` ``resourceName`` ``:`` expression ``)``
-playground-literal --> ``#imageLiteral`` ``(`` ``resourceName`` ``:`` expression ``)``
-```
+> Grammar of a literal expression:
+>
+> *literal-expression* → *literal*
+>
+> *literal-expression* → *array-literal* | *dictionary-literal* | *playground-literal*
+>
+> *literal-expression* → **`#file`** | **`#fileID`** | **`#filePath`**
+>
+> *literal-expression* → **`#line`** | **`#column`** | **`#function`** | **`#dsohandle`**
+>
+>
+>
+> *array-literal* → **`[`** *array-literal-items*_?_ **`]`**
+>
+> *array-literal-items* → *array-literal-item* **`,`**_?_ | *array-literal-item* **`,`** *array-literal-items*
+>
+> *array-literal-item* → *expression*
+>
+>
+>
+> *dictionary-literal* → **`[`** *dictionary-literal-items* **`]`** | **`[`** **`:`** **`]`**
+>
+> *dictionary-literal-items* → *dictionary-literal-item* **`,`**_?_ | *dictionary-literal-item* **`,`** *dictionary-literal-items*
+>
+> *dictionary-literal-item* → *expression* **`:`** *expression*
+>
+>
+>
+> *playground-literal* → **`#colorLiteral`** **`(`** **`red`** **`:`** *expression* **`,`** **`green`** **`:`** *expression* **`,`** **`blue`** **`:`** *expression* **`,`** **`alpha`** **`:`** *expression* **`)`**
+>
+> *playground-literal* → **`#fileLiteral`** **`(`** **`resourceName`** **`:`** *expression* **`)`**
+>
+> *playground-literal* → **`#imageLiteral`** **`(`** **`resourceName`** **`:`** *expression* **`)`**
 
 
 ### Self Expression
@@ -899,15 +912,17 @@ struct Point {
   iBooks Store screenshot begins here.
 }
 
-```
-Grammar of a self expression
-
-self-expression -->  ``self`` | self-method-expression | self-subscript-expression | self-initializer-expression
-
-self-method-expression --> ``self`` ``.`` identifier
-self-subscript-expression --> ``self`` ``[`` function-call-argument-list ``]``
-self-initializer-expression --> ``self`` ``.`` ``init``
-```
+> Grammar of a self expression:
+>
+> *self-expression* → **`self`** | *self-method-expression* | *self-subscript-expression* | *self-initializer-expression*
+>
+>
+>
+> *self-method-expression* → **`self`** **`.`** *identifier*
+>
+> *self-subscript-expression* → **`self`** **`[`** *function-call-argument-list* **`]`**
+>
+> *self-initializer-expression* → **`self`** **`.`** **`init`**
 
 
 ### Superclass Expression
@@ -931,15 +946,17 @@ Subclasses can use a superclass expression
 in their implementation of members, subscripting, and initializers
 to make use of the implementation in their superclass.
 
-```
-Grammar of a superclass expression
-
-superclass-expression --> superclass-method-expression | superclass-subscript-expression | superclass-initializer-expression
-
-superclass-method-expression --> ``super`` ``.`` identifier
-superclass-subscript-expression --> ``super`` ``[`` function-call-argument-list ``]``
-superclass-initializer-expression --> ``super`` ``.`` ``init``
-```
+> Grammar of a superclass expression:
+>
+> *superclass-expression* → *superclass-method-expression* | *superclass-subscript-expression* | *superclass-initializer-expression*
+>
+>
+>
+> *superclass-method-expression* → **`super`** **`.`** *identifier*
+>
+> *superclass-subscript-expression* → **`super`** **`[`** *function-call-argument-list* **`]`**
+>
+> *superclass-initializer-expression* → **`super`** **`.`** **`init`**
 
 
 ### Closure Expression
@@ -1299,27 +1316,41 @@ see <doc:AutomaticReferenceCounting#Resolving-Strong-Reference-Cycles-for-Closur
   ```
 }
 
-```
-Grammar of a closure expression
-
-closure-expression --> ``{`` attributes-OPT closure-signature-OPT statements-OPT ``}``
-
-closure-signature --> capture-list-OPT closure-parameter-clause ``async``-OPT ``throws``-OPT function-result-OPT ``in``
-closure-signature --> capture-list ``in``
-
-closure-parameter-clause --> ``(`` ``)`` | ``(`` closure-parameter-list ``)`` | identifier-list
-closure-parameter-list --> closure-parameter | closure-parameter ``,`` closure-parameter-list
-closure-parameter --> closure-parameter-name type-annotation-OPT
-closure-parameter --> closure-parameter-name type-annotation ``...``
-closure-parameter-name --> identifier
-
-capture-list --> ``[`` capture-list-items ``]``
-capture-list-items --> capture-list-item | capture-list-item ``,`` capture-list-items
-capture-list-item --> capture-specifier-OPT identifier
-capture-list-item --> capture-specifier-OPT identifier ``=`` expression
-capture-list-item --> capture-specifier-OPT self-expression
-capture-specifier --> ``weak`` | ``unowned`` | ``unowned(safe)`` | ``unowned(unsafe)``
-```
+> Grammar of a closure expression:
+>
+> *closure-expression* → **`{`** *attributes*_?_ *closure-signature*_?_ *statements*_?_ **`}`**
+>
+>
+>
+> *closure-signature* → *capture-list*_?_ *closure-parameter-clause* **`async`**_?_ **`throws`**_?_ *function-result*_?_ **`in`**
+>
+> *closure-signature* → *capture-list* **`in`**
+>
+>
+>
+> *closure-parameter-clause* → **`(`** **`)`** | **`(`** *closure-parameter-list* **`)`** | *identifier-list*
+>
+> *closure-parameter-list* → *closure-parameter* | *closure-parameter* **`,`** *closure-parameter-list*
+>
+> *closure-parameter* → *closure-parameter-name* *type-annotation*_?_
+>
+> *closure-parameter* → *closure-parameter-name* *type-annotation* **`...`**
+>
+> *closure-parameter-name* → *identifier*
+>
+>
+>
+> *capture-list* → **`[`** *capture-list-items* **`]`**
+>
+> *capture-list-items* → *capture-list-item* | *capture-list-item* **`,`** *capture-list-items*
+>
+> *capture-list-item* → *capture-specifier*_?_ *identifier*
+>
+> *capture-list-item* → *capture-specifier*_?_ *identifier* **`=`** *expression*
+>
+> *capture-list-item* → *capture-specifier*_?_ *self-expression*
+>
+> *capture-specifier* → **`weak`** | **`unowned`** | **`unowned(safe)`** | **`unowned(unsafe)`**
 
 
 ### Implicit Member Expression
@@ -1428,12 +1459,11 @@ the type of `x` matches the type implied by its context exactly,
 the type of `y` is convertible from `SomeClass` to `SomeClass?`,
 and the type of `z` is convertible from `SomeSubclass` to `SomeClass`.
 
-```
-Grammar of a implicit member expression
-
-implicit-member-expression --> ``.`` identifier
-implicit-member-expression --> ``.`` identifier ``.`` postfix-expression
-```
+> Grammar of a implicit member expression:
+>
+> *implicit-member-expression* → **`.`** *identifier*
+>
+> *implicit-member-expression* → **`.`** *identifier* **`.`** *postfix-expression*
 
 
 @Comment {
@@ -1488,11 +1518,9 @@ for example, the type of `(1)` is simply `Int`.
   See "Tuple Expression" below for langref grammar.
 }
 
-```
-Grammar of a parenthesized expression
-
-parenthesized-expression --> ``(`` expression ``)``
-```
+> Grammar of a parenthesized expression:
+>
+> *parenthesized-expression* → **`(`** *expression* **`)`**
 
 
 ### Tuple Expression
@@ -1542,13 +1570,13 @@ A single expression inside parentheses is a parenthesized expression.
 > However, like all type aliases, `Void` is always a type ---
 > you can't use it to write an empty tuple expression.
 
-```
-Grammar of a tuple expression
-
-tuple-expression --> ``(`` ``)`` | ``(`` tuple-element ``,`` tuple-element-list ``)``
-tuple-element-list --> tuple-element | tuple-element ``,`` tuple-element-list
-tuple-element --> expression | identifier ``:`` expression
-```
+> Grammar of a tuple expression:
+>
+> *tuple-expression* → **`(`** **`)`** | **`(`** *tuple-element* **`,`** *tuple-element-list* **`)`**
+>
+> *tuple-element-list* → *tuple-element* | *tuple-element* **`,`** *tuple-element-list*
+>
+> *tuple-element* → *expression* | *identifier* **`:`** *expression*
 
 
 ### Wildcard Expression
@@ -1574,11 +1602,9 @@ For example, in the following assignment
   ```
 }
 
-```
-Grammar of a wildcard expression
-
-wildcard-expression --> ``_``
-```
+> Grammar of a wildcard expression:
+>
+> *wildcard-expression* → **`_`**
 
 
 ### Key-Path Expression
@@ -2024,16 +2050,19 @@ For information about key-value coding and key-value observing,
 see [Key-Value Coding Programming Guide](https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/KeyValueCoding/index.html#//apple_ref/doc/uid/10000107i)
 and [Key-Value Observing Programming Guide](https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/KeyValueObserving/KeyValueObserving.html#//apple_ref/doc/uid/10000177i).
 
-```
-Grammar of a key-path expression
-
-key-path-expression --> ``\`` type-OPT ``.`` key-path-components
-key-path-components --> key-path-component | key-path-component ``.`` key-path-components
-key-path-component --> identifier key-path-postfixes-OPT | key-path-postfixes
-
-key-path-postfixes --> key-path-postfix key-path-postfixes-OPT
-key-path-postfix --> ``?`` | ``!`` | ``self`` | ``[`` function-call-argument-list ``]``
-```
+> Grammar of a key-path expression:
+>
+> *key-path-expression* → **`\`** *type*_?_ **`.`** *key-path-components*
+>
+> *key-path-components* → *key-path-component* | *key-path-component* **`.`** *key-path-components*
+>
+> *key-path-component* → *identifier* *key-path-postfixes*_?_ | *key-path-postfixes*
+>
+>
+>
+> *key-path-postfixes* → *key-path-postfix* *key-path-postfixes*_?_
+>
+> *key-path-postfix* → **`?`** | **`!`** | **`self`** | **`[`** *function-call-argument-list* **`]`**
 
 
 ### Selector Expression
@@ -2142,13 +2171,13 @@ For more information about using selectors
 in Swift code that interacts with Objective-C APIs,
 see [Using Objective-C Runtime Features in Swift](https://developer.apple.com/documentation/swift/using_objective_c_runtime_features_in_swift).
 
-```
-Grammar of a selector expression
-
-selector-expression --> ``#selector`` ``(`` expression  ``)``
-selector-expression --> ``#selector`` ``(`` ``getter:`` expression  ``)``
-selector-expression --> ``#selector`` ``(`` ``setter:`` expression  ``)``
-```
+> Grammar of a selector expression:
+>
+> *selector-expression* → **`#selector`** **`(`** *expression* **`)`**
+>
+> *selector-expression* → **`#selector`** **`(`** **`getter:`** *expression* **`)`**
+>
+> *selector-expression* → **`#selector`** **`(`** **`setter:`** *expression* **`)`**
 
 
 @Comment {
@@ -2257,11 +2286,9 @@ and [Key-Value Observing Programming Guide](https://developer.apple.com/library/
 
 > Note: Although the *property name* is an expression, it's never evaluated.
 
-```
-Grammar of a key-path string expression
-
-key-path-string-expression --> ``#keyPath`` ``(`` expression  ``)``
-```
+> Grammar of a key-path string expression:
+>
+> *key-path-string-expression* → **`#keyPath`** **`(`** *expression* **`)`**
 
 
 ## Postfix Expressions
@@ -2277,19 +2304,25 @@ see <doc:BasicOperators> and <doc:AdvancedOperators>.
 For information about the operators provided by the Swift standard library,
 see [Operator Declarations](https://developer.apple.com/documentation/swift/operator_declarations).
 
-```
-Grammar of a postfix expression
-
-postfix-expression --> primary-expression
-postfix-expression --> postfix-expression postfix-operator
-postfix-expression --> function-call-expression
-postfix-expression --> initializer-expression
-postfix-expression --> explicit-member-expression
-postfix-expression --> postfix-self-expression
-postfix-expression --> subscript-expression
-postfix-expression --> forced-value-expression
-postfix-expression --> optional-chaining-expression
-```
+> Grammar of a postfix expression:
+>
+> *postfix-expression* → *primary-expression*
+>
+> *postfix-expression* → *postfix-expression* *postfix-operator*
+>
+> *postfix-expression* → *function-call-expression*
+>
+> *postfix-expression* → *initializer-expression*
+>
+> *postfix-expression* → *explicit-member-expression*
+>
+> *postfix-expression* → *postfix-self-expression*
+>
+> *postfix-expression* → *subscript-expression*
+>
+> *postfix-expression* → *forced-value-expression*
+>
+> *postfix-expression* → *optional-chaining-expression*
 
 
 ### Function Call Expression
@@ -2655,21 +2688,29 @@ avoid using `&` instead of using the unsafe APIs explicitly.
   ```
 }
 
-```
-Grammar of a function call expression
-
-function-call-expression --> postfix-expression function-call-argument-clause
-function-call-expression --> postfix-expression function-call-argument-clause-OPT trailing-closures
-
-function-call-argument-clause --> ``(`` ``)`` | ``(`` function-call-argument-list ``)``
-function-call-argument-list --> function-call-argument | function-call-argument ``,`` function-call-argument-list
-function-call-argument --> expression | identifier ``:`` expression
-function-call-argument --> operator | identifier ``:`` operator
-
-trailing-closures --> closure-expression labeled-trailing-closures-OPT
-labeled-trailing-closures --> labeled-trailing-closure labeled-trailing-closures-OPT
-labeled-trailing-closure --> identifier ``:`` closure-expression
-```
+> Grammar of a function call expression:
+>
+> *function-call-expression* → *postfix-expression* *function-call-argument-clause*
+>
+> *function-call-expression* → *postfix-expression* *function-call-argument-clause*_?_ *trailing-closures*
+>
+>
+>
+> *function-call-argument-clause* → **`(`** **`)`** | **`(`** *function-call-argument-list* **`)`**
+>
+> *function-call-argument-list* → *function-call-argument* | *function-call-argument* **`,`** *function-call-argument-list*
+>
+> *function-call-argument* → *expression* | *identifier* **`:`** *expression*
+>
+> *function-call-argument* → *operator* | *identifier* **`:`** *operator*
+>
+>
+>
+> *trailing-closures* → *closure-expression* *labeled-trailing-closures*_?_
+>
+> *labeled-trailing-closures* → *labeled-trailing-closure* *labeled-trailing-closures*_?_
+>
+> *labeled-trailing-closure* → *identifier* **`:`** *closure-expression*
 
 
 ### Initializer Expression
@@ -2769,12 +2810,11 @@ let s4 = type(of: someValue)(data: 5)       // Error
   ```
 }
 
-```
-Grammar of an initializer expression
-
-initializer-expression --> postfix-expression ``.`` ``init``
-initializer-expression --> postfix-expression ``.`` ``init`` ``(`` argument-names ``)``
-```
+> Grammar of an initializer expression:
+>
+> *initializer-expression* → *postfix-expression* **`.`** **`init`**
+>
+> *initializer-expression* → *postfix-expression* **`.`** **`init`** **`(`** *argument-names* **`)`**
 
 
 ### Explicit Member Expression
@@ -3047,17 +3087,21 @@ The other branches can be empty.
   ```
 }
 
-```
-Grammar of an explicit member expression
-
-explicit-member-expression --> postfix-expression ``.`` decimal-digits
-explicit-member-expression --> postfix-expression ``.`` identifier generic-argument-clause-OPT
-explicit-member-expression --> postfix-expression ``.`` identifier ``(`` argument-names ``)``
-explicit-member-expression --> postfix-expression conditional-compilation-block
-
-argument-names --> argument-name argument-names-OPT
-argument-name --> identifier ``:``
-```
+> Grammar of an explicit member expression:
+>
+> *explicit-member-expression* → *postfix-expression* **`.`** *decimal-digits*
+>
+> *explicit-member-expression* → *postfix-expression* **`.`** *identifier* *generic-argument-clause*_?_
+>
+> *explicit-member-expression* → *postfix-expression* **`.`** *identifier* **`(`** *argument-names* **`)`**
+>
+> *explicit-member-expression* → *postfix-expression* *conditional-compilation-block*
+>
+>
+>
+> *argument-names* → *argument-name* *argument-names*_?_
+>
+> *argument-name* → *identifier* **`:`**
 
 
 @Comment {
@@ -3089,11 +3133,9 @@ to access a type as a value. For example,
 because `SomeClass.self` evaluates to the `SomeClass` type itself,
 you can pass it to a function or method that accepts a type-level argument.
 
-```
-Grammar of a postfix self expression
-
-postfix-self-expression --> postfix-expression ``.`` ``self``
-```
+> Grammar of a postfix self expression:
+>
+> *postfix-self-expression* → *postfix-expression* **`.`** **`self`**
 
 
 ### Subscript Expression
@@ -3131,11 +3173,9 @@ the subscript setter is called in the same way.
 For information about subscript declarations,
 see <doc:Declarations#Protocol-Subscript-Declaration>.
 
-```
-Grammar of a subscript expression
-
-subscript-expression --> postfix-expression ``[`` function-call-argument-list ``]``
-```
+> Grammar of a subscript expression:
+>
+> *subscript-expression* → *postfix-expression* **`[`** *function-call-argument-list* **`]`**
 
 
 @Comment {
@@ -3202,11 +3242,9 @@ someDictionary["a"]![0] = 100
   ```
 }
 
-```
-Grammar of a forced-value expression
-
-forced-value-expression --> postfix-expression ``!``
-```
+> Grammar of a forced-value expression:
+>
+> *forced-value-expression* → *postfix-expression* **`!`**
 
 
 ### Optional-Chaining Expression
@@ -3334,11 +3372,9 @@ someDictionary["a"]?[0] = someFunctionWithSideEffects()
   ```
 }
 
-```
-Grammar of an optional-chaining expression
-
-optional-chaining-expression --> postfix-expression ``?``
-```
+> Grammar of an optional-chaining expression:
+>
+> *optional-chaining-expression* → *postfix-expression* **`?`**
 
 
 

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/GenericParametersAndArguments.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/GenericParametersAndArguments.md
@@ -210,23 +210,33 @@ For more information about generic `where` clauses and to see an example
 of one in a generic function declaration,
 see <doc:Generics#Generic-Where-Clauses>.
 
-```
-Grammar of a generic parameter clause
-
-generic-parameter-clause --> ``<`` generic-parameter-list ``>``
-generic-parameter-list --> generic-parameter | generic-parameter ``,`` generic-parameter-list
-generic-parameter --> type-name
-generic-parameter --> type-name ``:`` type-identifier
-generic-parameter --> type-name ``:`` protocol-composition-type
-
-generic-where-clause --> ``where`` requirement-list
-requirement-list --> requirement | requirement ``,`` requirement-list
-requirement --> conformance-requirement | same-type-requirement
-
-conformance-requirement --> type-identifier ``:`` type-identifier
-conformance-requirement --> type-identifier ``:`` protocol-composition-type
-same-type-requirement --> type-identifier ``==`` type
-```
+> Grammar of a generic parameter clause:
+>
+> *generic-parameter-clause* → **`<`** *generic-parameter-list* **`>`**
+>
+> *generic-parameter-list* → *generic-parameter* | *generic-parameter* **`,`** *generic-parameter-list*
+>
+> *generic-parameter* → *type-name*
+>
+> *generic-parameter* → *type-name* **`:`** *type-identifier*
+>
+> *generic-parameter* → *type-name* **`:`** *protocol-composition-type*
+>
+>
+>
+> *generic-where-clause* → **`where`** *requirement-list*
+>
+> *requirement-list* → *requirement* | *requirement* **`,`** *requirement-list*
+>
+> *requirement* → *conformance-requirement* | *same-type-requirement*
+>
+>
+>
+> *conformance-requirement* → *type-identifier* **`:`** *type-identifier*
+>
+> *conformance-requirement* → *type-identifier* **`:`** *protocol-composition-type*
+>
+> *same-type-requirement* → *type-identifier* **`==`** *type*
 
 
 @Comment {
@@ -296,13 +306,13 @@ As mentioned in <doc:GenericParametersAndArguments#Generic-Parameter-Clause>,
 you don't use a generic argument clause to specify the type arguments
 of a generic function or initializer.
 
-```
-Grammar of a generic argument clause
-
-generic-argument-clause --> ``<`` generic-argument-list ``>``
-generic-argument-list --> generic-argument | generic-argument ``,`` generic-argument-list
-generic-argument --> type
-```
+> Grammar of a generic argument clause:
+>
+> *generic-argument-clause* → **`<`** *generic-argument-list* **`>`**
+>
+> *generic-argument-list* → *generic-argument* | *generic-argument* **`,`** *generic-argument-list*
+>
+> *generic-argument* → *type*
 
 
 

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/LexicalStructure.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/LexicalStructure.md
@@ -45,34 +45,55 @@ but the comment markers must be balanced.
 Comments can contain additional formatting and markup,
 as described in [Markup Formatting Reference](https://developer.apple.com/library/content/documentation/Xcode/Reference/xcode_markup_formatting_ref/index.html).
 
-```
-Grammar of whitespace
-
-whitespace --> whitespace-item whitespace-OPT
-whitespace-item --> line-break
-whitespace-item --> inline-space
-whitespace-item --> comment
-whitespace-item --> multiline-comment
-whitespace-item --> U+0000, U+000B, or U+000C
-
-line-break --> U+000A
-line-break --> U+000D
-line-break --> U+000D followed by U+000A
-
-inline-spaces --> inline-space inline-spaces-OPT
-inline-space --> U+0009 or U+0020
-
-comment --> ``//`` comment-text line-break
-multiline-comment --> ``/*`` multiline-comment-text ``*/``
-
-comment-text --> comment-text-item comment-text-OPT
-comment-text-item --> Any Unicode scalar value except U+000A or U+000D
-
-multiline-comment-text --> multiline-comment-text-item multiline-comment-text-OPT
-multiline-comment-text-item --> multiline-comment
-multiline-comment-text-item --> comment-text-item
-multiline-comment-text-item --> Any Unicode scalar value except ``/*`` or ``*/``
-```
+> Grammar of whitespace:
+>
+> *whitespace* → *whitespace-item* *whitespace*_?_
+>
+> *whitespace-item* → *line-break*
+>
+> *whitespace-item* → *inline-space*
+>
+> *whitespace-item* → *comment*
+>
+> *whitespace-item* → *multiline-comment*
+>
+> *whitespace-item* → U+0000, U+000B, or U+000C
+>
+>
+>
+> *line-break* → U+000A
+>
+> *line-break* → U+000D
+>
+> *line-break* → U+000D followed by U+000A
+>
+>
+>
+> *inline-spaces* → *inline-space* *inline-spaces*_?_
+>
+> *inline-space* → U+0009 or U+0020
+>
+>
+>
+> *comment* → **`//`** *comment-text* *line-break*
+>
+> *multiline-comment* → **`/*`** *multiline-comment-text* **`*/`**
+>
+>
+>
+> *comment-text* → *comment-text-item* *comment-text*_?_
+>
+> *comment-text-item* → Any Unicode scalar value except U+000A or U+000D
+>
+>
+>
+> *multiline-comment-text* → *multiline-comment-text-item* *multiline-comment-text*_?_
+>
+> *multiline-comment-text-item* → *multiline-comment*
+>
+> *multiline-comment-text-item* → *comment-text-item*
+>
+> *multiline-comment-text-item* → Any Unicode scalar value except  **`/*`** or  **`*/`**
 
 
 ## Identifiers
@@ -120,40 +141,67 @@ of the <doc:Attributes> chapter.
   the section name isn't title case so it doesn't necessarily look like a title.
 }
 
-```
-Grammar of an identifier
-
-identifier --> identifier-head identifier-characters-OPT
-identifier --> ````` identifier-head identifier-characters-OPT `````
-identifier --> implicit-parameter-name
-identifier --> property-wrapper-projection
-identifier-list --> identifier | identifier ``,`` identifier-list
-
-identifier-head --> Upper- or lowercase letter A through Z
-identifier-head --> ``_``
-identifier-head --> U+00A8, U+00AA, U+00AD, U+00AF, U+00B2--U+00B5, or U+00B7--U+00BA
-identifier-head --> U+00BC--U+00BE, U+00C0--U+00D6, U+00D8--U+00F6, or U+00F8--U+00FF
-identifier-head --> U+0100--U+02FF, U+0370--U+167F, U+1681--U+180D, or U+180F--U+1DBF
-identifier-head --> U+1E00--U+1FFF
-identifier-head --> U+200B--U+200D, U+202A--U+202E, U+203F--U+2040, U+2054, or U+2060--U+206F
-identifier-head --> U+2070--U+20CF, U+2100--U+218F, U+2460--U+24FF, or U+2776--U+2793
-identifier-head --> U+2C00--U+2DFF or U+2E80--U+2FFF
-identifier-head --> U+3004--U+3007, U+3021--U+302F, U+3031--U+303F, or U+3040--U+D7FF
-identifier-head --> U+F900--U+FD3D, U+FD40--U+FDCF, U+FDF0--U+FE1F, or U+FE30--U+FE44
-identifier-head --> U+FE47--U+FFFD
-identifier-head --> U+10000--U+1FFFD, U+20000--U+2FFFD, U+30000--U+3FFFD, or U+40000--U+4FFFD
-identifier-head --> U+50000--U+5FFFD, U+60000--U+6FFFD, U+70000--U+7FFFD, or U+80000--U+8FFFD
-identifier-head --> U+90000--U+9FFFD, U+A0000--U+AFFFD, U+B0000--U+BFFFD, or U+C0000--U+CFFFD
-identifier-head --> U+D0000--U+DFFFD or U+E0000--U+EFFFD
-
-identifier-character --> Digit 0 through 9
-identifier-character --> U+0300--U+036F, U+1DC0--U+1DFF, U+20D0--U+20FF, or U+FE20--U+FE2F
-identifier-character --> identifier-head
-identifier-characters --> identifier-character identifier-characters-OPT
-
-implicit-parameter-name --> ``$`` decimal-digits
-property-wrapper-projection --> ``$`` identifier-characters
-```
+> Grammar of an identifier:
+>
+> *identifier* → *identifier-head* *identifier-characters*_?_
+>
+> *identifier* → **`` ` ``** *identifier-head* *identifier-characters*_?_ **`` ` ``**
+>
+> *identifier* → *implicit-parameter-name*
+>
+> *identifier* → *property-wrapper-projection*
+>
+> *identifier-list* → *identifier* | *identifier* **`,`** *identifier-list*
+>
+>
+>
+> *identifier-head* → Upper- or lowercase letter A through Z
+>
+> *identifier-head* → **`_`**
+>
+> *identifier-head* → U+00A8, U+00AA, U+00AD, U+00AF, U+00B2–U+00B5, or U+00B7–U+00BA
+>
+> *identifier-head* → U+00BC–U+00BE, U+00C0–U+00D6, U+00D8–U+00F6, or U+00F8–U+00FF
+>
+> *identifier-head* → U+0100–U+02FF, U+0370–U+167F, U+1681–U+180D, or U+180F–U+1DBF
+>
+> *identifier-head* → U+1E00–U+1FFF
+>
+> *identifier-head* → U+200B–U+200D, U+202A–U+202E, U+203F–U+2040, U+2054, or U+2060–U+206F
+>
+> *identifier-head* → U+2070–U+20CF, U+2100–U+218F, U+2460–U+24FF, or U+2776–U+2793
+>
+> *identifier-head* → U+2C00–U+2DFF or U+2E80–U+2FFF
+>
+> *identifier-head* → U+3004–U+3007, U+3021–U+302F, U+3031–U+303F, or U+3040–U+D7FF
+>
+> *identifier-head* → U+F900–U+FD3D, U+FD40–U+FDCF, U+FDF0–U+FE1F, or U+FE30–U+FE44
+>
+> *identifier-head* → U+FE47–U+FFFD
+>
+> *identifier-head* → U+10000–U+1FFFD, U+20000–U+2FFFD, U+30000–U+3FFFD, or U+40000–U+4FFFD
+>
+> *identifier-head* → U+50000–U+5FFFD, U+60000–U+6FFFD, U+70000–U+7FFFD, or U+80000–U+8FFFD
+>
+> *identifier-head* → U+90000–U+9FFFD, U+A0000–U+AFFFD, U+B0000–U+BFFFD, or U+C0000–U+CFFFD
+>
+> *identifier-head* → U+D0000–U+DFFFD or U+E0000–U+EFFFD
+>
+>
+>
+> *identifier-character* → Digit 0 through 9
+>
+> *identifier-character* → U+0300–U+036F, U+1DC0–U+1DFF, U+20D0–U+20FF, or U+FE20–U+FE2F
+>
+> *identifier-character* → *identifier-head*
+>
+> *identifier-characters* → *identifier-character* *identifier-characters*_?_
+>
+>
+>
+> *implicit-parameter-name* → **`$`** *decimal-digits*
+>
+> *property-wrapper-projection* → **`$`** *identifier-characters*
 
 
 ## Keywords and Punctuation
@@ -464,15 +512,17 @@ in the declaration `let x: Int8 = 42`.
   There is no protocol for regex literal in the list because the stdlib intentionally omits that.
 }
 
-```
-Grammar of a literal
-
-literal --> numeric-literal | string-literal | regular-expression-literal | boolean-literal | nil-literal
-
-numeric-literal --> ``-``-OPT integer-literal | ``-``-OPT floating-point-literal
-boolean-literal --> ``true`` | ``false``
-nil-literal --> ``nil``
-```
+> Grammar of a literal:
+>
+> *literal* → *numeric-literal* | *string-literal* | *regular-expression-literal* | *boolean-literal* | *nil-literal*
+>
+>
+>
+> *numeric-literal* → **`-`**_?_ *integer-literal* | **`-`**_?_ *floating-point-literal*
+>
+> *boolean-literal* → **`true`** | **`false`**
+>
+> *nil-literal* → **`nil`**
 
 
 ### Integer Literals
@@ -521,35 +571,57 @@ as described in <doc:TheBasics#Integers>.
   (Doug confirmed this, 4/2/2014.)
 }
 
-```
-Grammar of an integer literal
-
-integer-literal --> binary-literal
-integer-literal --> octal-literal
-integer-literal --> decimal-literal
-integer-literal --> hexadecimal-literal
-
-binary-literal --> ``0b`` binary-digit binary-literal-characters-OPT
-binary-digit --> Digit 0 or 1
-binary-literal-character --> binary-digit | ``_``
-binary-literal-characters --> binary-literal-character binary-literal-characters-OPT
-
-octal-literal --> ``0o`` octal-digit octal-literal-characters-OPT
-octal-digit --> Digit 0 through 7
-octal-literal-character --> octal-digit | ``_``
-octal-literal-characters --> octal-literal-character octal-literal-characters-OPT
-
-decimal-literal --> decimal-digit decimal-literal-characters-OPT
-decimal-digit --> Digit 0 through 9
-decimal-digits --> decimal-digit decimal-digits-OPT
-decimal-literal-character --> decimal-digit | ``_``
-decimal-literal-characters --> decimal-literal-character decimal-literal-characters-OPT
-
-hexadecimal-literal --> ``0x`` hexadecimal-digit hexadecimal-literal-characters-OPT
-hexadecimal-digit --> Digit 0 through 9, a through f, or A through F
-hexadecimal-literal-character --> hexadecimal-digit | ``_``
-hexadecimal-literal-characters --> hexadecimal-literal-character hexadecimal-literal-characters-OPT
-```
+> Grammar of an integer literal:
+>
+> *integer-literal* → *binary-literal*
+>
+> *integer-literal* → *octal-literal*
+>
+> *integer-literal* → *decimal-literal*
+>
+> *integer-literal* → *hexadecimal-literal*
+>
+>
+>
+> *binary-literal* → **`0b`** *binary-digit* *binary-literal-characters*_?_
+>
+> *binary-digit* → Digit 0 or 1
+>
+> *binary-literal-character* → *binary-digit* | **`_`**
+>
+> *binary-literal-characters* → *binary-literal-character* *binary-literal-characters*_?_
+>
+>
+>
+> *octal-literal* → **`0o`** *octal-digit* *octal-literal-characters*_?_
+>
+> *octal-digit* → Digit 0 through 7
+>
+> *octal-literal-character* → *octal-digit* | **`_`**
+>
+> *octal-literal-characters* → *octal-literal-character* *octal-literal-characters*_?_
+>
+>
+>
+> *decimal-literal* → *decimal-digit* *decimal-literal-characters*_?_
+>
+> *decimal-digit* → Digit 0 through 9
+>
+> *decimal-digits* → *decimal-digit* *decimal-digits*_?_
+>
+> *decimal-literal-character* → *decimal-digit* | **`_`**
+>
+> *decimal-literal-characters* → *decimal-literal-character* *decimal-literal-characters*_?_
+>
+>
+>
+> *hexadecimal-literal* → **`0x`** *hexadecimal-digit* *hexadecimal-literal-characters*_?_
+>
+> *hexadecimal-digit* → Digit 0 through 9, a through f, or A through F
+>
+> *hexadecimal-literal-character* → *hexadecimal-digit* | **`_`**
+>
+> *hexadecimal-literal-characters* → *hexadecimal-literal-character* *hexadecimal-literal-characters*_?_
 
 
 ### Floating-Point Literals
@@ -598,22 +670,31 @@ which represents a 64-bit floating-point number.
 The Swift standard library also defines a `Float` type,
 which represents a 32-bit floating-point number.
 
-```
-Grammar of a floating-point literal
-
-floating-point-literal --> decimal-literal decimal-fraction-OPT decimal-exponent-OPT
-floating-point-literal --> hexadecimal-literal hexadecimal-fraction-OPT hexadecimal-exponent
-
-decimal-fraction --> ``.`` decimal-literal
-decimal-exponent --> floating-point-e sign-OPT decimal-literal
-
-hexadecimal-fraction --> ``.`` hexadecimal-digit hexadecimal-literal-characters-OPT
-hexadecimal-exponent --> floating-point-p sign-OPT decimal-literal
-
-floating-point-e --> ``e`` | ``E``
-floating-point-p --> ``p`` | ``P``
-sign --> ``+`` | ``-``
-```
+> Grammar of a floating-point literal:
+>
+> *floating-point-literal* → *decimal-literal* *decimal-fraction*_?_ *decimal-exponent*_?_
+>
+> *floating-point-literal* → *hexadecimal-literal* *hexadecimal-fraction*_?_ *hexadecimal-exponent*
+>
+>
+>
+> *decimal-fraction* → **`.`** *decimal-literal*
+>
+> *decimal-exponent* → *floating-point-e* *sign*_?_ *decimal-literal*
+>
+>
+>
+> *hexadecimal-fraction* → **`.`** *hexadecimal-digit* *hexadecimal-literal-characters*_?_
+>
+> *hexadecimal-exponent* → *floating-point-p* *sign*_?_ *decimal-literal*
+>
+>
+>
+> *floating-point-e* → **`e`** | **`E`**
+>
+> *floating-point-p* → **`p`** | **`P`**
+>
+> *sign* → **`+`** | **`-`**
 
 
 ### String Literals
@@ -864,46 +945,79 @@ let textB = "Hello world"
   ```
 }
 
-```
-Grammar of a string literal
-
-string-literal --> static-string-literal | interpolated-string-literal
-
-string-literal-opening-delimiter --> extended-string-literal-delimiter-OPT ``"``
-string-literal-closing-delimiter --> ``"`` extended-string-literal-delimiter-OPT
-
-static-string-literal --> string-literal-opening-delimiter quoted-text-OPT string-literal-closing-delimiter
-static-string-literal --> multiline-string-literal-opening-delimiter multiline-quoted-text-OPT multiline-string-literal-closing-delimiter
-
-multiline-string-literal-opening-delimiter --> extended-string-literal-delimiter-OPT ``"""``
-multiline-string-literal-closing-delimiter --> ``"""`` extended-string-literal-delimiter-OPT
-extended-string-literal-delimiter --> ``#`` extended-string-literal-delimiter-OPT
-
-quoted-text --> quoted-text-item quoted-text-OPT
-quoted-text-item --> escaped-character
-quoted-text-item --> Any Unicode scalar value except ``"``, ``\``, U+000A, or U+000D
-
-multiline-quoted-text --> multiline-quoted-text-item multiline-quoted-text-OPT
-multiline-quoted-text-item --> escaped-character
-multiline-quoted-text-item --> Any Unicode scalar value except ``\``
-multiline-quoted-text-item --> escaped-newline
-
-interpolated-string-literal --> string-literal-opening-delimiter interpolated-text-OPT string-literal-closing-delimiter
-interpolated-string-literal --> multiline-string-literal-opening-delimiter multiline-interpolated-text-OPT multiline-string-literal-closing-delimiter
-
-interpolated-text --> interpolated-text-item interpolated-text-OPT
-interpolated-text-item --> ``\(`` expression ``)`` | quoted-text-item
-
-multiline-interpolated-text --> multiline-interpolated-text-item multiline-interpolated-text-OPT
-multiline-interpolated-text-item --> ``\(`` expression ``)`` | multiline-quoted-text-item
-
-escape-sequence --> ``\`` extended-string-literal-delimiter
-escaped-character --> escape-sequence ``0`` | escape-sequence ``\`` | escape-sequence ``t`` | escape-sequence ``n`` | escape-sequence ``r`` | escape-sequence ``"`` | escape-sequence ``'``
-escaped-character -->  escape-sequence ``u`` ``{`` unicode-scalar-digits ``}``
-unicode-scalar-digits --> Between one and eight hexadecimal digits
-
-escaped-newline -->  escape-sequence inline-spaces-OPT line-break
-```
+> Grammar of a string literal:
+>
+> *string-literal* → *static-string-literal* | *interpolated-string-literal*
+>
+>
+>
+> *string-literal-opening-delimiter* → *extended-string-literal-delimiter*_?_ **`"`**
+>
+> *string-literal-closing-delimiter* → **`"`** *extended-string-literal-delimiter*_?_
+>
+>
+>
+> *static-string-literal* → *string-literal-opening-delimiter* *quoted-text*_?_ *string-literal-closing-delimiter*
+>
+> *static-string-literal* → *multiline-string-literal-opening-delimiter* *multiline-quoted-text*_?_ *multiline-string-literal-closing-delimiter*
+>
+>
+>
+> *multiline-string-literal-opening-delimiter* → *extended-string-literal-delimiter*_?_ **`"""`**
+>
+> *multiline-string-literal-closing-delimiter* → **`"""`** *extended-string-literal-delimiter*_?_
+>
+> *extended-string-literal-delimiter* → **`#`** *extended-string-literal-delimiter*_?_
+>
+>
+>
+> *quoted-text* → *quoted-text-item* *quoted-text*_?_
+>
+> *quoted-text-item* → *escaped-character*
+>
+> *quoted-text-item* → Any Unicode scalar value except  **`"`**,  **`\`**, U+000A, or U+000D
+>
+>
+>
+> *multiline-quoted-text* → *multiline-quoted-text-item* *multiline-quoted-text*_?_
+>
+> *multiline-quoted-text-item* → *escaped-character*
+>
+> *multiline-quoted-text-item* → Any Unicode scalar value except  **`\`**
+>
+> *multiline-quoted-text-item* → *escaped-newline*
+>
+>
+>
+> *interpolated-string-literal* → *string-literal-opening-delimiter* *interpolated-text*_?_ *string-literal-closing-delimiter*
+>
+> *interpolated-string-literal* → *multiline-string-literal-opening-delimiter* *multiline-interpolated-text*_?_ *multiline-string-literal-closing-delimiter*
+>
+>
+>
+> *interpolated-text* → *interpolated-text-item* *interpolated-text*_?_
+>
+> *interpolated-text-item* → **`\(`** *expression* **`)`** | *quoted-text-item*
+>
+>
+>
+> *multiline-interpolated-text* → *multiline-interpolated-text-item* *multiline-interpolated-text*_?_
+>
+> *multiline-interpolated-text-item* → **`\(`** *expression* **`)`** | *multiline-quoted-text-item*
+>
+>
+>
+> *escape-sequence* → **`\`** *extended-string-literal-delimiter*
+>
+> *escaped-character* → *escape-sequence* **`0`** | *escape-sequence* **`\`** | *escape-sequence* **`t`** | *escape-sequence* **`n`** | *escape-sequence* **`r`** | *escape-sequence* **`"`** | *escape-sequence* **`'`**
+>
+> *escaped-character* → *escape-sequence* **`u`** **`{`** *unicode-scalar-digits* **`}`**
+>
+> *unicode-scalar-digits* → Between one and eight hexadecimal digits
+>
+>
+>
+> *escaped-newline* → *escape-sequence* *inline-spaces*_?_ *line-break*
 
 
 @Comment {
@@ -1028,17 +1142,21 @@ let regex2 = # #/abc/# #     // Error
 If you need to make an empty regular expression literal,
 you must use the extended delimiter syntax.
 
-```
-Grammar of a regular expression literal
-
-regular-expression-literal --> regular-expression-literal-opening-delimiter regular-expression regular-expression-literal-closing-delimiter
-regular-expression --> Any regular expression
-
-regular-expression-literal-opening-delimiter --> extended-regular-expression-literal-delimiter-OPT ``/``
-regular-expression-literal-closing-delimiter --> ``/`` extended-regular-expression-literal-delimiter-OPT
-
-extended-regular-expression-literal-delimiter --> ``#`` extended-regular-expression-literal-delimiter-OPT
-```
+> Grammar of a regular expression literal:
+>
+> *regular-expression-literal* → *regular-expression-literal-opening-delimiter* *regular-expression* *regular-expression-literal-closing-delimiter*
+>
+> *regular-expression* → Any regular expression
+>
+>
+>
+> *regular-expression-literal-opening-delimiter* → *extended-regular-expression-literal-delimiter*_?_ **`/`**
+>
+> *regular-expression-literal-closing-delimiter* → **`/`** *extended-regular-expression-literal-delimiter*_?_
+>
+>
+>
+> *extended-regular-expression-literal-delimiter* → **`#`** *extended-regular-expression-literal-delimiter*_?_
 
 
 ## Operators
@@ -1204,48 +1322,83 @@ see <doc:AdvancedOperators#Operator-Methods>.
   The current list of reserved punctuation is in Tokens.def.
 }
 
-```
-Grammar of operators
-
-operator --> operator-head operator-characters-OPT
-operator --> dot-operator-head dot-operator-characters
-
-operator-head --> ``/`` | ``=`` | ``-`` | ``+`` | ``!`` | ``*`` | ``%`` | ``<`` | ``>`` | ``&`` | ``|`` | ``^`` | ``~`` | ``?``
-operator-head --> U+00A1--U+00A7
-operator-head --> U+00A9 or U+00AB
-operator-head --> U+00AC or U+00AE
-operator-head --> U+00B0--U+00B1
-operator-head --> U+00B6, U+00BB, U+00BF, U+00D7, or U+00F7
-operator-head --> U+2016--U+2017
-operator-head --> U+2020--U+2027
-operator-head --> U+2030--U+203E
-operator-head --> U+2041--U+2053
-operator-head --> U+2055--U+205E
-operator-head --> U+2190--U+23FF
-operator-head --> U+2500--U+2775
-operator-head --> U+2794--U+2BFF
-operator-head --> U+2E00--U+2E7F
-operator-head --> U+3001--U+3003
-operator-head --> U+3008--U+3020
-operator-head --> U+3030
-
-operator-character --> operator-head
-operator-character --> U+0300--U+036F
-operator-character --> U+1DC0--U+1DFF
-operator-character --> U+20D0--U+20FF
-operator-character --> U+FE00--U+FE0F
-operator-character --> U+FE20--U+FE2F
-operator-character --> U+E0100--U+E01EF
-operator-characters --> operator-character operator-characters-OPT
-
-dot-operator-head --> ``.``
-dot-operator-character --> ``.`` | operator-character
-dot-operator-characters --> dot-operator-character dot-operator-characters-OPT
-
-infix-operator --> operator
-prefix-operator --> operator
-postfix-operator --> operator
-```
+> Grammar of operators:
+>
+> *operator* → *operator-head* *operator-characters*_?_
+>
+> *operator* → *dot-operator-head* *dot-operator-characters*
+>
+>
+>
+> *operator-head* → **`/`** | **`=`** | **`-`** | **`+`** | **`!`** | **`*`** | **`%`** | **`<`** | **`>`** | **`&`** | **`|`** | **`^`** | **`~`** | **`?`**
+>
+> *operator-head* → U+00A1–U+00A7
+>
+> *operator-head* → U+00A9 or U+00AB
+>
+> *operator-head* → U+00AC or U+00AE
+>
+> *operator-head* → U+00B0–U+00B1
+>
+> *operator-head* → U+00B6, U+00BB, U+00BF, U+00D7, or U+00F7
+>
+> *operator-head* → U+2016–U+2017
+>
+> *operator-head* → U+2020–U+2027
+>
+> *operator-head* → U+2030–U+203E
+>
+> *operator-head* → U+2041–U+2053
+>
+> *operator-head* → U+2055–U+205E
+>
+> *operator-head* → U+2190–U+23FF
+>
+> *operator-head* → U+2500–U+2775
+>
+> *operator-head* → U+2794–U+2BFF
+>
+> *operator-head* → U+2E00–U+2E7F
+>
+> *operator-head* → U+3001–U+3003
+>
+> *operator-head* → U+3008–U+3020
+>
+> *operator-head* → U+3030
+>
+>
+>
+> *operator-character* → *operator-head*
+>
+> *operator-character* → U+0300–U+036F
+>
+> *operator-character* → U+1DC0–U+1DFF
+>
+> *operator-character* → U+20D0–U+20FF
+>
+> *operator-character* → U+FE00–U+FE0F
+>
+> *operator-character* → U+FE20–U+FE2F
+>
+> *operator-character* → U+E0100–U+E01EF
+>
+> *operator-characters* → *operator-character* *operator-characters*_?_
+>
+>
+>
+> *dot-operator-head* → **`.`**
+>
+> *dot-operator-character* → **`.`** | *operator-character*
+>
+> *dot-operator-characters* → *dot-operator-character* *dot-operator-characters*_?_
+>
+>
+>
+> *infix-operator* → *operator*
+>
+> *prefix-operator* → *operator*
+>
+> *postfix-operator* → *operator*
 
 
 

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Patterns.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Patterns.md
@@ -31,18 +31,23 @@ statement, a `catch` clause of a `do` statement,
 or in the case condition of an `if`, `while`,
 `guard`, or `for`-`in` statement.
 
-```
-Grammar of a pattern
-
-pattern --> wildcard-pattern type-annotation-OPT
-pattern --> identifier-pattern type-annotation-OPT
-pattern --> value-binding-pattern
-pattern --> tuple-pattern type-annotation-OPT
-pattern --> enum-case-pattern
-pattern --> optional-pattern
-pattern --> type-casting-pattern
-pattern --> expression-pattern
-```
+> Grammar of a pattern:
+>
+> *pattern* → *wildcard-pattern* *type-annotation*_?_
+>
+> *pattern* → *identifier-pattern* *type-annotation*_?_
+>
+> *pattern* → *value-binding-pattern*
+>
+> *pattern* → *tuple-pattern* *type-annotation*_?_
+>
+> *pattern* → *enum-case-pattern*
+>
+> *pattern* → *optional-pattern*
+>
+> *pattern* → *type-casting-pattern*
+>
+> *pattern* → *expression-pattern*
 
 
 ## Wildcard Pattern
@@ -69,11 +74,9 @@ for _ in 1...3 {
   ```
 }
 
-```
-Grammar of a wildcard pattern
-
-wildcard-pattern --> ``_``
-```
+> Grammar of a wildcard pattern:
+>
+> *wildcard-pattern* → **`_`**
 
 
 ## Identifier Pattern
@@ -103,11 +106,9 @@ When the pattern on the left-hand side of a variable or constant declaration
 is an identifier pattern,
 the identifier pattern is implicitly a subpattern of a value-binding pattern.
 
-```
-Grammar of an identifier pattern
-
-identifier-pattern --> identifier
-```
+> Grammar of an identifier pattern:
+>
+> *identifier-pattern* → *identifier*
 
 
 ## Value-Binding Pattern
@@ -151,11 +152,9 @@ In the example above, `let` distributes to each identifier pattern in the
 tuple pattern `(x, y)`. Because of this behavior, the `switch` cases
 `case let (x, y):` and `case (let x, let y):` match the same values.
 
-```
-Grammar of a value-binding pattern
-
-value-binding-pattern --> ``var`` pattern | ``let`` pattern
-```
+> Grammar of a value-binding pattern:
+>
+> *value-binding-pattern* → **`var`** *pattern* | **`let`** *pattern*
 
 
 @Comment {
@@ -248,13 +247,13 @@ let (a): Int = 2 // a: Int = 2
   ```
 }
 
-```
-Grammar of a tuple pattern
-
-tuple-pattern --> ``(`` tuple-pattern-element-list-OPT ``)``
-tuple-pattern-element-list --> tuple-pattern-element | tuple-pattern-element ``,`` tuple-pattern-element-list
-tuple-pattern-element --> pattern | identifier ``:`` pattern
-```
+> Grammar of a tuple pattern:
+>
+> *tuple-pattern* → **`(`** *tuple-pattern-element-list*_?_ **`)`**
+>
+> *tuple-pattern-element-list* → *tuple-pattern-element* | *tuple-pattern-element* **`,`** *tuple-pattern-element-list*
+>
+> *tuple-pattern-element* → *pattern* | *identifier* **`:`** *pattern*
 
 
 ## Enumeration Case Pattern
@@ -311,11 +310,9 @@ case nil:
   ```
 }
 
-```
-Grammar of an enumeration case pattern
-
-enum-case-pattern --> type-identifier-OPT ``.`` enum-case-name tuple-pattern-OPT
-```
+> Grammar of an enumeration case pattern:
+>
+> *enum-case-pattern* → *type-identifier*_?_ **`.`** *enum-case-name* *tuple-pattern*_?_
 
 
 ## Optional Pattern
@@ -393,11 +390,9 @@ for case let number? in arrayOfOptionalInts {
   ```
 }
 
-```
-Grammar of an optional pattern
-
-optional-pattern --> identifier-pattern ``?``
-```
+> Grammar of an optional pattern:
+>
+> *optional-pattern* → *identifier-pattern* **`?`**
 
 
 ## Type-Casting Patterns
@@ -427,13 +422,13 @@ For an example that uses a `switch` statement
 to match values with `is` and `as` patterns,
 see <doc:TypeCasting#Type-Casting-for-Any-and-AnyObject>.
 
-```
-Grammar of a type casting pattern
-
-type-casting-pattern --> is-pattern | as-pattern
-is-pattern --> ``is`` type
-as-pattern --> pattern ``as`` type
-```
+> Grammar of a type casting pattern:
+>
+> *type-casting-pattern* → *is-pattern* | *as-pattern*
+>
+> *is-pattern* → **`is`** *type*
+>
+> *as-pattern* → *pattern* **`as`** *type*
 
 
 ## Expression Pattern
@@ -520,11 +515,9 @@ switch point {
   ```
 }
 
-```
-Grammar of an expression pattern
-
-expression-pattern --> expression
-```
+> Grammar of an expression pattern:
+>
+> *expression-pattern* → *expression*
 
 
 

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Statements.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Statements.md
@@ -22,20 +22,27 @@ and a `defer` statement for running cleanup actions just before the current scop
 A semicolon (`;`) can optionally appear after any statement
 and is used to separate multiple statements if they appear on the same line.
 
-```
-Grammar of a statement
-
-statement --> expression ``;``-OPT
-statement --> declaration ``;``-OPT
-statement --> loop-statement ``;``-OPT
-statement --> branch-statement ``;``-OPT
-statement --> labeled-statement ``;``-OPT
-statement --> control-transfer-statement ``;``-OPT
-statement --> defer-statement ``;``-OPT
-statement --> do-statement ``;``-OPT
-statement --> compiler-control-statement
-statements --> statement statements-OPT
-```
+> Grammar of a statement:
+>
+> *statement* → *expression* **`;`**_?_
+>
+> *statement* → *declaration* **`;`**_?_
+>
+> *statement* → *loop-statement* **`;`**_?_
+>
+> *statement* → *branch-statement* **`;`**_?_
+>
+> *statement* → *labeled-statement* **`;`**_?_
+>
+> *statement* → *control-transfer-statement* **`;`**_?_
+>
+> *statement* → *defer-statement* **`;`**_?_
+>
+> *statement* → *do-statement* **`;`**_?_
+>
+> *statement* → *compiler-control-statement*
+>
+> *statements* → *statement* *statements*_?_
 
 
 @Comment {
@@ -62,13 +69,13 @@ Control flow in a loop statement can be changed by a `break` statement
 and a `continue` statement and is discussed in <doc:Statements#Break-Statement> and
 <doc:Statements#Continue-Statement> below.
 
-```
-Grammar of a loop statement
-
-loop-statement --> for-in-statement
-loop-statement --> while-statement
-loop-statement --> repeat-while-statement
-```
+> Grammar of a loop statement:
+>
+> *loop-statement* → *for-in-statement*
+>
+> *loop-statement* → *while-statement*
+>
+> *loop-statement* → *repeat-while-statement*
 
 
 ### For-In Statement
@@ -100,11 +107,9 @@ and then continues execution at the beginning of the loop.
 Otherwise, the program doesn't perform assignment or execute the *statements*,
 and it's finished executing the `for`-`in` statement.
 
-```
-Grammar of a for-in statement
-
-for-in-statement --> ``for`` ``case``-OPT pattern ``in`` expression where-clause-OPT code-block
-```
+> Grammar of a for-in statement:
+>
+> *for-in-statement* → **`for`** **`case`**_?_ *pattern* **`in`** *expression* *where-clause*_?_ *code-block*
 
 
 ### While Statement
@@ -135,17 +140,21 @@ must be of type `Bool` or a type bridged to `Bool`.
 The condition can also be an optional binding declaration,
 as discussed in <doc:TheBasics#Optional-Binding>.
 
-```
-Grammar of a while statement
-
-while-statement --> ``while`` condition-list code-block
-
-condition-list --> condition | condition ``,`` condition-list
-condition -->  expression | availability-condition | case-condition | optional-binding-condition
-
-case-condition --> ``case`` pattern initializer
-optional-binding-condition --> ``let`` pattern initializer-OPT | ``var`` pattern initializer-OPT
-```
+> Grammar of a while statement:
+>
+> *while-statement* → **`while`** *condition-list* *code-block*
+>
+>
+>
+> *condition-list* → *condition* | *condition* **`,`** *condition-list*
+>
+> *condition* → *expression* | *availability-condition* | *case-condition* | *optional-binding-condition*
+>
+>
+>
+> *case-condition* → **`case`** *pattern* *initializer*
+>
+> *optional-binding-condition* → **`let`** *pattern* *initializer*_?_ | **`var`** *pattern* *initializer*_?_
 
 
 ### Repeat-While Statement
@@ -175,11 +184,9 @@ the *statements* in a `repeat`-`while` statement are executed at least once.
 The value of the *condition*
 must be of type `Bool` or a type bridged to `Bool`.
 
-```
-Grammar of a repeat-while statement
-
-repeat-while-statement --> ``repeat`` code-block ``while`` expression
-```
+> Grammar of a repeat-while statement:
+>
+> *repeat-while-statement* → **`repeat`** *code-block* **`while`** *expression*
 
 
 ## Branch Statements
@@ -194,13 +201,13 @@ an `if` statement, a `guard` statement, and a `switch` statement.
 Control flow in an `if` statement or a `switch` statement can be changed by a `break` statement
 and is discussed in <doc:Statements#Break-Statement> below.
 
-```
-Grammar of a branch statement
-
-branch-statement --> if-statement
-branch-statement --> guard-statement
-branch-statement --> switch-statement
-```
+> Grammar of a branch statement:
+>
+> *branch-statement* → *if-statement*
+>
+> *branch-statement* → *guard-statement*
+>
+> *branch-statement* → *switch-statement*
 
 
 ### If Statement
@@ -256,12 +263,11 @@ must be of type `Bool` or a type bridged to `Bool`.
 The condition can also be an optional binding declaration,
 as discussed in <doc:TheBasics#Optional-Binding>.
 
-```
-Grammar of an if statement
-
-if-statement --> ``if`` condition-list code-block else-clause-OPT
-else-clause --> ``else`` code-block | ``else`` if-statement
-```
+> Grammar of an if statement:
+>
+> *if-statement* → **`if`** *condition-list* *code-block* *else-clause*_?_
+>
+> *else-clause* → **`else`** *code-block* | **`else`** *if-statement*
 
 
 ### Guard Statement
@@ -301,11 +307,9 @@ Control transfer statements are discussed in <doc:Statements#Control-Transfer-St
 For more information on functions with the `Never` return type,
 see <doc:Declarations#Functions-that-Never-Return>.
 
-```
-Grammar of a guard statement
-
-guard-statement --> ``guard`` condition-list ``else`` code-block
-```
+> Grammar of a guard statement:
+>
+> *guard-statement* → **`guard`** *condition-list* **`else`** *code-block*
 
 
 ### Switch Statement
@@ -525,28 +529,43 @@ in the case from which you want execution to continue.
 For more information about the `fallthrough` statement,
 see <doc:Statements#Fallthrough-Statement> below.
 
-```
-Grammar of a switch statement
-
-switch-statement --> ``switch`` expression ``{`` switch-cases-OPT ``}``
-switch-cases --> switch-case switch-cases-OPT
-switch-case --> case-label statements
-switch-case --> default-label statements
-switch-case --> conditional-switch-case
-
-case-label --> attributes-OPT ``case`` case-item-list ``:``
-case-item-list --> pattern where-clause-OPT | pattern where-clause-OPT ``,`` case-item-list
-default-label --> attributes-OPT ``default`` ``:``
-
-where-clause --> ``where`` where-expression
-where-expression --> expression
-
-conditional-switch-case --> switch-if-directive-clause switch-elseif-directive-clauses-OPT switch-else-directive-clause-OPT endif-directive
-switch-if-directive-clause --> if-directive compilation-condition switch-cases-OPT
-switch-elseif-directive-clauses --> elseif-directive-clause switch-elseif-directive-clauses-OPT
-switch-elseif-directive-clause --> elseif-directive compilation-condition switch-cases-OPT
-switch-else-directive-clause --> else-directive switch-cases-OPT
-```
+> Grammar of a switch statement:
+>
+> *switch-statement* → **`switch`** *expression* **`{`** *switch-cases*_?_ **`}`**
+>
+> *switch-cases* → *switch-case* *switch-cases*_?_
+>
+> *switch-case* → *case-label* *statements*
+>
+> *switch-case* → *default-label* *statements*
+>
+> *switch-case* → *conditional-switch-case*
+>
+>
+>
+> *case-label* → *attributes*_?_ **`case`** *case-item-list* **`:`**
+>
+> *case-item-list* → *pattern* *where-clause*_?_ | *pattern* *where-clause*_?_ **`,`** *case-item-list*
+>
+> *default-label* → *attributes*_?_ **`default`** **`:`**
+>
+>
+>
+> *where-clause* → **`where`** *where-expression*
+>
+> *where-expression* → *expression*
+>
+>
+>
+> *conditional-switch-case* → *switch-if-directive-clause* *switch-elseif-directive-clauses*_?_ *switch-else-directive-clause*_?_ *endif-directive*
+>
+> *switch-if-directive-clause* → *if-directive* *compilation-condition* *switch-cases*_?_
+>
+> *switch-elseif-directive-clauses* → *elseif-directive-clause* *switch-elseif-directive-clauses*_?_
+>
+> *switch-elseif-directive-clause* → *elseif-directive* *compilation-condition* *switch-cases*_?_
+>
+> *switch-else-directive-clause* → *else-directive* *switch-cases*_?_
 
 
 @Comment {
@@ -588,17 +607,21 @@ see <doc:ControlFlow#Labeled-Statements> in <doc:ControlFlow>.
   ```
 }
 
-```
-Grammar of a labeled statement
-
-labeled-statement --> statement-label loop-statement
-labeled-statement --> statement-label if-statement
-labeled-statement --> statement-label switch-statement
-labeled-statement --> statement-label do-statement
-
-statement-label --> label-name ``:``
-label-name --> identifier
-```
+> Grammar of a labeled statement:
+>
+> *labeled-statement* → *statement-label* *loop-statement*
+>
+> *labeled-statement* → *statement-label* *if-statement*
+>
+> *labeled-statement* → *statement-label* *switch-statement*
+>
+> *labeled-statement* → *statement-label* *do-statement*
+>
+>
+>
+> *statement-label* → *label-name* **`:`**
+>
+> *label-name* → *identifier*
 
 
 ## Control Transfer Statements
@@ -608,15 +631,17 @@ by unconditionally transferring program control from one piece of code to anothe
 Swift has five control transfer statements: a `break` statement, a `continue` statement,
 a `fallthrough` statement, a `return` statement, and a `throw` statement.
 
-```
-Grammar of a control transfer statement
-
-control-transfer-statement --> break-statement
-control-transfer-statement --> continue-statement
-control-transfer-statement --> fallthrough-statement
-control-transfer-statement --> return-statement
-control-transfer-statement --> throw-statement
-```
+> Grammar of a control transfer statement:
+>
+> *control-transfer-statement* → *break-statement*
+>
+> *control-transfer-statement* → *continue-statement*
+>
+> *control-transfer-statement* → *fallthrough-statement*
+>
+> *control-transfer-statement* → *return-statement*
+>
+> *control-transfer-statement* → *throw-statement*
 
 
 ### Break Statement
@@ -649,11 +674,9 @@ For examples of how to use a `break` statement,
 see <doc:ControlFlow#Break> and <doc:ControlFlow#Labeled-Statements>
 in <doc:ControlFlow>.
 
-```
-Grammar of a break statement
-
-break-statement --> ``break`` label-name-OPT
-```
+> Grammar of a break statement:
+>
+> *break-statement* → **`break`** *label-name*_?_
 
 
 ### Continue Statement
@@ -689,11 +712,9 @@ For examples of how to use a `continue` statement,
 see <doc:ControlFlow#Continue> and <doc:ControlFlow#Labeled-Statements>
 in <doc:ControlFlow>.
 
-```
-Grammar of a continue statement
-
-continue-statement --> ``continue`` label-name-OPT
-```
+> Grammar of a continue statement:
+>
+> *continue-statement* → **`continue`** *label-name*_?_
 
 
 ### Fallthrough Statement
@@ -716,11 +737,9 @@ For an example of how to use a `fallthrough` statement in a `switch` statement,
 see <doc:ControlFlow#Control-Transfer-Statements>
 in <doc:ControlFlow>.
 
-```
-Grammar of a fallthrough statement
-
-fallthrough-statement --> ``fallthrough``
-```
+> Grammar of a fallthrough statement:
+>
+> *fallthrough-statement* → **`fallthrough`**
 
 
 ### Return Statement
@@ -757,11 +776,9 @@ When a `return` statement isn't followed by an expression,
 it can be used only to return from a function or method that doesn't return a value
 (that is, when the return type of the function or method is `Void` or `()`).
 
-```
-Grammar of a return statement
-
-return-statement --> ``return`` expression-OPT
-```
+> Grammar of a return statement:
+>
+> *return-statement* → **`return`** *expression*_?_
 
 
 ### Throw Statement
@@ -789,11 +806,9 @@ For an example of how to use a `throw` statement,
 see <doc:ErrorHandling#Propagating-Errors-Using-Throwing-Functions>
 in <doc:ErrorHandling>.
 
-```
-Grammar of a throw statement
-
-throw-statement --> ``throw`` expression
-```
+> Grammar of a throw statement:
+>
+> *throw-statement* → **`throw`** *expression*
 
 
 ## Defer Statement
@@ -901,11 +916,9 @@ f()
 The statements in the `defer` statement can't
 transfer program control outside of the `defer` statement.
 
-```
-Grammar of a defer statement
-
-defer-statement --> ``defer`` code-block
-```
+> Grammar of a defer statement:
+>
+> *defer-statement* → **`defer`** *code-block*
 
 
 ## Do Statement
@@ -977,15 +990,17 @@ see <doc:Patterns>.
 To see an example of how to use a `do` statement with several `catch` clauses,
 see <doc:ErrorHandling#Handling-Errors>.
 
-```
-Grammar of a do statement
-
-do-statement --> ``do`` code-block catch-clauses-OPT
-catch-clauses --> catch-clause catch-clauses-OPT
-catch-clause --> ``catch`` catch-pattern-list-OPT code-block
-catch-pattern-list --> catch-pattern | catch-pattern ``,`` catch-pattern-list
-catch-pattern --> pattern where-clause-OPT
-```
+> Grammar of a do statement:
+>
+> *do-statement* → **`do`** *code-block* *catch-clauses*_?_
+>
+> *catch-clauses* → *catch-clause* *catch-clauses*_?_
+>
+> *catch-clause* → **`catch`** *catch-pattern-list*_?_ *code-block*
+>
+> *catch-pattern-list* → *catch-pattern* | *catch-pattern* **`,`** *catch-pattern-list*
+>
+> *catch-pattern* → *pattern* *where-clause*_?_
 
 
 ## Compiler Control Statements
@@ -996,13 +1011,13 @@ a conditional compilation block
 a line control statement,
 and a compile-time diagnostic statement.
 
-```
-Grammar of a compiler control statement
-
-compiler-control-statement --> conditional-compilation-block
-compiler-control-statement --> line-control-statement
-compiler-control-statement --> diagnostic-statement
-```
+> Grammar of a compiler control statement:
+>
+> *compiler-control-statement* → *conditional-compilation-block*
+>
+> *compiler-control-statement* → *line-control-statement*
+>
+> *compiler-control-statement* → *diagnostic-statement*
 
 
 ### Conditional Compilation Block
@@ -1257,41 +1272,69 @@ For information about how you can wrap
 explicit member expressions in conditional compilation blocks,
 see <doc:Expressions#Explicit-Member-Expression>.
 
-```
-Grammar of a conditional compilation block
-
-conditional-compilation-block --> if-directive-clause elseif-directive-clauses-OPT else-directive-clause-OPT endif-directive
-
-if-directive-clause --> if-directive compilation-condition statements-OPT
-elseif-directive-clauses --> elseif-directive-clause elseif-directive-clauses-OPT
-elseif-directive-clause --> elseif-directive compilation-condition statements-OPT
-else-directive-clause --> else-directive statements-OPT
-if-directive --> ``#if``
-elseif-directive --> ``#elseif``
-else-directive --> ``#else``
-endif-directive --> ``#endif``
-
-compilation-condition --> platform-condition
-compilation-condition --> identifier
-compilation-condition --> boolean-literal
-compilation-condition --> ``(`` compilation-condition ``)``
-compilation-condition --> ``!`` compilation-condition
-compilation-condition --> compilation-condition ``&&`` compilation-condition
-compilation-condition --> compilation-condition ``||`` compilation-condition
-
-platform-condition --> ``os`` ``(`` operating-system ``)``
-platform-condition --> ``arch`` ``(`` architecture ``)``
-platform-condition --> ``swift`` ``(`` ``>=`` swift-version ``)`` | ``swift`` ``(`` ``<`` swift-version ``)``
-platform-condition --> ``compiler`` ``(`` ``>=`` swift-version ``)`` | ``compiler`` ``(`` ``<`` swift-version ``)``
-platform-condition --> ``canImport`` ``(`` import-path ``)``
-platform-condition --> ``targetEnvironment`` ``(`` environment ``)``
-
-operating-system --> ``macOS`` | ``iOS`` | ``watchOS`` | ``tvOS`` | ``Linux`` | ``Windows``
-architecture --> ``i386`` | ``x86_64`` |  ``arm`` | ``arm64``
-swift-version --> decimal-digits swift-version-continuation-OPT
-swift-version-continuation --> ``.`` decimal-digits swift-version-continuation-OPT
-environment --> ``simulator`` | ``macCatalyst``
-```
+> Grammar of a conditional compilation block:
+>
+> *conditional-compilation-block* → *if-directive-clause* *elseif-directive-clauses*_?_ *else-directive-clause*_?_ *endif-directive*
+>
+>
+>
+> *if-directive-clause* → *if-directive* *compilation-condition* *statements*_?_
+>
+> *elseif-directive-clauses* → *elseif-directive-clause* *elseif-directive-clauses*_?_
+>
+> *elseif-directive-clause* → *elseif-directive* *compilation-condition* *statements*_?_
+>
+> *else-directive-clause* → *else-directive* *statements*_?_
+>
+> *if-directive* → **`#if`**
+>
+> *elseif-directive* → **`#elseif`**
+>
+> *else-directive* → **`#else`**
+>
+> *endif-directive* → **`#endif`**
+>
+>
+>
+> *compilation-condition* → *platform-condition*
+>
+> *compilation-condition* → *identifier*
+>
+> *compilation-condition* → *boolean-literal*
+>
+> *compilation-condition* → **`(`** *compilation-condition* **`)`**
+>
+> *compilation-condition* → **`!`** *compilation-condition*
+>
+> *compilation-condition* → *compilation-condition* **`&&`** *compilation-condition*
+>
+> *compilation-condition* → *compilation-condition* **`||`** *compilation-condition*
+>
+>
+>
+> *platform-condition* → **`os`** **`(`** *operating-system* **`)`**
+>
+> *platform-condition* → **`arch`** **`(`** *architecture* **`)`**
+>
+> *platform-condition* → **`swift`** **`(`** **`>=`** *swift-version* **`)`** | **`swift`** **`(`** **`<`** *swift-version* **`)`**
+>
+> *platform-condition* → **`compiler`** **`(`** **`>=`** *swift-version* **`)`** | **`compiler`** **`(`** **`<`** *swift-version* **`)`**
+>
+> *platform-condition* → **`canImport`** **`(`** *import-path* **`)`**
+>
+> *platform-condition* → **`targetEnvironment`** **`(`** *environment* **`)`**
+>
+>
+>
+> *operating-system* → **`macOS`** | **`iOS`** | **`watchOS`** | **`tvOS`** | **`Linux`** | **`Windows`**
+>
+> *architecture* → **`i386`** | **`x86_64`** | **`arm`** | **`arm64`**
+>
+> *swift-version* → *decimal-digits* *swift-version-continuation*_?_
+>
+> *swift-version-continuation* → **`.`** *decimal-digits* *swift-version-continuation*_?_
+>
+> *environment* → **`simulator`** | **`macCatalyst`**
 
 
 @Comment {
@@ -1338,14 +1381,15 @@ see <doc:Expressions#Literal-Expression>.
 The second form of a line control statement, `#sourceLocation()`,
 resets the source code location back to the default line numbering and file path.
 
-```
-Grammar of a line control statement
-
-line-control-statement --> ``#sourceLocation`` ``(`` ``file:`` file-path ``,`` ``line:`` line-number ``)``
-line-control-statement --> ``#sourceLocation`` ``(`` ``)``
-line-number --> A decimal integer greater than zero
-file-path --> static-string-literal
-```
+> Grammar of a line control statement:
+>
+> *line-control-statement* → **`#sourceLocation`** **`(`** **`file:`** *file-path* **`,`** **`line:`** *line-number* **`)`**
+>
+> *line-control-statement* → **`#sourceLocation`** **`(`** **`)`**
+>
+> *line-number* → A decimal integer greater than zero
+>
+> *file-path* → *static-string-literal*
 
 
 ### Compile-Time Diagnostic Statement
@@ -1369,14 +1413,15 @@ Static string literals can't use features like
 string interpolation or concatenation,
 but they can use the multiline string literal syntax.
 
-```
-Grammar of a compile-time diagnostic statement
-
-diagnostic-statement --> ``#error`` ``(`` diagnostic-message ``)``
-diagnostic-statement --> ``#warning`` ``(`` diagnostic-message ``)``
-
-diagnostic-message --> static-string-literal
-```
+> Grammar of a compile-time diagnostic statement:
+>
+> *diagnostic-statement* → **`#error`** **`(`** *diagnostic-message* **`)`**
+>
+> *diagnostic-statement* → **`#warning`** **`(`** *diagnostic-message* **`)`**
+>
+>
+>
+> *diagnostic-message* → *static-string-literal*
 
 
 @Comment {
@@ -1469,24 +1514,35 @@ In an unavailability condition,
 the `*` argument is implicit and must not be included.
 It has the same meaning as the `*` argument in an availability condition.
 
-```
-Grammar of an availability condition
-
-availability-condition --> ``#available`` ``(`` availability-arguments ``)``
-availability-condition --> ``#unavailable`` ``(`` availability-arguments ``)``
-availability-arguments --> availability-argument | availability-argument ``,`` availability-arguments
-availability-argument --> platform-name platform-version
-availability-argument --> ``*``
-
-platform-name --> ``iOS`` | ``iOSApplicationExtension``
-platform-name --> ``macOS`` | ``macOSApplicationExtension``
-platform-name --> ``macCatalyst`` | ``macCatalystApplicationExtension``
-platform-name --> ``watchOS`` | ``watchOSApplicationExtension``
-platform-name --> ``tvOS`` | ``tvOSApplicationExtension``
-platform-version --> decimal-digits
-platform-version --> decimal-digits ``.`` decimal-digits
-platform-version --> decimal-digits ``.`` decimal-digits ``.`` decimal-digits
-```
+> Grammar of an availability condition:
+>
+> *availability-condition* → **`#available`** **`(`** *availability-arguments* **`)`**
+>
+> *availability-condition* → **`#unavailable`** **`(`** *availability-arguments* **`)`**
+>
+> *availability-arguments* → *availability-argument* | *availability-argument* **`,`** *availability-arguments*
+>
+> *availability-argument* → *platform-name* *platform-version*
+>
+> *availability-argument* → **`*`**
+>
+>
+>
+> *platform-name* → **`iOS`** | **`iOSApplicationExtension`**
+>
+> *platform-name* → **`macOS`** | **`macOSApplicationExtension`**
+>
+> *platform-name* → **`macCatalyst`** | **`macCatalystApplicationExtension`**
+>
+> *platform-name* → **`watchOS`** | **`watchOSApplicationExtension`**
+>
+> *platform-name* → **`tvOS`** | **`tvOSApplicationExtension`**
+>
+> *platform-version* → *decimal-digits*
+>
+> *platform-version* → *decimal-digits* **`.`** *decimal-digits*
+>
+> *platform-version* → *decimal-digits* **`.`** *decimal-digits* **`.`** *decimal-digits*
 
 
 @Comment {

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
@@ -49,9 +49,7 @@
 > *multiline-comment-text-item* → *comment-text-item*
 >
 > *multiline-comment-text-item* → Any Unicode scalar value except  **`/*`** or  **`*/`**
->
->
->
+
 
 > Grammar of an identifier:
 >
@@ -114,9 +112,7 @@
 > *implicit-parameter-name* → **`$`** *decimal-digits*
 >
 > *property-wrapper-projection* → **`$`** *identifier-characters*
->
->
->
+
 
 > Grammar of a literal:
 >
@@ -129,9 +125,7 @@
 > *boolean-literal* → **`true`** | **`false`**
 >
 > *nil-literal* → **`nil`**
->
->
->
+
 
 > Grammar of an integer literal:
 >
@@ -184,9 +178,7 @@
 > *hexadecimal-literal-character* → *hexadecimal-digit* | **`_`**
 >
 > *hexadecimal-literal-characters* → *hexadecimal-literal-character* *hexadecimal-literal-characters*_?_
->
->
->
+
 
 > Grammar of a floating-point literal:
 >
@@ -213,9 +205,7 @@
 > *floating-point-p* → **`p`** | **`P`**
 >
 > *sign* → **`+`** | **`-`**
->
->
->
+
 
 > Grammar of a string literal:
 >
@@ -290,9 +280,7 @@
 >
 >
 > *escaped-newline* → *escape-sequence* *inline-spaces*_?_ *line-break*
->
->
->
+
 
 > Grammar of a regular expression literal:
 >
@@ -309,9 +297,7 @@
 >
 >
 > *extended-regular-expression-literal-delimiter* → **`#`** *extended-regular-expression-literal-delimiter*_?_
->
->
->
+
 
 > Grammar of operators:
 >
@@ -390,9 +376,7 @@
 > *prefix-operator* → *operator*
 >
 > *postfix-operator* → *operator*
->
->
->
+
 
 > Grammar of a type:
 >
@@ -421,25 +405,19 @@
 > *type* → *self-type*
 >
 > *type* → **`(`** *type* **`)`**
->
->
->
+
 
 > Grammar of a type annotation:
 >
 > *type-annotation* → **`:`** *attributes*_?_ **`inout`**_?_ *type*
->
->
->
+
 
 > Grammar of a type identifier:
 >
 > *type-identifier* → *type-name* *generic-argument-clause*_?_ | *type-name* *generic-argument-clause*_?_ **`.`** *type-identifier*
 >
 > *type-name* → *identifier*
->
->
->
+
 
 > Grammar of a tuple type:
 >
@@ -450,9 +428,7 @@
 > *tuple-type-element* → *element-name* *type-annotation* | *type*
 >
 > *element-name* → *identifier*
->
->
->
+
 
 > Grammar of a function type:
 >
@@ -471,122 +447,90 @@
 > *function-type-argument* → *attributes*_?_ **`inout`**_?_ *type* | *argument-label* *type-annotation*
 >
 > *argument-label* → *identifier*
->
->
->
+
 
 > Grammar of an array type:
 >
 > *array-type* → **`[`** *type* **`]`**
->
->
->
+
 
 > Grammar of a dictionary type:
 >
 > *dictionary-type* → **`[`** *type* **`:`** *type* **`]`**
->
->
->
+
 
 > Grammar of an optional type:
 >
 > *optional-type* → *type* **`?`**
->
->
->
+
 
 > Grammar of an implicitly unwrapped optional type:
 >
 > *implicitly-unwrapped-optional-type* → *type* **`!`**
->
->
->
+
 
 > Grammar of a protocol composition type:
 >
 > *protocol-composition-type* → *type-identifier* **`&`** *protocol-composition-continuation*
 >
 > *protocol-composition-continuation* → *type-identifier* | *protocol-composition-type*
->
->
->
+
 
 > Grammar of an opaque type:
 >
 > *opaque-type* → **`some`** *type*
->
->
->
+
 
 > Grammar of a metatype type:
 >
 > *metatype-type* → *type* **`.`** **`Type`** | *type* **`.`** **`Protocol`**
->
->
->
+
 
 > Grammar of an Any type:
 >
 > *any-type* → **`Any`**
->
->
->
+
 
 > Grammar of a Self type:
 >
 > *self-type* → **`Self`**
->
->
->
+
 
 > Grammar of a type inheritance clause:
 >
 > *type-inheritance-clause* → **`:`** *type-inheritance-list*
 >
 > *type-inheritance-list* → *attributes*_?_ *type-identifier* | *attributes*_?_ *type-identifier* **`,`** *type-inheritance-list*
->
->
->
+
 
 > Grammar of an expression:
 >
 > *expression* → *try-operator*_?_ *await-operator*_?_ *prefix-expression* *infix-expressions*_?_
 >
 > *expression-list* → *expression* | *expression* **`,`** *expression-list*
->
->
->
+
 
 > Grammar of a prefix expression:
 >
 > *prefix-expression* → *prefix-operator*_?_ *postfix-expression*
 >
 > *prefix-expression* → *in-out-expression*
->
->
->
+
 
 > Grammar of an in-out expression:
 >
 > *in-out-expression* → **`&`** *identifier*
->
->
->
+
 
 > Grammar of a try expression:
 >
 > *try-operator* → **`try`** | **`try`** **`?`** | **`try`** **`!`**
->
->
->
+
 
 > Grammar of an await expression:
 >
 > *await-operator* → **`await`**
->
->
->
+
 
 > Grammar of an infix expression:
 >
@@ -599,23 +543,17 @@
 > *infix-expression* → *type-casting-operator*
 >
 > *infix-expressions* → *infix-expression* *infix-expressions*_?_
->
->
->
+
 
 > Grammar of an assignment operator:
 >
 > *assignment-operator* → **`=`**
->
->
->
+
 
 > Grammar of a conditional operator:
 >
 > *conditional-operator* → **`?`** *expression* **`:`**
->
->
->
+
 
 > Grammar of a type-casting operator:
 >
@@ -626,9 +564,7 @@
 > *type-casting-operator* → **`as`** **`?`** *type*
 >
 > *type-casting-operator* → **`as`** **`!`** *type*
->
->
->
+
 
 > Grammar of a primary expression:
 >
@@ -655,9 +591,7 @@
 > *primary-expression* → *selector-expression*
 >
 > *primary-expression* → *key-path-string-expression*
->
->
->
+
 
 > Grammar of a literal expression:
 >
@@ -692,9 +626,7 @@
 > *playground-literal* → **`#fileLiteral`** **`(`** **`resourceName`** **`:`** *expression* **`)`**
 >
 > *playground-literal* → **`#imageLiteral`** **`(`** **`resourceName`** **`:`** *expression* **`)`**
->
->
->
+
 
 > Grammar of a self expression:
 >
@@ -707,9 +639,7 @@
 > *self-subscript-expression* → **`self`** **`[`** *function-call-argument-list* **`]`**
 >
 > *self-initializer-expression* → **`self`** **`.`** **`init`**
->
->
->
+
 
 > Grammar of a superclass expression:
 >
@@ -722,9 +652,7 @@
 > *superclass-subscript-expression* → **`super`** **`[`** *function-call-argument-list* **`]`**
 >
 > *superclass-initializer-expression* → **`super`** **`.`** **`init`**
->
->
->
+
 
 > Grammar of a closure expression:
 >
@@ -761,25 +689,19 @@
 > *capture-list-item* → *capture-specifier*_?_ *self-expression*
 >
 > *capture-specifier* → **`weak`** | **`unowned`** | **`unowned(safe)`** | **`unowned(unsafe)`**
->
->
->
+
 
 > Grammar of a implicit member expression:
 >
 > *implicit-member-expression* → **`.`** *identifier*
 >
 > *implicit-member-expression* → **`.`** *identifier* **`.`** *postfix-expression*
->
->
->
+
 
 > Grammar of a parenthesized expression:
 >
 > *parenthesized-expression* → **`(`** *expression* **`)`**
->
->
->
+
 
 > Grammar of a tuple expression:
 >
@@ -788,16 +710,12 @@
 > *tuple-element-list* → *tuple-element* | *tuple-element* **`,`** *tuple-element-list*
 >
 > *tuple-element* → *expression* | *identifier* **`:`** *expression*
->
->
->
+
 
 > Grammar of a wildcard expression:
 >
 > *wildcard-expression* → **`_`**
->
->
->
+
 
 > Grammar of a key-path expression:
 >
@@ -812,9 +730,7 @@
 > *key-path-postfixes* → *key-path-postfix* *key-path-postfixes*_?_
 >
 > *key-path-postfix* → **`?`** | **`!`** | **`self`** | **`[`** *function-call-argument-list* **`]`**
->
->
->
+
 
 > Grammar of a selector expression:
 >
@@ -823,16 +739,12 @@
 > *selector-expression* → **`#selector`** **`(`** **`getter:`** *expression* **`)`**
 >
 > *selector-expression* → **`#selector`** **`(`** **`setter:`** *expression* **`)`**
->
->
->
+
 
 > Grammar of a key-path string expression:
 >
 > *key-path-string-expression* → **`#keyPath`** **`(`** *expression* **`)`**
->
->
->
+
 
 > Grammar of a postfix expression:
 >
@@ -853,9 +765,7 @@
 > *postfix-expression* → *forced-value-expression*
 >
 > *postfix-expression* → *optional-chaining-expression*
->
->
->
+
 
 > Grammar of a function call expression:
 >
@@ -880,18 +790,14 @@
 > *labeled-trailing-closures* → *labeled-trailing-closure* *labeled-trailing-closures*_?_
 >
 > *labeled-trailing-closure* → *identifier* **`:`** *closure-expression*
->
->
->
+
 
 > Grammar of an initializer expression:
 >
 > *initializer-expression* → *postfix-expression* **`.`** **`init`**
 >
 > *initializer-expression* → *postfix-expression* **`.`** **`init`** **`(`** *argument-names* **`)`**
->
->
->
+
 
 > Grammar of an explicit member expression:
 >
@@ -908,37 +814,27 @@
 > *argument-names* → *argument-name* *argument-names*_?_
 >
 > *argument-name* → *identifier* **`:`**
->
->
->
+
 
 > Grammar of a postfix self expression:
 >
 > *postfix-self-expression* → *postfix-expression* **`.`** **`self`**
->
->
->
+
 
 > Grammar of a subscript expression:
 >
 > *subscript-expression* → *postfix-expression* **`[`** *function-call-argument-list* **`]`**
->
->
->
+
 
 > Grammar of a forced-value expression:
 >
 > *forced-value-expression* → *postfix-expression* **`!`**
->
->
->
+
 
 > Grammar of an optional-chaining expression:
 >
 > *optional-chaining-expression* → *postfix-expression* **`?`**
->
->
->
+
 
 > Grammar of a statement:
 >
@@ -961,9 +857,7 @@
 > *statement* → *compiler-control-statement*
 >
 > *statements* → *statement* *statements*_?_
->
->
->
+
 
 > Grammar of a loop statement:
 >
@@ -972,16 +866,12 @@
 > *loop-statement* → *while-statement*
 >
 > *loop-statement* → *repeat-while-statement*
->
->
->
+
 
 > Grammar of a for-in statement:
 >
 > *for-in-statement* → **`for`** **`case`**_?_ *pattern* **`in`** *expression* *where-clause*_?_ *code-block*
->
->
->
+
 
 > Grammar of a while statement:
 >
@@ -998,16 +888,12 @@
 > *case-condition* → **`case`** *pattern* *initializer*
 >
 > *optional-binding-condition* → **`let`** *pattern* *initializer*_?_ | **`var`** *pattern* *initializer*_?_
->
->
->
+
 
 > Grammar of a repeat-while statement:
 >
 > *repeat-while-statement* → **`repeat`** *code-block* **`while`** *expression*
->
->
->
+
 
 > Grammar of a branch statement:
 >
@@ -1016,25 +902,19 @@
 > *branch-statement* → *guard-statement*
 >
 > *branch-statement* → *switch-statement*
->
->
->
+
 
 > Grammar of an if statement:
 >
 > *if-statement* → **`if`** *condition-list* *code-block* *else-clause*_?_
 >
 > *else-clause* → **`else`** *code-block* | **`else`** *if-statement*
->
->
->
+
 
 > Grammar of a guard statement:
 >
 > *guard-statement* → **`guard`** *condition-list* **`else`** *code-block*
->
->
->
+
 
 > Grammar of a switch statement:
 >
@@ -1073,9 +953,7 @@
 > *switch-elseif-directive-clause* → *elseif-directive* *compilation-condition* *switch-cases*_?_
 >
 > *switch-else-directive-clause* → *else-directive* *switch-cases*_?_
->
->
->
+
 
 > Grammar of a labeled statement:
 >
@@ -1092,9 +970,7 @@
 > *statement-label* → *label-name* **`:`**
 >
 > *label-name* → *identifier*
->
->
->
+
 
 > Grammar of a control transfer statement:
 >
@@ -1107,51 +983,37 @@
 > *control-transfer-statement* → *return-statement*
 >
 > *control-transfer-statement* → *throw-statement*
->
->
->
+
 
 > Grammar of a break statement:
 >
 > *break-statement* → **`break`** *label-name*_?_
->
->
->
+
 
 > Grammar of a continue statement:
 >
 > *continue-statement* → **`continue`** *label-name*_?_
->
->
->
+
 
 > Grammar of a fallthrough statement:
 >
 > *fallthrough-statement* → **`fallthrough`**
->
->
->
+
 
 > Grammar of a return statement:
 >
 > *return-statement* → **`return`** *expression*_?_
->
->
->
+
 
 > Grammar of a throw statement:
 >
 > *throw-statement* → **`throw`** *expression*
->
->
->
+
 
 > Grammar of a defer statement:
 >
 > *defer-statement* → **`defer`** *code-block*
->
->
->
+
 
 > Grammar of a do statement:
 >
@@ -1164,9 +1026,7 @@
 > *catch-pattern-list* → *catch-pattern* | *catch-pattern* **`,`** *catch-pattern-list*
 >
 > *catch-pattern* → *pattern* *where-clause*_?_
->
->
->
+
 
 > Grammar of a compiler control statement:
 >
@@ -1175,9 +1035,7 @@
 > *compiler-control-statement* → *line-control-statement*
 >
 > *compiler-control-statement* → *diagnostic-statement*
->
->
->
+
 
 > Grammar of a conditional compilation block:
 >
@@ -1242,9 +1100,7 @@
 > *swift-version-continuation* → **`.`** *decimal-digits* *swift-version-continuation*_?_
 >
 > *environment* → **`simulator`** | **`macCatalyst`**
->
->
->
+
 
 > Grammar of a line control statement:
 >
@@ -1255,9 +1111,7 @@
 > *line-number* → A decimal integer greater than zero
 >
 > *file-path* → *static-string-literal*
->
->
->
+
 
 > Grammar of a compile-time diagnostic statement:
 >
@@ -1268,9 +1122,7 @@
 >
 >
 > *diagnostic-message* → *static-string-literal*
->
->
->
+
 
 > Grammar of an availability condition:
 >
@@ -1301,9 +1153,7 @@
 > *platform-version* → *decimal-digits* **`.`** *decimal-digits*
 >
 > *platform-version* → *decimal-digits* **`.`** *decimal-digits* **`.`** *decimal-digits*
->
->
->
+
 
 > Grammar of a declaration:
 >
@@ -1340,23 +1190,17 @@
 > *declaration* → *precedence-group-declaration*
 >
 > *declarations* → *declaration* *declarations*_?_
->
->
->
+
 
 > Grammar of a top-level declaration:
 >
 > *top-level-declaration* → *statements*_?_
->
->
->
+
 
 > Grammar of a code block:
 >
 > *code-block* → **`{`** *statements*_?_ **`}`**
->
->
->
+
 
 > Grammar of an import declaration:
 >
@@ -1367,9 +1211,7 @@
 > *import-kind* → **`typealias`** | **`struct`** | **`class`** | **`enum`** | **`protocol`** | **`let`** | **`var`** | **`func`**
 >
 > *import-path* → *identifier* | *identifier* **`.`** *import-path*
->
->
->
+
 
 > Grammar of a constant declaration:
 >
@@ -1382,9 +1224,7 @@
 > *pattern-initializer* → *pattern* *initializer*_?_
 >
 > *initializer* → **`=`** *expression*
->
->
->
+
 
 > Grammar of a variable declaration:
 >
@@ -1439,9 +1279,7 @@
 > *willSet-clause* → *attributes*_?_ **`willSet`** *setter-name*_?_ *code-block*
 >
 > *didSet-clause* → *attributes*_?_ **`didSet`** *setter-name*_?_ *code-block*
->
->
->
+
 
 > Grammar of a type alias declaration:
 >
@@ -1450,9 +1288,7 @@
 > *typealias-name* → *identifier*
 >
 > *typealias-assignment* → **`=`** *type*
->
->
->
+
 
 > Grammar of a function declaration:
 >
@@ -1491,9 +1327,7 @@
 > *local-parameter-name* → *identifier*
 >
 > *default-argument-clause* → **`=`** *expression*
->
->
->
+
 
 > Grammar of an enumeration declaration:
 >
@@ -1536,9 +1370,7 @@
 > *raw-value-assignment* → **`=`** *raw-value-literal*
 >
 > *raw-value-literal* → *numeric-literal* | *static-string-literal* | *boolean-literal*
->
->
->
+
 
 > Grammar of a structure declaration:
 >
@@ -1553,9 +1385,7 @@
 > *struct-members* → *struct-member* *struct-members*_?_
 >
 > *struct-member* → *declaration* | *compiler-control-statement*
->
->
->
+
 
 > Grammar of a class declaration:
 >
@@ -1572,9 +1402,7 @@
 > *class-members* → *class-member* *class-members*_?_
 >
 > *class-member* → *declaration* | *compiler-control-statement*
->
->
->
+
 
 > Grammar of an actor declaration:
 >
@@ -1589,9 +1417,7 @@
 > *actor-members* → *actor-member* *actor-members*_?_
 >
 > *actor-member* → *declaration* | *compiler-control-statement*
->
->
->
+
 
 > Grammar of a protocol declaration:
 >
@@ -1620,46 +1446,34 @@
 > *protocol-member-declaration* → *protocol-associated-type-declaration*
 >
 > *protocol-member-declaration* → *typealias-declaration*
->
->
->
+
 
 > Grammar of a protocol property declaration:
 >
 > *protocol-property-declaration* → *variable-declaration-head* *variable-name* *type-annotation* *getter-setter-keyword-block*
->
->
->
+
 
 > Grammar of a protocol method declaration:
 >
 > *protocol-method-declaration* → *function-head* *function-name* *generic-parameter-clause*_?_ *function-signature* *generic-where-clause*_?_
->
->
->
+
 
 > Grammar of a protocol initializer declaration:
 >
 > *protocol-initializer-declaration* → *initializer-head* *generic-parameter-clause*_?_ *parameter-clause* **`throws`**_?_ *generic-where-clause*_?_
 >
 > *protocol-initializer-declaration* → *initializer-head* *generic-parameter-clause*_?_ *parameter-clause* **`rethrows`** *generic-where-clause*_?_
->
->
->
+
 
 > Grammar of a protocol subscript declaration:
 >
 > *protocol-subscript-declaration* → *subscript-head* *subscript-result* *generic-where-clause*_?_ *getter-setter-keyword-block*
->
->
->
+
 
 > Grammar of a protocol associated type declaration:
 >
 > *protocol-associated-type-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`associatedtype`** *typealias-name* *type-inheritance-clause*_?_ *typealias-assignment*_?_ *generic-where-clause*_?_
->
->
->
+
 
 > Grammar of an initializer declaration:
 >
@@ -1674,16 +1488,12 @@
 > *initializer-head* → *attributes*_?_ *declaration-modifiers*_?_ **`init`** **`!`**
 >
 > *initializer-body* → *code-block*
->
->
->
+
 
 > Grammar of a deinitializer declaration:
 >
 > *deinitializer-declaration* → *attributes*_?_ **`deinit`** *code-block*
->
->
->
+
 
 > Grammar of an extension declaration:
 >
@@ -1696,9 +1506,7 @@
 > *extension-members* → *extension-member* *extension-members*_?_
 >
 > *extension-member* → *declaration* | *compiler-control-statement*
->
->
->
+
 
 > Grammar of a subscript declaration:
 >
@@ -1711,9 +1519,7 @@
 > *subscript-head* → *attributes*_?_ *declaration-modifiers*_?_ **`subscript`** *generic-parameter-clause*_?_ *parameter-clause*
 >
 > *subscript-result* → **`->`** *attributes*_?_ *type*
->
->
->
+
 
 > Grammar of an operator declaration:
 >
@@ -1730,9 +1536,7 @@
 >
 >
 > *infix-operator-group* → **`:`** *precedence-group-name*
->
->
->
+
 
 > Grammar of a precedence group declaration:
 >
@@ -1771,9 +1575,7 @@
 > *precedence-group-names* → *precedence-group-name* | *precedence-group-name* **`,`** *precedence-group-names*
 >
 > *precedence-group-name* → *identifier*
->
->
->
+
 
 > Grammar of a declaration modifier:
 >
@@ -1806,9 +1608,7 @@
 >
 >
 > *actor-isolation-modifier* → **`nonisolated`**
->
->
->
+
 
 > Grammar of an attribute:
 >
@@ -1833,9 +1633,6 @@
 > *balanced-token* → Any identifier, keyword, literal, or operator
 >
 > *balanced-token* → Any punctuation except  **`(`**,  **`)`**,  **`[`**,  **`]`**,  **`{`**, or  **`}`**
->
->
->
 
 > Grammar of a pattern:
 >
@@ -1854,30 +1651,22 @@
 > *pattern* → *type-casting-pattern*
 >
 > *pattern* → *expression-pattern*
->
->
->
+
 
 > Grammar of a wildcard pattern:
 >
 > *wildcard-pattern* → **`_`**
->
->
->
+
 
 > Grammar of an identifier pattern:
 >
 > *identifier-pattern* → *identifier*
->
->
->
+
 
 > Grammar of a value-binding pattern:
 >
 > *value-binding-pattern* → **`var`** *pattern* | **`let`** *pattern*
->
->
->
+
 
 > Grammar of a tuple pattern:
 >
@@ -1886,23 +1675,17 @@
 > *tuple-pattern-element-list* → *tuple-pattern-element* | *tuple-pattern-element* **`,`** *tuple-pattern-element-list*
 >
 > *tuple-pattern-element* → *pattern* | *identifier* **`:`** *pattern*
->
->
->
+
 
 > Grammar of an enumeration case pattern:
 >
 > *enum-case-pattern* → *type-identifier*_?_ **`.`** *enum-case-name* *tuple-pattern*_?_
->
->
->
+
 
 > Grammar of an optional pattern:
 >
 > *optional-pattern* → *identifier-pattern* **`?`**
->
->
->
+
 
 > Grammar of a type casting pattern:
 >
@@ -1911,16 +1694,12 @@
 > *is-pattern* → **`is`** *type*
 >
 > *as-pattern* → *pattern* **`as`** *type*
->
->
->
+
 
 > Grammar of an expression pattern:
 >
 > *expression-pattern* → *expression*
->
->
->
+
 
 > Grammar of a generic parameter clause:
 >
@@ -1949,9 +1728,7 @@
 > *conformance-requirement* → *type-identifier* **`:`** *protocol-composition-type*
 >
 > *same-type-requirement* → *type-identifier* **`==`** *type*
->
->
->
+
 
 > Grammar of a generic argument clause:
 >
@@ -1960,9 +1737,7 @@
 > *generic-argument-list* → *generic-argument* | *generic-argument* **`,`** *generic-argument-list*
 >
 > *generic-argument* → *type*
->
->
->
+
 
 
 @Comment {

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
@@ -1,0 +1,1976 @@
+# Summary of the Grammar
+
+> Grammar of whitespace:
+>
+> *whitespace* → *whitespace-item* *whitespace*_?_
+>
+> *whitespace-item* → *line-break*
+>
+> *whitespace-item* → *inline-space*
+>
+> *whitespace-item* → *comment*
+>
+> *whitespace-item* → *multiline-comment*
+>
+> *whitespace-item* → U+0000, U+000B, or U+000C
+>
+>
+>
+> *line-break* → U+000A
+>
+> *line-break* → U+000D
+>
+> *line-break* → U+000D followed by U+000A
+>
+>
+>
+> *inline-spaces* → *inline-space* *inline-spaces*_?_
+>
+> *inline-space* → U+0009 or U+0020
+>
+>
+>
+> *comment* → **`//`** *comment-text* *line-break*
+>
+> *multiline-comment* → **`/*`** *multiline-comment-text* **`*/`**
+>
+>
+>
+> *comment-text* → *comment-text-item* *comment-text*_?_
+>
+> *comment-text-item* → Any Unicode scalar value except U+000A or U+000D
+>
+>
+>
+> *multiline-comment-text* → *multiline-comment-text-item* *multiline-comment-text*_?_
+>
+> *multiline-comment-text-item* → *multiline-comment*
+>
+> *multiline-comment-text-item* → *comment-text-item*
+>
+> *multiline-comment-text-item* → Any Unicode scalar value except  **`/*`** or  **`*/`**
+>
+>
+>
+
+> Grammar of an identifier:
+>
+> *identifier* → *identifier-head* *identifier-characters*_?_
+>
+> *identifier* → **`` ` ``** *identifier-head* *identifier-characters*_?_ **`` ` ``**
+>
+> *identifier* → *implicit-parameter-name*
+>
+> *identifier* → *property-wrapper-projection*
+>
+> *identifier-list* → *identifier* | *identifier* **`,`** *identifier-list*
+>
+>
+>
+> *identifier-head* → Upper- or lowercase letter A through Z
+>
+> *identifier-head* → **`_`**
+>
+> *identifier-head* → U+00A8, U+00AA, U+00AD, U+00AF, U+00B2–U+00B5, or U+00B7–U+00BA
+>
+> *identifier-head* → U+00BC–U+00BE, U+00C0–U+00D6, U+00D8–U+00F6, or U+00F8–U+00FF
+>
+> *identifier-head* → U+0100–U+02FF, U+0370–U+167F, U+1681–U+180D, or U+180F–U+1DBF
+>
+> *identifier-head* → U+1E00–U+1FFF
+>
+> *identifier-head* → U+200B–U+200D, U+202A–U+202E, U+203F–U+2040, U+2054, or U+2060–U+206F
+>
+> *identifier-head* → U+2070–U+20CF, U+2100–U+218F, U+2460–U+24FF, or U+2776–U+2793
+>
+> *identifier-head* → U+2C00–U+2DFF or U+2E80–U+2FFF
+>
+> *identifier-head* → U+3004–U+3007, U+3021–U+302F, U+3031–U+303F, or U+3040–U+D7FF
+>
+> *identifier-head* → U+F900–U+FD3D, U+FD40–U+FDCF, U+FDF0–U+FE1F, or U+FE30–U+FE44
+>
+> *identifier-head* → U+FE47–U+FFFD
+>
+> *identifier-head* → U+10000–U+1FFFD, U+20000–U+2FFFD, U+30000–U+3FFFD, or U+40000–U+4FFFD
+>
+> *identifier-head* → U+50000–U+5FFFD, U+60000–U+6FFFD, U+70000–U+7FFFD, or U+80000–U+8FFFD
+>
+> *identifier-head* → U+90000–U+9FFFD, U+A0000–U+AFFFD, U+B0000–U+BFFFD, or U+C0000–U+CFFFD
+>
+> *identifier-head* → U+D0000–U+DFFFD or U+E0000–U+EFFFD
+>
+>
+>
+> *identifier-character* → Digit 0 through 9
+>
+> *identifier-character* → U+0300–U+036F, U+1DC0–U+1DFF, U+20D0–U+20FF, or U+FE20–U+FE2F
+>
+> *identifier-character* → *identifier-head*
+>
+> *identifier-characters* → *identifier-character* *identifier-characters*_?_
+>
+>
+>
+> *implicit-parameter-name* → **`$`** *decimal-digits*
+>
+> *property-wrapper-projection* → **`$`** *identifier-characters*
+>
+>
+>
+
+> Grammar of a literal:
+>
+> *literal* → *numeric-literal* | *string-literal* | *regular-expression-literal* | *boolean-literal* | *nil-literal*
+>
+>
+>
+> *numeric-literal* → **`-`**_?_ *integer-literal* | **`-`**_?_ *floating-point-literal*
+>
+> *boolean-literal* → **`true`** | **`false`**
+>
+> *nil-literal* → **`nil`**
+>
+>
+>
+
+> Grammar of an integer literal:
+>
+> *integer-literal* → *binary-literal*
+>
+> *integer-literal* → *octal-literal*
+>
+> *integer-literal* → *decimal-literal*
+>
+> *integer-literal* → *hexadecimal-literal*
+>
+>
+>
+> *binary-literal* → **`0b`** *binary-digit* *binary-literal-characters*_?_
+>
+> *binary-digit* → Digit 0 or 1
+>
+> *binary-literal-character* → *binary-digit* | **`_`**
+>
+> *binary-literal-characters* → *binary-literal-character* *binary-literal-characters*_?_
+>
+>
+>
+> *octal-literal* → **`0o`** *octal-digit* *octal-literal-characters*_?_
+>
+> *octal-digit* → Digit 0 through 7
+>
+> *octal-literal-character* → *octal-digit* | **`_`**
+>
+> *octal-literal-characters* → *octal-literal-character* *octal-literal-characters*_?_
+>
+>
+>
+> *decimal-literal* → *decimal-digit* *decimal-literal-characters*_?_
+>
+> *decimal-digit* → Digit 0 through 9
+>
+> *decimal-digits* → *decimal-digit* *decimal-digits*_?_
+>
+> *decimal-literal-character* → *decimal-digit* | **`_`**
+>
+> *decimal-literal-characters* → *decimal-literal-character* *decimal-literal-characters*_?_
+>
+>
+>
+> *hexadecimal-literal* → **`0x`** *hexadecimal-digit* *hexadecimal-literal-characters*_?_
+>
+> *hexadecimal-digit* → Digit 0 through 9, a through f, or A through F
+>
+> *hexadecimal-literal-character* → *hexadecimal-digit* | **`_`**
+>
+> *hexadecimal-literal-characters* → *hexadecimal-literal-character* *hexadecimal-literal-characters*_?_
+>
+>
+>
+
+> Grammar of a floating-point literal:
+>
+> *floating-point-literal* → *decimal-literal* *decimal-fraction*_?_ *decimal-exponent*_?_
+>
+> *floating-point-literal* → *hexadecimal-literal* *hexadecimal-fraction*_?_ *hexadecimal-exponent*
+>
+>
+>
+> *decimal-fraction* → **`.`** *decimal-literal*
+>
+> *decimal-exponent* → *floating-point-e* *sign*_?_ *decimal-literal*
+>
+>
+>
+> *hexadecimal-fraction* → **`.`** *hexadecimal-digit* *hexadecimal-literal-characters*_?_
+>
+> *hexadecimal-exponent* → *floating-point-p* *sign*_?_ *decimal-literal*
+>
+>
+>
+> *floating-point-e* → **`e`** | **`E`**
+>
+> *floating-point-p* → **`p`** | **`P`**
+>
+> *sign* → **`+`** | **`-`**
+>
+>
+>
+
+> Grammar of a string literal:
+>
+> *string-literal* → *static-string-literal* | *interpolated-string-literal*
+>
+>
+>
+> *string-literal-opening-delimiter* → *extended-string-literal-delimiter*_?_ **`"`**
+>
+> *string-literal-closing-delimiter* → **`"`** *extended-string-literal-delimiter*_?_
+>
+>
+>
+> *static-string-literal* → *string-literal-opening-delimiter* *quoted-text*_?_ *string-literal-closing-delimiter*
+>
+> *static-string-literal* → *multiline-string-literal-opening-delimiter* *multiline-quoted-text*_?_ *multiline-string-literal-closing-delimiter*
+>
+>
+>
+> *multiline-string-literal-opening-delimiter* → *extended-string-literal-delimiter*_?_ **`"""`**
+>
+> *multiline-string-literal-closing-delimiter* → **`"""`** *extended-string-literal-delimiter*_?_
+>
+> *extended-string-literal-delimiter* → **`#`** *extended-string-literal-delimiter*_?_
+>
+>
+>
+> *quoted-text* → *quoted-text-item* *quoted-text*_?_
+>
+> *quoted-text-item* → *escaped-character*
+>
+> *quoted-text-item* → Any Unicode scalar value except  **`"`**,  **`\`**, U+000A, or U+000D
+>
+>
+>
+> *multiline-quoted-text* → *multiline-quoted-text-item* *multiline-quoted-text*_?_
+>
+> *multiline-quoted-text-item* → *escaped-character*
+>
+> *multiline-quoted-text-item* → Any Unicode scalar value except  **`\`**
+>
+> *multiline-quoted-text-item* → *escaped-newline*
+>
+>
+>
+> *interpolated-string-literal* → *string-literal-opening-delimiter* *interpolated-text*_?_ *string-literal-closing-delimiter*
+>
+> *interpolated-string-literal* → *multiline-string-literal-opening-delimiter* *multiline-interpolated-text*_?_ *multiline-string-literal-closing-delimiter*
+>
+>
+>
+> *interpolated-text* → *interpolated-text-item* *interpolated-text*_?_
+>
+> *interpolated-text-item* → **`\(`** *expression* **`)`** | *quoted-text-item*
+>
+>
+>
+> *multiline-interpolated-text* → *multiline-interpolated-text-item* *multiline-interpolated-text*_?_
+>
+> *multiline-interpolated-text-item* → **`\(`** *expression* **`)`** | *multiline-quoted-text-item*
+>
+>
+>
+> *escape-sequence* → **`\`** *extended-string-literal-delimiter*
+>
+> *escaped-character* → *escape-sequence* **`0`** | *escape-sequence* **`\`** | *escape-sequence* **`t`** | *escape-sequence* **`n`** | *escape-sequence* **`r`** | *escape-sequence* **`"`** | *escape-sequence* **`'`**
+>
+> *escaped-character* → *escape-sequence* **`u`** **`{`** *unicode-scalar-digits* **`}`**
+>
+> *unicode-scalar-digits* → Between one and eight hexadecimal digits
+>
+>
+>
+> *escaped-newline* → *escape-sequence* *inline-spaces*_?_ *line-break*
+>
+>
+>
+
+> Grammar of a regular expression literal:
+>
+> *regular-expression-literal* → *regular-expression-literal-opening-delimiter* *regular-expression* *regular-expression-literal-closing-delimiter*
+>
+> *regular-expression* → Any regular expression
+>
+>
+>
+> *regular-expression-literal-opening-delimiter* → *extended-regular-expression-literal-delimiter*_?_ **`/`**
+>
+> *regular-expression-literal-closing-delimiter* → **`/`** *extended-regular-expression-literal-delimiter*_?_
+>
+>
+>
+> *extended-regular-expression-literal-delimiter* → **`#`** *extended-regular-expression-literal-delimiter*_?_
+>
+>
+>
+
+> Grammar of operators:
+>
+> *operator* → *operator-head* *operator-characters*_?_
+>
+> *operator* → *dot-operator-head* *dot-operator-characters*
+>
+>
+>
+> *operator-head* → **`/`** | **`=`** | **`-`** | **`+`** | **`!`** | **`*`** | **`%`** | **`<`** | **`>`** | **`&`** | **`|`** | **`^`** | **`~`** | **`?`**
+>
+> *operator-head* → U+00A1–U+00A7
+>
+> *operator-head* → U+00A9 or U+00AB
+>
+> *operator-head* → U+00AC or U+00AE
+>
+> *operator-head* → U+00B0–U+00B1
+>
+> *operator-head* → U+00B6, U+00BB, U+00BF, U+00D7, or U+00F7
+>
+> *operator-head* → U+2016–U+2017
+>
+> *operator-head* → U+2020–U+2027
+>
+> *operator-head* → U+2030–U+203E
+>
+> *operator-head* → U+2041–U+2053
+>
+> *operator-head* → U+2055–U+205E
+>
+> *operator-head* → U+2190–U+23FF
+>
+> *operator-head* → U+2500–U+2775
+>
+> *operator-head* → U+2794–U+2BFF
+>
+> *operator-head* → U+2E00–U+2E7F
+>
+> *operator-head* → U+3001–U+3003
+>
+> *operator-head* → U+3008–U+3020
+>
+> *operator-head* → U+3030
+>
+>
+>
+> *operator-character* → *operator-head*
+>
+> *operator-character* → U+0300–U+036F
+>
+> *operator-character* → U+1DC0–U+1DFF
+>
+> *operator-character* → U+20D0–U+20FF
+>
+> *operator-character* → U+FE00–U+FE0F
+>
+> *operator-character* → U+FE20–U+FE2F
+>
+> *operator-character* → U+E0100–U+E01EF
+>
+> *operator-characters* → *operator-character* *operator-characters*_?_
+>
+>
+>
+> *dot-operator-head* → **`.`**
+>
+> *dot-operator-character* → **`.`** | *operator-character*
+>
+> *dot-operator-characters* → *dot-operator-character* *dot-operator-characters*_?_
+>
+>
+>
+> *infix-operator* → *operator*
+>
+> *prefix-operator* → *operator*
+>
+> *postfix-operator* → *operator*
+>
+>
+>
+
+> Grammar of a type:
+>
+> *type* → *function-type*
+>
+> *type* → *array-type*
+>
+> *type* → *dictionary-type*
+>
+> *type* → *type-identifier*
+>
+> *type* → *tuple-type*
+>
+> *type* → *optional-type*
+>
+> *type* → *implicitly-unwrapped-optional-type*
+>
+> *type* → *protocol-composition-type*
+>
+> *type* → *opaque-type*
+>
+> *type* → *metatype-type*
+>
+> *type* → *any-type*
+>
+> *type* → *self-type*
+>
+> *type* → **`(`** *type* **`)`**
+>
+>
+>
+
+> Grammar of a type annotation:
+>
+> *type-annotation* → **`:`** *attributes*_?_ **`inout`**_?_ *type*
+>
+>
+>
+
+> Grammar of a type identifier:
+>
+> *type-identifier* → *type-name* *generic-argument-clause*_?_ | *type-name* *generic-argument-clause*_?_ **`.`** *type-identifier*
+>
+> *type-name* → *identifier*
+>
+>
+>
+
+> Grammar of a tuple type:
+>
+> *tuple-type* → **`(`** **`)`** | **`(`** *tuple-type-element* **`,`** *tuple-type-element-list* **`)`**
+>
+> *tuple-type-element-list* → *tuple-type-element* | *tuple-type-element* **`,`** *tuple-type-element-list*
+>
+> *tuple-type-element* → *element-name* *type-annotation* | *type*
+>
+> *element-name* → *identifier*
+>
+>
+>
+
+> Grammar of a function type:
+>
+> *function-type* → *attributes*_?_ *function-type-argument-clause* **`async`**_?_ **`throws`**_?_ **`->`** *type*
+>
+>
+>
+> *function-type-argument-clause* → **`(`** **`)`**
+>
+> *function-type-argument-clause* → **`(`** *function-type-argument-list* **`...`**_?_ **`)`**
+>
+>
+>
+> *function-type-argument-list* → *function-type-argument* | *function-type-argument* **`,`** *function-type-argument-list*
+>
+> *function-type-argument* → *attributes*_?_ **`inout`**_?_ *type* | *argument-label* *type-annotation*
+>
+> *argument-label* → *identifier*
+>
+>
+>
+
+> Grammar of an array type:
+>
+> *array-type* → **`[`** *type* **`]`**
+>
+>
+>
+
+> Grammar of a dictionary type:
+>
+> *dictionary-type* → **`[`** *type* **`:`** *type* **`]`**
+>
+>
+>
+
+> Grammar of an optional type:
+>
+> *optional-type* → *type* **`?`**
+>
+>
+>
+
+> Grammar of an implicitly unwrapped optional type:
+>
+> *implicitly-unwrapped-optional-type* → *type* **`!`**
+>
+>
+>
+
+> Grammar of a protocol composition type:
+>
+> *protocol-composition-type* → *type-identifier* **`&`** *protocol-composition-continuation*
+>
+> *protocol-composition-continuation* → *type-identifier* | *protocol-composition-type*
+>
+>
+>
+
+> Grammar of an opaque type:
+>
+> *opaque-type* → **`some`** *type*
+>
+>
+>
+
+> Grammar of a metatype type:
+>
+> *metatype-type* → *type* **`.`** **`Type`** | *type* **`.`** **`Protocol`**
+>
+>
+>
+
+> Grammar of an Any type:
+>
+> *any-type* → **`Any`**
+>
+>
+>
+
+> Grammar of a Self type:
+>
+> *self-type* → **`Self`**
+>
+>
+>
+
+> Grammar of a type inheritance clause:
+>
+> *type-inheritance-clause* → **`:`** *type-inheritance-list*
+>
+> *type-inheritance-list* → *attributes*_?_ *type-identifier* | *attributes*_?_ *type-identifier* **`,`** *type-inheritance-list*
+>
+>
+>
+
+> Grammar of an expression:
+>
+> *expression* → *try-operator*_?_ *await-operator*_?_ *prefix-expression* *infix-expressions*_?_
+>
+> *expression-list* → *expression* | *expression* **`,`** *expression-list*
+>
+>
+>
+
+> Grammar of a prefix expression:
+>
+> *prefix-expression* → *prefix-operator*_?_ *postfix-expression*
+>
+> *prefix-expression* → *in-out-expression*
+>
+>
+>
+
+> Grammar of an in-out expression:
+>
+> *in-out-expression* → **`&`** *identifier*
+>
+>
+>
+
+> Grammar of a try expression:
+>
+> *try-operator* → **`try`** | **`try`** **`?`** | **`try`** **`!`**
+>
+>
+>
+
+> Grammar of an await expression:
+>
+> *await-operator* → **`await`**
+>
+>
+>
+
+> Grammar of an infix expression:
+>
+> *infix-expression* → *infix-operator* *prefix-expression*
+>
+> *infix-expression* → *assignment-operator* *try-operator*_?_ *prefix-expression*
+>
+> *infix-expression* → *conditional-operator* *try-operator*_?_ *prefix-expression*
+>
+> *infix-expression* → *type-casting-operator*
+>
+> *infix-expressions* → *infix-expression* *infix-expressions*_?_
+>
+>
+>
+
+> Grammar of an assignment operator:
+>
+> *assignment-operator* → **`=`**
+>
+>
+>
+
+> Grammar of a conditional operator:
+>
+> *conditional-operator* → **`?`** *expression* **`:`**
+>
+>
+>
+
+> Grammar of a type-casting operator:
+>
+> *type-casting-operator* → **`is`** *type*
+>
+> *type-casting-operator* → **`as`** *type*
+>
+> *type-casting-operator* → **`as`** **`?`** *type*
+>
+> *type-casting-operator* → **`as`** **`!`** *type*
+>
+>
+>
+
+> Grammar of a primary expression:
+>
+> *primary-expression* → *identifier* *generic-argument-clause*_?_
+>
+> *primary-expression* → *literal-expression*
+>
+> *primary-expression* → *self-expression*
+>
+> *primary-expression* → *superclass-expression*
+>
+> *primary-expression* → *closure-expression*
+>
+> *primary-expression* → *parenthesized-expression*
+>
+> *primary-expression* → *tuple-expression*
+>
+> *primary-expression* → *implicit-member-expression*
+>
+> *primary-expression* → *wildcard-expression*
+>
+> *primary-expression* → *key-path-expression*
+>
+> *primary-expression* → *selector-expression*
+>
+> *primary-expression* → *key-path-string-expression*
+>
+>
+>
+
+> Grammar of a literal expression:
+>
+> *literal-expression* → *literal*
+>
+> *literal-expression* → *array-literal* | *dictionary-literal* | *playground-literal*
+>
+> *literal-expression* → **`#file`** | **`#fileID`** | **`#filePath`**
+>
+> *literal-expression* → **`#line`** | **`#column`** | **`#function`** | **`#dsohandle`**
+>
+>
+>
+> *array-literal* → **`[`** *array-literal-items*_?_ **`]`**
+>
+> *array-literal-items* → *array-literal-item* **`,`**_?_ | *array-literal-item* **`,`** *array-literal-items*
+>
+> *array-literal-item* → *expression*
+>
+>
+>
+> *dictionary-literal* → **`[`** *dictionary-literal-items* **`]`** | **`[`** **`:`** **`]`**
+>
+> *dictionary-literal-items* → *dictionary-literal-item* **`,`**_?_ | *dictionary-literal-item* **`,`** *dictionary-literal-items*
+>
+> *dictionary-literal-item* → *expression* **`:`** *expression*
+>
+>
+>
+> *playground-literal* → **`#colorLiteral`** **`(`** **`red`** **`:`** *expression* **`,`** **`green`** **`:`** *expression* **`,`** **`blue`** **`:`** *expression* **`,`** **`alpha`** **`:`** *expression* **`)`**
+>
+> *playground-literal* → **`#fileLiteral`** **`(`** **`resourceName`** **`:`** *expression* **`)`**
+>
+> *playground-literal* → **`#imageLiteral`** **`(`** **`resourceName`** **`:`** *expression* **`)`**
+>
+>
+>
+
+> Grammar of a self expression:
+>
+> *self-expression* → **`self`** | *self-method-expression* | *self-subscript-expression* | *self-initializer-expression*
+>
+>
+>
+> *self-method-expression* → **`self`** **`.`** *identifier*
+>
+> *self-subscript-expression* → **`self`** **`[`** *function-call-argument-list* **`]`**
+>
+> *self-initializer-expression* → **`self`** **`.`** **`init`**
+>
+>
+>
+
+> Grammar of a superclass expression:
+>
+> *superclass-expression* → *superclass-method-expression* | *superclass-subscript-expression* | *superclass-initializer-expression*
+>
+>
+>
+> *superclass-method-expression* → **`super`** **`.`** *identifier*
+>
+> *superclass-subscript-expression* → **`super`** **`[`** *function-call-argument-list* **`]`**
+>
+> *superclass-initializer-expression* → **`super`** **`.`** **`init`**
+>
+>
+>
+
+> Grammar of a closure expression:
+>
+> *closure-expression* → **`{`** *attributes*_?_ *closure-signature*_?_ *statements*_?_ **`}`**
+>
+>
+>
+> *closure-signature* → *capture-list*_?_ *closure-parameter-clause* **`async`**_?_ **`throws`**_?_ *function-result*_?_ **`in`**
+>
+> *closure-signature* → *capture-list* **`in`**
+>
+>
+>
+> *closure-parameter-clause* → **`(`** **`)`** | **`(`** *closure-parameter-list* **`)`** | *identifier-list*
+>
+> *closure-parameter-list* → *closure-parameter* | *closure-parameter* **`,`** *closure-parameter-list*
+>
+> *closure-parameter* → *closure-parameter-name* *type-annotation*_?_
+>
+> *closure-parameter* → *closure-parameter-name* *type-annotation* **`...`**
+>
+> *closure-parameter-name* → *identifier*
+>
+>
+>
+> *capture-list* → **`[`** *capture-list-items* **`]`**
+>
+> *capture-list-items* → *capture-list-item* | *capture-list-item* **`,`** *capture-list-items*
+>
+> *capture-list-item* → *capture-specifier*_?_ *identifier*
+>
+> *capture-list-item* → *capture-specifier*_?_ *identifier* **`=`** *expression*
+>
+> *capture-list-item* → *capture-specifier*_?_ *self-expression*
+>
+> *capture-specifier* → **`weak`** | **`unowned`** | **`unowned(safe)`** | **`unowned(unsafe)`**
+>
+>
+>
+
+> Grammar of a implicit member expression:
+>
+> *implicit-member-expression* → **`.`** *identifier*
+>
+> *implicit-member-expression* → **`.`** *identifier* **`.`** *postfix-expression*
+>
+>
+>
+
+> Grammar of a parenthesized expression:
+>
+> *parenthesized-expression* → **`(`** *expression* **`)`**
+>
+>
+>
+
+> Grammar of a tuple expression:
+>
+> *tuple-expression* → **`(`** **`)`** | **`(`** *tuple-element* **`,`** *tuple-element-list* **`)`**
+>
+> *tuple-element-list* → *tuple-element* | *tuple-element* **`,`** *tuple-element-list*
+>
+> *tuple-element* → *expression* | *identifier* **`:`** *expression*
+>
+>
+>
+
+> Grammar of a wildcard expression:
+>
+> *wildcard-expression* → **`_`**
+>
+>
+>
+
+> Grammar of a key-path expression:
+>
+> *key-path-expression* → **`\`** *type*_?_ **`.`** *key-path-components*
+>
+> *key-path-components* → *key-path-component* | *key-path-component* **`.`** *key-path-components*
+>
+> *key-path-component* → *identifier* *key-path-postfixes*_?_ | *key-path-postfixes*
+>
+>
+>
+> *key-path-postfixes* → *key-path-postfix* *key-path-postfixes*_?_
+>
+> *key-path-postfix* → **`?`** | **`!`** | **`self`** | **`[`** *function-call-argument-list* **`]`**
+>
+>
+>
+
+> Grammar of a selector expression:
+>
+> *selector-expression* → **`#selector`** **`(`** *expression* **`)`**
+>
+> *selector-expression* → **`#selector`** **`(`** **`getter:`** *expression* **`)`**
+>
+> *selector-expression* → **`#selector`** **`(`** **`setter:`** *expression* **`)`**
+>
+>
+>
+
+> Grammar of a key-path string expression:
+>
+> *key-path-string-expression* → **`#keyPath`** **`(`** *expression* **`)`**
+>
+>
+>
+
+> Grammar of a postfix expression:
+>
+> *postfix-expression* → *primary-expression*
+>
+> *postfix-expression* → *postfix-expression* *postfix-operator*
+>
+> *postfix-expression* → *function-call-expression*
+>
+> *postfix-expression* → *initializer-expression*
+>
+> *postfix-expression* → *explicit-member-expression*
+>
+> *postfix-expression* → *postfix-self-expression*
+>
+> *postfix-expression* → *subscript-expression*
+>
+> *postfix-expression* → *forced-value-expression*
+>
+> *postfix-expression* → *optional-chaining-expression*
+>
+>
+>
+
+> Grammar of a function call expression:
+>
+> *function-call-expression* → *postfix-expression* *function-call-argument-clause*
+>
+> *function-call-expression* → *postfix-expression* *function-call-argument-clause*_?_ *trailing-closures*
+>
+>
+>
+> *function-call-argument-clause* → **`(`** **`)`** | **`(`** *function-call-argument-list* **`)`**
+>
+> *function-call-argument-list* → *function-call-argument* | *function-call-argument* **`,`** *function-call-argument-list*
+>
+> *function-call-argument* → *expression* | *identifier* **`:`** *expression*
+>
+> *function-call-argument* → *operator* | *identifier* **`:`** *operator*
+>
+>
+>
+> *trailing-closures* → *closure-expression* *labeled-trailing-closures*_?_
+>
+> *labeled-trailing-closures* → *labeled-trailing-closure* *labeled-trailing-closures*_?_
+>
+> *labeled-trailing-closure* → *identifier* **`:`** *closure-expression*
+>
+>
+>
+
+> Grammar of an initializer expression:
+>
+> *initializer-expression* → *postfix-expression* **`.`** **`init`**
+>
+> *initializer-expression* → *postfix-expression* **`.`** **`init`** **`(`** *argument-names* **`)`**
+>
+>
+>
+
+> Grammar of an explicit member expression:
+>
+> *explicit-member-expression* → *postfix-expression* **`.`** *decimal-digits*
+>
+> *explicit-member-expression* → *postfix-expression* **`.`** *identifier* *generic-argument-clause*_?_
+>
+> *explicit-member-expression* → *postfix-expression* **`.`** *identifier* **`(`** *argument-names* **`)`**
+>
+> *explicit-member-expression* → *postfix-expression* *conditional-compilation-block*
+>
+>
+>
+> *argument-names* → *argument-name* *argument-names*_?_
+>
+> *argument-name* → *identifier* **`:`**
+>
+>
+>
+
+> Grammar of a postfix self expression:
+>
+> *postfix-self-expression* → *postfix-expression* **`.`** **`self`**
+>
+>
+>
+
+> Grammar of a subscript expression:
+>
+> *subscript-expression* → *postfix-expression* **`[`** *function-call-argument-list* **`]`**
+>
+>
+>
+
+> Grammar of a forced-value expression:
+>
+> *forced-value-expression* → *postfix-expression* **`!`**
+>
+>
+>
+
+> Grammar of an optional-chaining expression:
+>
+> *optional-chaining-expression* → *postfix-expression* **`?`**
+>
+>
+>
+
+> Grammar of a statement:
+>
+> *statement* → *expression* **`;`**_?_
+>
+> *statement* → *declaration* **`;`**_?_
+>
+> *statement* → *loop-statement* **`;`**_?_
+>
+> *statement* → *branch-statement* **`;`**_?_
+>
+> *statement* → *labeled-statement* **`;`**_?_
+>
+> *statement* → *control-transfer-statement* **`;`**_?_
+>
+> *statement* → *defer-statement* **`;`**_?_
+>
+> *statement* → *do-statement* **`;`**_?_
+>
+> *statement* → *compiler-control-statement*
+>
+> *statements* → *statement* *statements*_?_
+>
+>
+>
+
+> Grammar of a loop statement:
+>
+> *loop-statement* → *for-in-statement*
+>
+> *loop-statement* → *while-statement*
+>
+> *loop-statement* → *repeat-while-statement*
+>
+>
+>
+
+> Grammar of a for-in statement:
+>
+> *for-in-statement* → **`for`** **`case`**_?_ *pattern* **`in`** *expression* *where-clause*_?_ *code-block*
+>
+>
+>
+
+> Grammar of a while statement:
+>
+> *while-statement* → **`while`** *condition-list* *code-block*
+>
+>
+>
+> *condition-list* → *condition* | *condition* **`,`** *condition-list*
+>
+> *condition* → *expression* | *availability-condition* | *case-condition* | *optional-binding-condition*
+>
+>
+>
+> *case-condition* → **`case`** *pattern* *initializer*
+>
+> *optional-binding-condition* → **`let`** *pattern* *initializer*_?_ | **`var`** *pattern* *initializer*_?_
+>
+>
+>
+
+> Grammar of a repeat-while statement:
+>
+> *repeat-while-statement* → **`repeat`** *code-block* **`while`** *expression*
+>
+>
+>
+
+> Grammar of a branch statement:
+>
+> *branch-statement* → *if-statement*
+>
+> *branch-statement* → *guard-statement*
+>
+> *branch-statement* → *switch-statement*
+>
+>
+>
+
+> Grammar of an if statement:
+>
+> *if-statement* → **`if`** *condition-list* *code-block* *else-clause*_?_
+>
+> *else-clause* → **`else`** *code-block* | **`else`** *if-statement*
+>
+>
+>
+
+> Grammar of a guard statement:
+>
+> *guard-statement* → **`guard`** *condition-list* **`else`** *code-block*
+>
+>
+>
+
+> Grammar of a switch statement:
+>
+> *switch-statement* → **`switch`** *expression* **`{`** *switch-cases*_?_ **`}`**
+>
+> *switch-cases* → *switch-case* *switch-cases*_?_
+>
+> *switch-case* → *case-label* *statements*
+>
+> *switch-case* → *default-label* *statements*
+>
+> *switch-case* → *conditional-switch-case*
+>
+>
+>
+> *case-label* → *attributes*_?_ **`case`** *case-item-list* **`:`**
+>
+> *case-item-list* → *pattern* *where-clause*_?_ | *pattern* *where-clause*_?_ **`,`** *case-item-list*
+>
+> *default-label* → *attributes*_?_ **`default`** **`:`**
+>
+>
+>
+> *where-clause* → **`where`** *where-expression*
+>
+> *where-expression* → *expression*
+>
+>
+>
+> *conditional-switch-case* → *switch-if-directive-clause* *switch-elseif-directive-clauses*_?_ *switch-else-directive-clause*_?_ *endif-directive*
+>
+> *switch-if-directive-clause* → *if-directive* *compilation-condition* *switch-cases*_?_
+>
+> *switch-elseif-directive-clauses* → *elseif-directive-clause* *switch-elseif-directive-clauses*_?_
+>
+> *switch-elseif-directive-clause* → *elseif-directive* *compilation-condition* *switch-cases*_?_
+>
+> *switch-else-directive-clause* → *else-directive* *switch-cases*_?_
+>
+>
+>
+
+> Grammar of a labeled statement:
+>
+> *labeled-statement* → *statement-label* *loop-statement*
+>
+> *labeled-statement* → *statement-label* *if-statement*
+>
+> *labeled-statement* → *statement-label* *switch-statement*
+>
+> *labeled-statement* → *statement-label* *do-statement*
+>
+>
+>
+> *statement-label* → *label-name* **`:`**
+>
+> *label-name* → *identifier*
+>
+>
+>
+
+> Grammar of a control transfer statement:
+>
+> *control-transfer-statement* → *break-statement*
+>
+> *control-transfer-statement* → *continue-statement*
+>
+> *control-transfer-statement* → *fallthrough-statement*
+>
+> *control-transfer-statement* → *return-statement*
+>
+> *control-transfer-statement* → *throw-statement*
+>
+>
+>
+
+> Grammar of a break statement:
+>
+> *break-statement* → **`break`** *label-name*_?_
+>
+>
+>
+
+> Grammar of a continue statement:
+>
+> *continue-statement* → **`continue`** *label-name*_?_
+>
+>
+>
+
+> Grammar of a fallthrough statement:
+>
+> *fallthrough-statement* → **`fallthrough`**
+>
+>
+>
+
+> Grammar of a return statement:
+>
+> *return-statement* → **`return`** *expression*_?_
+>
+>
+>
+
+> Grammar of a throw statement:
+>
+> *throw-statement* → **`throw`** *expression*
+>
+>
+>
+
+> Grammar of a defer statement:
+>
+> *defer-statement* → **`defer`** *code-block*
+>
+>
+>
+
+> Grammar of a do statement:
+>
+> *do-statement* → **`do`** *code-block* *catch-clauses*_?_
+>
+> *catch-clauses* → *catch-clause* *catch-clauses*_?_
+>
+> *catch-clause* → **`catch`** *catch-pattern-list*_?_ *code-block*
+>
+> *catch-pattern-list* → *catch-pattern* | *catch-pattern* **`,`** *catch-pattern-list*
+>
+> *catch-pattern* → *pattern* *where-clause*_?_
+>
+>
+>
+
+> Grammar of a compiler control statement:
+>
+> *compiler-control-statement* → *conditional-compilation-block*
+>
+> *compiler-control-statement* → *line-control-statement*
+>
+> *compiler-control-statement* → *diagnostic-statement*
+>
+>
+>
+
+> Grammar of a conditional compilation block:
+>
+> *conditional-compilation-block* → *if-directive-clause* *elseif-directive-clauses*_?_ *else-directive-clause*_?_ *endif-directive*
+>
+>
+>
+> *if-directive-clause* → *if-directive* *compilation-condition* *statements*_?_
+>
+> *elseif-directive-clauses* → *elseif-directive-clause* *elseif-directive-clauses*_?_
+>
+> *elseif-directive-clause* → *elseif-directive* *compilation-condition* *statements*_?_
+>
+> *else-directive-clause* → *else-directive* *statements*_?_
+>
+> *if-directive* → **`#if`**
+>
+> *elseif-directive* → **`#elseif`**
+>
+> *else-directive* → **`#else`**
+>
+> *endif-directive* → **`#endif`**
+>
+>
+>
+> *compilation-condition* → *platform-condition*
+>
+> *compilation-condition* → *identifier*
+>
+> *compilation-condition* → *boolean-literal*
+>
+> *compilation-condition* → **`(`** *compilation-condition* **`)`**
+>
+> *compilation-condition* → **`!`** *compilation-condition*
+>
+> *compilation-condition* → *compilation-condition* **`&&`** *compilation-condition*
+>
+> *compilation-condition* → *compilation-condition* **`||`** *compilation-condition*
+>
+>
+>
+> *platform-condition* → **`os`** **`(`** *operating-system* **`)`**
+>
+> *platform-condition* → **`arch`** **`(`** *architecture* **`)`**
+>
+> *platform-condition* → **`swift`** **`(`** **`>=`** *swift-version* **`)`** | **`swift`** **`(`** **`<`** *swift-version* **`)`**
+>
+> *platform-condition* → **`compiler`** **`(`** **`>=`** *swift-version* **`)`** | **`compiler`** **`(`** **`<`** *swift-version* **`)`**
+>
+> *platform-condition* → **`canImport`** **`(`** *import-path* **`)`**
+>
+> *platform-condition* → **`targetEnvironment`** **`(`** *environment* **`)`**
+>
+>
+>
+> *operating-system* → **`macOS`** | **`iOS`** | **`watchOS`** | **`tvOS`** | **`Linux`** | **`Windows`**
+>
+> *architecture* → **`i386`** | **`x86_64`** | **`arm`** | **`arm64`**
+>
+> *swift-version* → *decimal-digits* *swift-version-continuation*_?_
+>
+> *swift-version-continuation* → **`.`** *decimal-digits* *swift-version-continuation*_?_
+>
+> *environment* → **`simulator`** | **`macCatalyst`**
+>
+>
+>
+
+> Grammar of a line control statement:
+>
+> *line-control-statement* → **`#sourceLocation`** **`(`** **`file:`** *file-path* **`,`** **`line:`** *line-number* **`)`**
+>
+> *line-control-statement* → **`#sourceLocation`** **`(`** **`)`**
+>
+> *line-number* → A decimal integer greater than zero
+>
+> *file-path* → *static-string-literal*
+>
+>
+>
+
+> Grammar of a compile-time diagnostic statement:
+>
+> *diagnostic-statement* → **`#error`** **`(`** *diagnostic-message* **`)`**
+>
+> *diagnostic-statement* → **`#warning`** **`(`** *diagnostic-message* **`)`**
+>
+>
+>
+> *diagnostic-message* → *static-string-literal*
+>
+>
+>
+
+> Grammar of an availability condition:
+>
+> *availability-condition* → **`#available`** **`(`** *availability-arguments* **`)`**
+>
+> *availability-condition* → **`#unavailable`** **`(`** *availability-arguments* **`)`**
+>
+> *availability-arguments* → *availability-argument* | *availability-argument* **`,`** *availability-arguments*
+>
+> *availability-argument* → *platform-name* *platform-version*
+>
+> *availability-argument* → **`*`**
+>
+>
+>
+> *platform-name* → **`iOS`** | **`iOSApplicationExtension`**
+>
+> *platform-name* → **`macOS`** | **`macOSApplicationExtension`**
+>
+> *platform-name* → **`macCatalyst`** | **`macCatalystApplicationExtension`**
+>
+> *platform-name* → **`watchOS`** | **`watchOSApplicationExtension`**
+>
+> *platform-name* → **`tvOS`** | **`tvOSApplicationExtension`**
+>
+> *platform-version* → *decimal-digits*
+>
+> *platform-version* → *decimal-digits* **`.`** *decimal-digits*
+>
+> *platform-version* → *decimal-digits* **`.`** *decimal-digits* **`.`** *decimal-digits*
+>
+>
+>
+
+> Grammar of a declaration:
+>
+> *declaration* → *import-declaration*
+>
+> *declaration* → *constant-declaration*
+>
+> *declaration* → *variable-declaration*
+>
+> *declaration* → *typealias-declaration*
+>
+> *declaration* → *function-declaration*
+>
+> *declaration* → *enum-declaration*
+>
+> *declaration* → *struct-declaration*
+>
+> *declaration* → *class-declaration*
+>
+> *declaration* → *actor-declaration*
+>
+> *declaration* → *protocol-declaration*
+>
+> *declaration* → *initializer-declaration*
+>
+> *declaration* → *deinitializer-declaration*
+>
+> *declaration* → *extension-declaration*
+>
+> *declaration* → *subscript-declaration*
+>
+> *declaration* → *operator-declaration*
+>
+> *declaration* → *precedence-group-declaration*
+>
+> *declarations* → *declaration* *declarations*_?_
+>
+>
+>
+
+> Grammar of a top-level declaration:
+>
+> *top-level-declaration* → *statements*_?_
+>
+>
+>
+
+> Grammar of a code block:
+>
+> *code-block* → **`{`** *statements*_?_ **`}`**
+>
+>
+>
+
+> Grammar of an import declaration:
+>
+> *import-declaration* → *attributes*_?_ **`import`** *import-kind*_?_ *import-path*
+>
+>
+>
+> *import-kind* → **`typealias`** | **`struct`** | **`class`** | **`enum`** | **`protocol`** | **`let`** | **`var`** | **`func`**
+>
+> *import-path* → *identifier* | *identifier* **`.`** *import-path*
+>
+>
+>
+
+> Grammar of a constant declaration:
+>
+> *constant-declaration* → *attributes*_?_ *declaration-modifiers*_?_ **`let`** *pattern-initializer-list*
+>
+>
+>
+> *pattern-initializer-list* → *pattern-initializer* | *pattern-initializer* **`,`** *pattern-initializer-list*
+>
+> *pattern-initializer* → *pattern* *initializer*_?_
+>
+> *initializer* → **`=`** *expression*
+>
+>
+>
+
+> Grammar of a variable declaration:
+>
+> *variable-declaration* → *variable-declaration-head* *pattern-initializer-list*
+>
+> *variable-declaration* → *variable-declaration-head* *variable-name* *type-annotation* *code-block*
+>
+> *variable-declaration* → *variable-declaration-head* *variable-name* *type-annotation* *getter-setter-block*
+>
+> *variable-declaration* → *variable-declaration-head* *variable-name* *type-annotation* *getter-setter-keyword-block*
+>
+> *variable-declaration* → *variable-declaration-head* *variable-name* *initializer* *willSet-didSet-block*
+>
+> *variable-declaration* → *variable-declaration-head* *variable-name* *type-annotation* *initializer*_?_ *willSet-didSet-block*
+>
+>
+>
+> *variable-declaration-head* → *attributes*_?_ *declaration-modifiers*_?_ **`var`**
+>
+> *variable-name* → *identifier*
+>
+>
+>
+> *getter-setter-block* → *code-block*
+>
+> *getter-setter-block* → **`{`** *getter-clause* *setter-clause*_?_ **`}`**
+>
+> *getter-setter-block* → **`{`** *setter-clause* *getter-clause* **`}`**
+>
+> *getter-clause* → *attributes*_?_ *mutation-modifier*_?_ **`get`** *code-block*
+>
+> *setter-clause* → *attributes*_?_ *mutation-modifier*_?_ **`set`** *setter-name*_?_ *code-block*
+>
+> *setter-name* → **`(`** *identifier* **`)`**
+>
+>
+>
+> *getter-setter-keyword-block* → **`{`** *getter-keyword-clause* *setter-keyword-clause*_?_ **`}`**
+>
+> *getter-setter-keyword-block* → **`{`** *setter-keyword-clause* *getter-keyword-clause* **`}`**
+>
+> *getter-keyword-clause* → *attributes*_?_ *mutation-modifier*_?_ **`get`**
+>
+> *setter-keyword-clause* → *attributes*_?_ *mutation-modifier*_?_ **`set`**
+>
+>
+>
+> *willSet-didSet-block* → **`{`** *willSet-clause* *didSet-clause*_?_ **`}`**
+>
+> *willSet-didSet-block* → **`{`** *didSet-clause* *willSet-clause*_?_ **`}`**
+>
+> *willSet-clause* → *attributes*_?_ **`willSet`** *setter-name*_?_ *code-block*
+>
+> *didSet-clause* → *attributes*_?_ **`didSet`** *setter-name*_?_ *code-block*
+>
+>
+>
+
+> Grammar of a type alias declaration:
+>
+> *typealias-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`typealias`** *typealias-name* *generic-parameter-clause*_?_ *typealias-assignment*
+>
+> *typealias-name* → *identifier*
+>
+> *typealias-assignment* → **`=`** *type*
+>
+>
+>
+
+> Grammar of a function declaration:
+>
+> *function-declaration* → *function-head* *function-name* *generic-parameter-clause*_?_ *function-signature* *generic-where-clause*_?_ *function-body*_?_
+>
+>
+>
+> *function-head* → *attributes*_?_ *declaration-modifiers*_?_ **`func`**
+>
+> *function-name* → *identifier* | *operator*
+>
+>
+>
+> *function-signature* → *parameter-clause* **`async`**_?_ **`throws`**_?_ *function-result*_?_
+>
+> *function-signature* → *parameter-clause* **`async`**_?_ **`rethrows`** *function-result*_?_
+>
+> *function-result* → **`->`** *attributes*_?_ *type*
+>
+> *function-body* → *code-block*
+>
+>
+>
+> *parameter-clause* → **`(`** **`)`** | **`(`** *parameter-list* **`)`**
+>
+> *parameter-list* → *parameter* | *parameter* **`,`** *parameter-list*
+>
+> *parameter* → *external-parameter-name*_?_ *local-parameter-name* *type-annotation* *default-argument-clause*_?_
+>
+> *parameter* → *external-parameter-name*_?_ *local-parameter-name* *type-annotation*
+>
+> *parameter* → *external-parameter-name*_?_ *local-parameter-name* *type-annotation* **`...`**
+>
+> *external-parameter-name* → *identifier*
+>
+> *local-parameter-name* → *identifier*
+>
+> *default-argument-clause* → **`=`** *expression*
+>
+>
+>
+
+> Grammar of an enumeration declaration:
+>
+> *enum-declaration* → *attributes*_?_ *access-level-modifier*_?_ *union-style-enum*
+>
+> *enum-declaration* → *attributes*_?_ *access-level-modifier*_?_ *raw-value-style-enum*
+>
+>
+>
+> *union-style-enum* → **`indirect`**_?_ **`enum`** *enum-name* *generic-parameter-clause*_?_ *type-inheritance-clause*_?_ *generic-where-clause*_?_ **`{`** *union-style-enum-members*_?_ **`}`**
+>
+> *union-style-enum-members* → *union-style-enum-member* *union-style-enum-members*_?_
+>
+> *union-style-enum-member* → *declaration* | *union-style-enum-case-clause* | *compiler-control-statement*
+>
+> *union-style-enum-case-clause* → *attributes*_?_ **`indirect`**_?_ **`case`** *union-style-enum-case-list*
+>
+> *union-style-enum-case-list* → *union-style-enum-case* | *union-style-enum-case* **`,`** *union-style-enum-case-list*
+>
+> *union-style-enum-case* → *enum-case-name* *tuple-type*_?_
+>
+> *enum-name* → *identifier*
+>
+> *enum-case-name* → *identifier*
+>
+>
+>
+> *raw-value-style-enum* → **`enum`** *enum-name* *generic-parameter-clause*_?_ *type-inheritance-clause* *generic-where-clause*_?_ **`{`** *raw-value-style-enum-members* **`}`**
+>
+> *raw-value-style-enum-members* → *raw-value-style-enum-member* *raw-value-style-enum-members*_?_
+>
+> *raw-value-style-enum-member* → *declaration* | *raw-value-style-enum-case-clause* | *compiler-control-statement*
+>
+> *raw-value-style-enum-case-clause* → *attributes*_?_ **`case`** *raw-value-style-enum-case-list*
+>
+> *raw-value-style-enum-case-list* → *raw-value-style-enum-case* | *raw-value-style-enum-case* **`,`** *raw-value-style-enum-case-list*
+>
+> *raw-value-style-enum-case* → *enum-case-name* *raw-value-assignment*_?_
+>
+> *raw-value-assignment* → **`=`** *raw-value-literal*
+>
+> *raw-value-literal* → *numeric-literal* | *static-string-literal* | *boolean-literal*
+>
+>
+>
+
+> Grammar of a structure declaration:
+>
+> *struct-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`struct`** *struct-name* *generic-parameter-clause*_?_ *type-inheritance-clause*_?_ *generic-where-clause*_?_ *struct-body*
+>
+> *struct-name* → *identifier*
+>
+> *struct-body* → **`{`** *struct-members*_?_ **`}`**
+>
+>
+>
+> *struct-members* → *struct-member* *struct-members*_?_
+>
+> *struct-member* → *declaration* | *compiler-control-statement*
+>
+>
+>
+
+> Grammar of a class declaration:
+>
+> *class-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`final`**_?_ **`class`** *class-name* *generic-parameter-clause*_?_ *type-inheritance-clause*_?_ *generic-where-clause*_?_ *class-body*
+>
+> *class-declaration* → *attributes*_?_ **`final`** *access-level-modifier*_?_ **`class`** *class-name* *generic-parameter-clause*_?_ *type-inheritance-clause*_?_ *generic-where-clause*_?_ *class-body*
+>
+> *class-name* → *identifier*
+>
+> *class-body* → **`{`** *class-members*_?_ **`}`**
+>
+>
+>
+> *class-members* → *class-member* *class-members*_?_
+>
+> *class-member* → *declaration* | *compiler-control-statement*
+>
+>
+>
+
+> Grammar of an actor declaration:
+>
+> *actor-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`actor`** *actor-name* *generic-parameter-clause*_?_ *type-inheritance-clause*_?_ *generic-where-clause*_?_ *actor-body*
+>
+> *actor-name* → *identifier*
+>
+> *actor-body* → **`{`** *actor-members*_?_ **`}`**
+>
+>
+>
+> *actor-members* → *actor-member* *actor-members*_?_
+>
+> *actor-member* → *declaration* | *compiler-control-statement*
+>
+>
+>
+
+> Grammar of a protocol declaration:
+>
+> *protocol-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`protocol`** *protocol-name* *type-inheritance-clause*_?_ *generic-where-clause*_?_ *protocol-body*
+>
+> *protocol-name* → *identifier*
+>
+> *protocol-body* → **`{`** *protocol-members*_?_ **`}`**
+>
+>
+>
+> *protocol-members* → *protocol-member* *protocol-members*_?_
+>
+> *protocol-member* → *protocol-member-declaration* | *compiler-control-statement*
+>
+>
+>
+> *protocol-member-declaration* → *protocol-property-declaration*
+>
+> *protocol-member-declaration* → *protocol-method-declaration*
+>
+> *protocol-member-declaration* → *protocol-initializer-declaration*
+>
+> *protocol-member-declaration* → *protocol-subscript-declaration*
+>
+> *protocol-member-declaration* → *protocol-associated-type-declaration*
+>
+> *protocol-member-declaration* → *typealias-declaration*
+>
+>
+>
+
+> Grammar of a protocol property declaration:
+>
+> *protocol-property-declaration* → *variable-declaration-head* *variable-name* *type-annotation* *getter-setter-keyword-block*
+>
+>
+>
+
+> Grammar of a protocol method declaration:
+>
+> *protocol-method-declaration* → *function-head* *function-name* *generic-parameter-clause*_?_ *function-signature* *generic-where-clause*_?_
+>
+>
+>
+
+> Grammar of a protocol initializer declaration:
+>
+> *protocol-initializer-declaration* → *initializer-head* *generic-parameter-clause*_?_ *parameter-clause* **`throws`**_?_ *generic-where-clause*_?_
+>
+> *protocol-initializer-declaration* → *initializer-head* *generic-parameter-clause*_?_ *parameter-clause* **`rethrows`** *generic-where-clause*_?_
+>
+>
+>
+
+> Grammar of a protocol subscript declaration:
+>
+> *protocol-subscript-declaration* → *subscript-head* *subscript-result* *generic-where-clause*_?_ *getter-setter-keyword-block*
+>
+>
+>
+
+> Grammar of a protocol associated type declaration:
+>
+> *protocol-associated-type-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`associatedtype`** *typealias-name* *type-inheritance-clause*_?_ *typealias-assignment*_?_ *generic-where-clause*_?_
+>
+>
+>
+
+> Grammar of an initializer declaration:
+>
+> *initializer-declaration* → *initializer-head* *generic-parameter-clause*_?_ *parameter-clause* **`async`**_?_ **`throws`**_?_ *generic-where-clause*_?_ *initializer-body*
+>
+> *initializer-declaration* → *initializer-head* *generic-parameter-clause*_?_ *parameter-clause* **`async`**_?_ **`rethrows`** *generic-where-clause*_?_ *initializer-body*
+>
+> *initializer-head* → *attributes*_?_ *declaration-modifiers*_?_ **`init`**
+>
+> *initializer-head* → *attributes*_?_ *declaration-modifiers*_?_ **`init`** **`?`**
+>
+> *initializer-head* → *attributes*_?_ *declaration-modifiers*_?_ **`init`** **`!`**
+>
+> *initializer-body* → *code-block*
+>
+>
+>
+
+> Grammar of a deinitializer declaration:
+>
+> *deinitializer-declaration* → *attributes*_?_ **`deinit`** *code-block*
+>
+>
+>
+
+> Grammar of an extension declaration:
+>
+> *extension-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`extension`** *type-identifier* *type-inheritance-clause*_?_ *generic-where-clause*_?_ *extension-body*
+>
+> *extension-body* → **`{`** *extension-members*_?_ **`}`**
+>
+>
+>
+> *extension-members* → *extension-member* *extension-members*_?_
+>
+> *extension-member* → *declaration* | *compiler-control-statement*
+>
+>
+>
+
+> Grammar of a subscript declaration:
+>
+> *subscript-declaration* → *subscript-head* *subscript-result* *generic-where-clause*_?_ *code-block*
+>
+> *subscript-declaration* → *subscript-head* *subscript-result* *generic-where-clause*_?_ *getter-setter-block*
+>
+> *subscript-declaration* → *subscript-head* *subscript-result* *generic-where-clause*_?_ *getter-setter-keyword-block*
+>
+> *subscript-head* → *attributes*_?_ *declaration-modifiers*_?_ **`subscript`** *generic-parameter-clause*_?_ *parameter-clause*
+>
+> *subscript-result* → **`->`** *attributes*_?_ *type*
+>
+>
+>
+
+> Grammar of an operator declaration:
+>
+> *operator-declaration* → *prefix-operator-declaration* | *postfix-operator-declaration* | *infix-operator-declaration*
+>
+>
+>
+> *prefix-operator-declaration* → **`prefix`** **`operator`** *operator*
+>
+> *postfix-operator-declaration* → **`postfix`** **`operator`** *operator*
+>
+> *infix-operator-declaration* → **`infix`** **`operator`** *operator* *infix-operator-group*_?_
+>
+>
+>
+> *infix-operator-group* → **`:`** *precedence-group-name*
+>
+>
+>
+
+> Grammar of a precedence group declaration:
+>
+> *precedence-group-declaration* → **`precedencegroup`** *precedence-group-name* **`{`** *precedence-group-attributes*_?_ **`}`**
+>
+>
+>
+> *precedence-group-attributes* → *precedence-group-attribute* *precedence-group-attributes*_?_
+>
+> *precedence-group-attribute* → *precedence-group-relation*
+>
+> *precedence-group-attribute* → *precedence-group-assignment*
+>
+> *precedence-group-attribute* → *precedence-group-associativity*
+>
+>
+>
+> *precedence-group-relation* → **`higherThan`** **`:`** *precedence-group-names*
+>
+> *precedence-group-relation* → **`lowerThan`** **`:`** *precedence-group-names*
+>
+>
+>
+> *precedence-group-assignment* → **`assignment`** **`:`** *boolean-literal*
+>
+>
+>
+> *precedence-group-associativity* → **`associativity`** **`:`** **`left`**
+>
+> *precedence-group-associativity* → **`associativity`** **`:`** **`right`**
+>
+> *precedence-group-associativity* → **`associativity`** **`:`** **`none`**
+>
+>
+>
+> *precedence-group-names* → *precedence-group-name* | *precedence-group-name* **`,`** *precedence-group-names*
+>
+> *precedence-group-name* → *identifier*
+>
+>
+>
+
+> Grammar of a declaration modifier:
+>
+> *declaration-modifier* → **`class`** | **`convenience`** | **`dynamic`** | **`final`** | **`infix`** | **`lazy`** | **`optional`** | **`override`** | **`postfix`** | **`prefix`** | **`required`** | **`static`** | **`unowned`** | **`unowned`** **`(`** **`safe`** **`)`** | **`unowned`** **`(`** **`unsafe`** **`)`** | **`weak`**
+>
+> *declaration-modifier* → *access-level-modifier*
+>
+> *declaration-modifier* → *mutation-modifier*
+>
+> *declaration-modifier* → *actor-isolation-modifier*
+>
+> *declaration-modifiers* → *declaration-modifier* *declaration-modifiers*_?_
+>
+>
+>
+> *access-level-modifier* → **`private`** | **`private`** **`(`** **`set`** **`)`**
+>
+> *access-level-modifier* → **`fileprivate`** | **`fileprivate`** **`(`** **`set`** **`)`**
+>
+> *access-level-modifier* → **`internal`** | **`internal`** **`(`** **`set`** **`)`**
+>
+> *access-level-modifier* → **`public`** | **`public`** **`(`** **`set`** **`)`**
+>
+> *access-level-modifier* → **`open`** | **`open`** **`(`** **`set`** **`)`**
+>
+>
+>
+> *mutation-modifier* → **`mutating`** | **`nonmutating`**
+>
+>
+>
+> *actor-isolation-modifier* → **`nonisolated`**
+>
+>
+>
+
+> Grammar of an attribute:
+>
+> *attribute* → **`@`** *attribute-name* *attribute-argument-clause*_?_
+>
+> *attribute-name* → *identifier*
+>
+> *attribute-argument-clause* → **`(`** *balanced-tokens*_?_ **`)`**
+>
+> *attributes* → *attribute* *attributes*_?_
+>
+>
+>
+> *balanced-tokens* → *balanced-token* *balanced-tokens*_?_
+>
+> *balanced-token* → **`(`** *balanced-tokens*_?_ **`)`**
+>
+> *balanced-token* → **`[`** *balanced-tokens*_?_ **`]`**
+>
+> *balanced-token* → **`{`** *balanced-tokens*_?_ **`}`**
+>
+> *balanced-token* → Any identifier, keyword, literal, or operator
+>
+> *balanced-token* → Any punctuation except  **`(`**,  **`)`**,  **`[`**,  **`]`**,  **`{`**, or  **`}`**
+>
+>
+>
+
+> Grammar of a pattern:
+>
+> *pattern* → *wildcard-pattern* *type-annotation*_?_
+>
+> *pattern* → *identifier-pattern* *type-annotation*_?_
+>
+> *pattern* → *value-binding-pattern*
+>
+> *pattern* → *tuple-pattern* *type-annotation*_?_
+>
+> *pattern* → *enum-case-pattern*
+>
+> *pattern* → *optional-pattern*
+>
+> *pattern* → *type-casting-pattern*
+>
+> *pattern* → *expression-pattern*
+>
+>
+>
+
+> Grammar of a wildcard pattern:
+>
+> *wildcard-pattern* → **`_`**
+>
+>
+>
+
+> Grammar of an identifier pattern:
+>
+> *identifier-pattern* → *identifier*
+>
+>
+>
+
+> Grammar of a value-binding pattern:
+>
+> *value-binding-pattern* → **`var`** *pattern* | **`let`** *pattern*
+>
+>
+>
+
+> Grammar of a tuple pattern:
+>
+> *tuple-pattern* → **`(`** *tuple-pattern-element-list*_?_ **`)`**
+>
+> *tuple-pattern-element-list* → *tuple-pattern-element* | *tuple-pattern-element* **`,`** *tuple-pattern-element-list*
+>
+> *tuple-pattern-element* → *pattern* | *identifier* **`:`** *pattern*
+>
+>
+>
+
+> Grammar of an enumeration case pattern:
+>
+> *enum-case-pattern* → *type-identifier*_?_ **`.`** *enum-case-name* *tuple-pattern*_?_
+>
+>
+>
+
+> Grammar of an optional pattern:
+>
+> *optional-pattern* → *identifier-pattern* **`?`**
+>
+>
+>
+
+> Grammar of a type casting pattern:
+>
+> *type-casting-pattern* → *is-pattern* | *as-pattern*
+>
+> *is-pattern* → **`is`** *type*
+>
+> *as-pattern* → *pattern* **`as`** *type*
+>
+>
+>
+
+> Grammar of an expression pattern:
+>
+> *expression-pattern* → *expression*
+>
+>
+>
+
+> Grammar of a generic parameter clause:
+>
+> *generic-parameter-clause* → **`<`** *generic-parameter-list* **`>`**
+>
+> *generic-parameter-list* → *generic-parameter* | *generic-parameter* **`,`** *generic-parameter-list*
+>
+> *generic-parameter* → *type-name*
+>
+> *generic-parameter* → *type-name* **`:`** *type-identifier*
+>
+> *generic-parameter* → *type-name* **`:`** *protocol-composition-type*
+>
+>
+>
+> *generic-where-clause* → **`where`** *requirement-list*
+>
+> *requirement-list* → *requirement* | *requirement* **`,`** *requirement-list*
+>
+> *requirement* → *conformance-requirement* | *same-type-requirement*
+>
+>
+>
+> *conformance-requirement* → *type-identifier* **`:`** *type-identifier*
+>
+> *conformance-requirement* → *type-identifier* **`:`** *protocol-composition-type*
+>
+> *same-type-requirement* → *type-identifier* **`==`** *type*
+>
+>
+>
+
+> Grammar of a generic argument clause:
+>
+> *generic-argument-clause* → **`<`** *generic-argument-list* **`>`**
+>
+> *generic-argument-list* → *generic-argument* | *generic-argument* **`,`** *generic-argument-list*
+>
+> *generic-argument* → *type*
+>
+>
+>
+
+
+@Comment {
+This source file is part of the Swift.org open source project
+
+Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+}

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
@@ -1,5 +1,18 @@
 # Summary of the Grammar
 
+<!--
+
+=== IMPORTANT ===
+
+This file is manually updated.
+
+If you edit formal grammar elsewhere in the reference,
+make the same change here also.
+
+=== IMPORTANT ===
+
+-->
+
 > Grammar of whitespace:
 >
 > *whitespace* → *whitespace-item* *whitespace*_?_

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Types.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Types.md
@@ -34,23 +34,34 @@ For example, `(Int)` is equivalent to `Int`.
 This chapter discusses the types defined in the Swift language itself
 and describes the type inference behavior of Swift.
 
-```
-Grammar of a type
+> Grammar of a type:
+>
+> *type* → *function-type*
+>
+> *type* → *array-type*
+>
+> *type* → *dictionary-type*
+>
+> *type* → *type-identifier*
+>
+> *type* → *tuple-type*
+>
+> *type* → *optional-type*
+>
+> *type* → *implicitly-unwrapped-optional-type*
+>
+> *type* → *protocol-composition-type*
+>
+> *type* → *opaque-type*
+>
+> *type* → *metatype-type*
+>
+> *type* → *any-type*
+>
+> *type* → *self-type*
+>
+> *type* → **`(`** *type* **`)`**
 
-type --> function-type
-type --> array-type
-type --> dictionary-type
-type --> type-identifier
-type --> tuple-type
-type --> optional-type
-type --> implicitly-unwrapped-optional-type
-type --> protocol-composition-type
-type --> opaque-type
-type --> metatype-type
-type --> any-type
-type --> self-type
-type --> ``(`` type ``)``
-```
 
 
 ## Type Annotation
@@ -81,11 +92,9 @@ the parameter `a` to the function `someFunction` is specified to have the type `
 
 Type annotations can contain an optional list of type attributes before the type.
 
-```
-Grammar of a type annotation
-
-type-annotation --> ``:`` attributes-OPT ``inout``-OPT type
-```
+> Grammar of a type annotation:
+>
+> *type-annotation* → **`:`** *attributes*_?_ **`inout`**_?_ *type*
 
 
 ## Type Identifier
@@ -140,12 +149,11 @@ var someValue: ExampleModule.MyType
   ```
 }
 
-```
-Grammar of a type identifier
-
-type-identifier --> type-name generic-argument-clause-OPT | type-name generic-argument-clause-OPT ``.`` type-identifier
-type-name --> identifier
-```
+> Grammar of a type identifier:
+>
+> *type-identifier* → *type-name* *generic-argument-clause*_?_ | *type-name* *generic-argument-clause*_?_ **`.`** *type-identifier*
+>
+> *type-name* → *identifier*
 
 
 ## Tuple Type
@@ -187,14 +195,15 @@ someTuple = (left: 5, right: 5)  // Error: names don't match
 All tuple types contain two or more types,
 except for `Void` which is a type alias for the empty tuple type, `()`.
 
-```
-Grammar of a tuple type
-
-tuple-type --> ``(`` ``)`` | ``(`` tuple-type-element ``,`` tuple-type-element-list ``)``
-tuple-type-element-list --> tuple-type-element | tuple-type-element ``,`` tuple-type-element-list
-tuple-type-element --> element-name type-annotation | type
-element-name --> identifier
-```
+> Grammar of a tuple type:
+>
+> *tuple-type* → **`(`** **`)`** | **`(`** *tuple-type-element* **`,`** *tuple-type-element-list* **`)`**
+>
+> *tuple-type-element-list* → *tuple-type-element* | *tuple-type-element* **`,`** *tuple-type-element-list*
+>
+> *tuple-type-element* → *element-name* *type-annotation* | *type*
+>
+> *element-name* → *identifier*
 
 
 ## Function Type
@@ -493,18 +502,23 @@ by using the `withoutActuallyEscaping(_:do:)` function.
 For information about avoiding conflicting access to memory,
 see <doc:MemorySafety>.
 
-```
-Grammar of a function type
-
-function-type --> attributes-OPT function-type-argument-clause ``async``-OPT ``throws``-OPT ``->`` type
-
-function-type-argument-clause --> ``(`` ``)``
-function-type-argument-clause --> ``(`` function-type-argument-list ``...``-OPT ``)``
-
-function-type-argument-list --> function-type-argument | function-type-argument ``,`` function-type-argument-list
-function-type-argument --> attributes-OPT ``inout``-OPT type | argument-label type-annotation
-argument-label --> identifier
-```
+> Grammar of a function type:
+>
+> *function-type* → *attributes*_?_ *function-type-argument-clause* **`async`**_?_ **`throws`**_?_ **`->`** *type*
+>
+>
+>
+> *function-type-argument-clause* → **`(`** **`)`**
+>
+> *function-type-argument-clause* → **`(`** *function-type-argument-list* **`...`**_?_ **`)`**
+>
+>
+>
+> *function-type-argument-list* → *function-type-argument* | *function-type-argument* **`,`** *function-type-argument-list*
+>
+> *function-type-argument* → *attributes*_?_ **`inout`**_?_ *type* | *argument-label* *type-annotation*
+>
+> *argument-label* → *identifier*
 
 
 @Comment {
@@ -585,11 +599,9 @@ the example above, `array3D[0]` refers to `[[1, 2], [3, 4]]`,
 For a detailed discussion of the Swift standard library `Array` type,
 see <doc:CollectionTypes#Arrays>.
 
-```
-Grammar of an array type
-
-array-type --> ``[`` type ``]``
-```
+> Grammar of an array type:
+>
+> *array-type* → **`[`** *type* **`]`**
 
 
 ## Dictionary Type
@@ -641,11 +653,9 @@ The key type of a dictionary must conform to the Swift standard library `Hashabl
 For a detailed discussion of the Swift standard library `Dictionary` type,
 see <doc:CollectionTypes#Dictionaries>.
 
-```
-Grammar of a dictionary type
-
-dictionary-type --> ``[`` type ``:`` type ``]``
-```
+> Grammar of a dictionary type:
+>
+> *dictionary-type* → **`[`** *type* **`:`** *type* **`]`**
 
 
 ## Optional Type
@@ -726,11 +736,9 @@ no operation is performed and therefore no runtime error is produced.
 For more information and to see examples that show how to use optional types,
 see <doc:TheBasics#Optionals>.
 
-```
-Grammar of an optional type
-
-optional-type --> type ``?``
-```
+> Grammar of an optional type:
+>
+> *optional-type* → *type* **`?`**
 
 
 ## Implicitly Unwrapped Optional Type
@@ -788,11 +796,9 @@ no operation is performed and therefore no runtime error is produced.
 For more information about implicitly unwrapped optional types,
 see <doc:TheBasics#Implicitly-Unwrapped-Optionals>.
 
-```
-Grammar of an implicitly unwrapped optional type
-
-implicitly-unwrapped-optional-type --> type ``!``
-```
+> Grammar of an implicitly unwrapped optional type:
+>
+> *implicitly-unwrapped-optional-type* → *type* **`!`**
 
 
 ## Protocol Composition Type
@@ -863,12 +869,11 @@ typealias PQR = PQ & Q & R
   ```
 }
 
-```
-Grammar of a protocol composition type
-
-protocol-composition-type --> type-identifier ``&`` protocol-composition-continuation
-protocol-composition-continuation --> type-identifier | protocol-composition-type
-```
+> Grammar of a protocol composition type:
+>
+> *protocol-composition-type* → *type-identifier* **`&`** *protocol-composition-continuation*
+>
+> *protocol-composition-continuation* → *type-identifier* | *protocol-composition-type*
 
 
 ## Opaque Type
@@ -917,11 +922,9 @@ that are part of the function's generic type parameters.
 For example, a function `someFunction<T>()`
 could return a value of type `T` or `Dictionary<String, T>`.
 
-```
-Grammar of an opaque type
-
-opaque-type --> ``some`` type
-```
+> Grammar of an opaque type:
+>
+> *opaque-type* → **`some`** *type*
 
 
 ## Metatype Type
@@ -1030,11 +1033,9 @@ let anotherInstance = metatype.init(string: "some string")
   ```
 }
 
-```
-Grammar of a metatype type
-
-metatype-type --> type ``.`` ``Type`` | type ``.`` ``Protocol``
-```
+> Grammar of a metatype type:
+>
+> *metatype-type* → *type* **`.`** **`Type`** | *type* **`.`** **`Protocol`**
 
 
 ## Any Type
@@ -1102,11 +1103,9 @@ For more information, see
 <doc:Protocols#Class-Only-Protocols>
 and [AnyObject](https://developer.apple.com/documentation/swift/anyobject).
 
-```
-Grammar of an Any type
-
-any-type --> ``Any``
-```
+> Grammar of an Any type:
+>
+> *any-type* → **`Any`**
 
 
 ## Self Type
@@ -1228,11 +1227,9 @@ function in the Swift standard library.
 Writing `Self.someStaticMember` to access a member of the current type
 is the same as writing `type(of: self).someStaticMember`.
 
-```
-Grammar of a Self type
-
-self-type --> ``Self``
-```
+> Grammar of a Self type:
+>
+> *self-type* → **`Self`**
 
 
 ## Type Inheritance Clause
@@ -1263,12 +1260,11 @@ a single, named type that specifies the type of those raw values.
 For an example of an enumeration definition that uses a type inheritance clause
 to specify the type of its raw values, see <doc:Enumerations#Raw-Values>.
 
-```
-Grammar of a type inheritance clause
-
-type-inheritance-clause --> ``:`` type-inheritance-list
-type-inheritance-list --> attributes-OPT type-identifier | attributes-OPT type-identifier ``,`` type-inheritance-list
-```
+> Grammar of a type inheritance clause:
+>
+> *type-inheritance-clause* → **`:`** *type-inheritance-list*
+>
+> *type-inheritance-list* → *attributes*_?_ *type-identifier* | *attributes*_?_ *type-identifier* **`,`** *type-inheritance-list*
 
 
 ## Type Inference

--- a/Sources/TSPL/TSPL.docc/TSPL.md
+++ b/Sources/TSPL/TSPL.docc/TSPL.md
@@ -54,6 +54,7 @@
 - <doc:Attributes>
 - <doc:Patterns>
 - <doc:GenericParametersAndArguments>
+- <doc:SummaryOfTheGrammar>
 
 ### Revision History
 


### PR DESCRIPTION
DocC doesn't support subscripts, so instead of using subscript "opt" for optionality, use a postfix question mark.  Alternatives considered included text like "OPT" or "(opt)" and Unicode subscript characters.  The former are hard to read and interrupt the flow of the grammar.  The latter render poorly because they're intended for phonetic annotation, so the different letters don't share a baseline in many fonts.

It's a known issue that DocC doesn't support hard breaks, so insert a paragraph break between each grammar production for now.  I added a "double" paragraph break between groups, where there used to be a blank line, to preserve that information for when DocC adds hard break support in the future.

Fixes https://github.com/apple/swift-book/issues/3
Fixes rdar://101001280