### PR TITLE
Fix the tour's example for empty array & dictionary syntax

### DIFF
--- a/Sources/TSPL/TSPL.docc/GuidedTour/GuidedTour.md
+++ b/Sources/TSPL/TSPL.docc/GuidedTour/GuidedTour.md
@@ -274,6 +274,10 @@ occupations["Jayne"] = "Public Relations"
   ```
 -->
 
+@Comment {
+  iBooks Store screenshot begins here.
+}
+
 Arrays automatically grow as you add elements.
 
 ```swift
@@ -292,12 +296,14 @@ print(fruits)
   ```
 -->
 
-To create an empty array or dictionary,
-use the initializer syntax.
+To create an empty array, write `[]`
+and to create empty dictionary write `[:]` ---
+for example, when you set a new value for a variable
+or pass an argument to a function.
 
 ```swift
-let emptyArray: [String] = []
-let emptyDictionary: [String: Float] = [:]
+fruits = []
+occupations = [:]
 ```
 
 
@@ -305,8 +311,8 @@ let emptyDictionary: [String: Float] = [:]
   - test: `guided-tour`
   
   ```swifttest
-  -> let emptyArray: [String] = []
-  -> let emptyDictionary: [String: Float] = [:]
+  -> fruits = []
+  -> occupations = [:]
   ```
 -->
 
@@ -321,8 +327,8 @@ or pass an argument to a function.
 -->
 
 ```swift
-fruits = []
-occupations = [:]
+let emptyArray: [String] = []
+let emptyDictionary: [String: Float] = [:]
 ```
 
 
@@ -330,8 +336,11 @@ occupations = [:]
   - test: `guided-tour`
   
   ```swifttest
-  -> fruits = []
-  -> occupations = [:]
+  -> let emptyArray: [String] = []
+  -> let emptyDictionary: [String: Float] = [:]
+  ---
+  -> let anotherEmptyArray = [String]()
+  -> let emptyDictionary = [String: Float]()
   ```
 -->
 

--- a/Sources/TSPL/TSPL.docc/GuidedTour/GuidedTour.md
+++ b/Sources/TSPL/TSPL.docc/GuidedTour/GuidedTour.md
@@ -316,15 +316,9 @@ occupations = [:]
   ```
 -->
 
-If type information can be inferred,
-you can write an empty array as `[]`
-and an empty dictionary as `[:]` ---
-for example, when you set a new value for a variable
-or pass an argument to a function.
-
-<!--
-  iBooks Store screenshot begins here.
--->
+If you're assigning an empty array or dictionary to a new variable,
+or another place where there isn't any type information,
+you need to specify the type.
 
 ```swift
 let emptyArray: [String] = []

--- a/Sources/TSPL/TSPL.docc/GuidedTour/GuidedTour.md
+++ b/Sources/TSPL/TSPL.docc/GuidedTour/GuidedTour.md
@@ -274,9 +274,9 @@ occupations["Jayne"] = "Public Relations"
   ```
 -->
 
-@Comment {
+<!--
   iBooks Store screenshot begins here.
-}
+-->
 
 Arrays automatically grow as you add elements.
 

--- a/Sources/TSPL/TSPL.docc/GuidedTour/GuidedTour.md
+++ b/Sources/TSPL/TSPL.docc/GuidedTour/GuidedTour.md
@@ -296,10 +296,9 @@ print(fruits)
   ```
 -->
 
-To create an empty array, write `[]`
-and to create empty dictionary write `[:]` ---
-for example, when you set a new value for a variable
-or pass an argument to a function.
+You also use brackets to write an empty array or dictionary.
+For an array, write `[]`,
+and for a dictionary, write `[:]`.
 
 ```swift
 fruits = []


### PR DESCRIPTION
These examples used to contrast the literal `[]` and initializer `[String]()` syntax, but we revised the book to remove the latter as part of a [style update](https://github.com/apple/swift-book/commit/639bcc61dde12b16cb50fcd81885292bfd6a2883).

Fixes rdar://101867425