### PR TITLE
Collapse adjacent blank lines.

### DIFF
--- a/Sources/TSPL/TSPL.docc/GuidedTour/AboutSwift.md
+++ b/Sources/TSPL/TSPL.docc/GuidedTour/AboutSwift.md
@@ -1,5 +1,3 @@
-
-
 # About Swift
 
 Understand the high-level goals of the language.
@@ -49,7 +47,6 @@ Swift has been years in the making,
 and it continues to evolve with new features and capabilities.
 Our goals for Swift are ambitious.
 We can’t wait to see what you create with it.
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/GuidedTour/Compatibility.md
+++ b/Sources/TSPL/TSPL.docc/GuidedTour/Compatibility.md
@@ -1,5 +1,3 @@
-
-
 # Version Compatibility
 
 Learn what functionality is available in older language modes.
@@ -50,7 +48,6 @@ This means, if you have a large project
 that's divided into multiple frameworks,
 you can migrate your code from Swift 4 to Swift 5.7
 one framework at a time.
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/GuidedTour/GuidedTour.md
+++ b/Sources/TSPL/TSPL.docc/GuidedTour/GuidedTour.md
@@ -1,10 +1,6 @@
-
-
 # A Swift Tour
 
 Explore the features and syntax of Swift.
-
-
 
 Tradition suggests that the first program in a new language
 should print the words “Hello, world!” on the screen.
@@ -19,7 +15,6 @@ In Swift, this can be done in a single line:
 print("Hello, world!")
 // Prints "Hello, world!"
 ```
-
 
 <!--
   - test: `guided-tour`
@@ -63,7 +58,6 @@ myVariable = 50
 let myConstant = 42
 ```
 
-
 <!--
   - test: `guided-tour`
   
@@ -94,7 +88,6 @@ let implicitDouble = 70.0
 let explicitDouble: Double = 70
 ```
 
-
 <!--
   - test: `guided-tour`
   
@@ -117,7 +110,6 @@ let label = "The width is "
 let width = 94
 let widthLabel = label + String(width)
 ```
-
 
 <!--
   - test: `guided-tour`
@@ -152,7 +144,6 @@ let appleSummary = "I have \(apples) apples."
 let fruitSummary = "I have \(apples + oranges) pieces of fruit."
 ```
 
-
 <!--
   - test: `guided-tour`
   
@@ -184,7 +175,6 @@ I said "I have \(apples) apples."
 And then I said "I have \(apples + oranges) pieces of fruit."
 """
 ```
-
 
 <!--
   - test: `guided-tour`
@@ -258,7 +248,6 @@ var occupations = [
 occupations["Jayne"] = "Public Relations"
 ```
 
-
 <!--
   - test: `guided-tour`
   
@@ -281,7 +270,6 @@ fruits.append("blueberries")
 print(fruits)
 ```
 
-
 <!--
   - test: `guided-tour`
   
@@ -299,7 +287,6 @@ use the initializer syntax.
 let emptyArray: [String] = []
 let emptyDictionary: [String: Float] = [:]
 ```
-
 
 <!--
   - test: `guided-tour`
@@ -324,7 +311,6 @@ or pass an argument to a function.
 fruits = []
 occupations = [:]
 ```
-
 
 <!--
   - test: `guided-tour`
@@ -356,7 +342,6 @@ for score in individualScores {
 print(teamScore)
 // Prints "11"
 ```
-
 
 <!--
   - test: `guided-tour`
@@ -425,7 +410,6 @@ if let name = optionalName {
 }
 ```
 
-
 <!--
   - test: `guided-tour`
   
@@ -467,7 +451,6 @@ let fullName: String = "John Appleseed"
 let informalGreeting = "Hi \(nickname ?? fullName)"
 ```
 
-
 <!--
   - test: `guided-tour`
   
@@ -488,7 +471,6 @@ if let nickname {
     print("Hey, \(nickname)")
 }
 ```
-
 
 <!--
   - test: `guided-tour`
@@ -527,7 +509,6 @@ default:
 }
 // Prints "Is it a spicy red pepper?"
 ```
-
 
 <!--
   - test: `guided-tour`
@@ -599,7 +580,6 @@ print(largest)
 // Prints "25"
 ```
 
-
 <!--
   - test: `guided-tour`
   
@@ -652,7 +632,6 @@ print(m)
 // Prints "128"
 ```
 
-
 <!--
   - test: `guided-tour`
   
@@ -684,7 +663,6 @@ for i in 0..<4 {
 print(total)
 // Prints "6"
 ```
-
 
 <!--
   - test: `guided-tour`
@@ -725,7 +703,6 @@ func greet(person: String, day: String) -> String {
 greet(person: "Bob", day: "Tuesday")
 ```
 
-
 <!--
   - test: `guided-tour`
   
@@ -755,7 +732,6 @@ func greet(_ person: String, on day: String) -> String {
 }
 greet("John", on: "Wednesday")
 ```
-
 
 <!--
   - test: `guided-tour`
@@ -808,7 +784,6 @@ print(statistics.2)
 // Prints "120"
 ```
 
-
 <!--
   - test: `guided-tour`
   
@@ -858,7 +833,6 @@ func returnFifteen() -> Int {
 returnFifteen()
 ```
 
-
 <!--
   - test: `guided-tour`
   
@@ -891,7 +865,6 @@ func makeIncrementer() -> ((Int) -> Int) {
 var increment = makeIncrementer()
 increment(7)
 ```
-
 
 <!--
   - test: `guided-tour`
@@ -928,7 +901,6 @@ func lessThanTen(number: Int) -> Bool {
 var numbers = [20, 19, 7, 12]
 hasAnyMatches(list: numbers, condition: lessThanTen)
 ```
-
 
 <!--
   - test: `guided-tour`
@@ -970,7 +942,6 @@ numbers.map({ (number: Int) -> Int in
 })
 ```
 
-
 <!--
   - test: `guided-tour`
   
@@ -1001,7 +972,6 @@ print(mappedNumbers)
 // Prints "[60, 57, 21, 36]"
 ```
 
-
 <!--
   - test: `guided-tour`
   
@@ -1024,7 +994,6 @@ let sortedNumbers = numbers.sorted { $0 > $1 }
 print(sortedNumbers)
 // Prints "[20, 19, 12, 7]"
 ```
-
 
 <!--
   - test: `guided-tour`
@@ -1075,7 +1044,6 @@ class Shape {
 }
 ```
 
-
 <!--
   - test: `guided-tour`
   
@@ -1104,7 +1072,6 @@ var shape = Shape()
 shape.numberOfSides = 7
 var shapeDescription = shape.simpleDescription()
 ```
-
 
 <!--
   - test: `guided-tour`
@@ -1136,7 +1103,6 @@ class NamedShape {
     }
 }
 ```
-
 
 <!--
   - test: `guided-tour`
@@ -1208,7 +1174,6 @@ let test = Square(sideLength: 5.2, name: "my test square")
 test.area()
 test.simpleDescription()
 ```
-
 
 <!--
   - test: `guided-tour`
@@ -1283,7 +1248,6 @@ triangle.perimeter = 9.9
 print(triangle.sideLength)
 // Prints "3.3000000000000003"
 ```
-
 
 <!--
   - test: `guided-tour`
@@ -1375,7 +1339,6 @@ print(triangleAndSquare.triangle.sideLength)
 // Prints "50.0"
 ```
 
-
 <!--
   - test: `guided-tour`
   
@@ -1429,7 +1392,6 @@ let optionalSquare: Square? = Square(sideLength: 2.5, name: "optional square")
 let sideLength = optionalSquare?.sideLength
 ```
 
-
 <!--
   - test: `guided-tour`
   
@@ -1479,7 +1441,6 @@ enum Rank: Int {
 let ace = Rank.ace
 let aceRawValue = ace.rawValue
 ```
-
 
 <!--
   - test: `guided-tour`
@@ -1535,7 +1496,6 @@ if let convertedRank = Rank(rawValue: 3) {
 }
 ```
 
-
 <!--
   - test: `guided-tour`
   
@@ -1574,7 +1534,6 @@ enum Suit {
 let hearts = Suit.hearts
 let heartsDescription = hearts.simpleDescription()
 ```
-
 
 <!--
   - test: `guided-tour`
@@ -1691,7 +1650,6 @@ case let .failure(message):
 // Prints "Sunrise is at 6:00 am and sunset is at 8:09 pm."
 ```
 
-
 <!--
   - test: `guided-tour`
   
@@ -1740,7 +1698,6 @@ let threeOfSpades = Card(rank: .three, suit: .spades)
 let threeOfSpadesDescription = threeOfSpades.simpleDescription()
 ```
 
-
 <!--
   - test: `guided-tour`
   
@@ -1776,7 +1733,6 @@ func fetchUserID(from server: String) async -> Int {
 }
 ```
 
-
 <!--
   - test: `guided-tour`
   
@@ -1801,7 +1757,6 @@ func fetchUsername(from server: String) async -> String {
     return "Guest"
 }
 ```
-
 
 <!--
   - test: `guided-tour`
@@ -1830,7 +1785,6 @@ func connectUser(to server: String) async {
 }
 ```
 
-
 <!--
   - test: `guided-tour`
   
@@ -1854,7 +1808,6 @@ Task {
 // Prints "Hello Guest, user ID 97"
 ```
 
-
 <!--
   - test: `guided-tour`
   
@@ -1877,7 +1830,6 @@ protocol ExampleProtocol {
      mutating func adjust()
 }
 ```
-
 
 <!--
   - test: `guided-tour`
@@ -1922,7 +1874,6 @@ var b = SimpleStructure()
 b.adjust()
 let bDescription = b.simpleDescription
 ```
-
 
 <!--
   - test: `guided-tour`
@@ -1986,7 +1937,6 @@ print(7.simpleDescription)
 // Prints "The number 7"
 ```
 
-
 <!--
   - test: `guided-tour`
   
@@ -2020,7 +1970,6 @@ print(protocolValue.simpleDescription)
 // Prints "A very simple class.  Now 100% adjusted."
 // print(protocolValue.anotherProperty)  // Uncomment to see the error
 ```
-
 
 <!--
   - test: `guided-tour`
@@ -2071,7 +2020,6 @@ enum PrinterError: Error {
 }
 ```
 
-
 <!--
   - test: `guided-tour`
   
@@ -2098,7 +2046,6 @@ func send(job: Int, toPrinter printerName: String) throws -> String {
     return "Job sent"
 }
 ```
-
 
 <!--
   - test: `guided-tour`
@@ -2130,7 +2077,6 @@ do {
 }
 // Prints "Job sent"
 ```
-
 
 <!--
   - test: `guided-tour`
@@ -2191,7 +2137,6 @@ do {
 // Prints "Job sent"
 ```
 
-
 <!--
   - test: `guided-tour`
   
@@ -2226,7 +2171,6 @@ the value that the function returned.
 let printerSuccess = try? send(job: 1884, toPrinter: "Mergenthaler")
 let printerFailure = try? send(job: 1885, toPrinter: "Never Has Toner")
 ```
-
 
 <!--
   - test: `guided-tour`
@@ -2265,7 +2209,6 @@ fridgeContains("banana")
 print(fridgeIsOpen)
 // Prints "false"
 ```
-
 
 <!--
   - test: `guided-tour`
@@ -2315,7 +2258,6 @@ func makeArray<Item>(repeating item: Item, numberOfTimes: Int) -> [Item] {
 makeArray(repeating: "knock", numberOfTimes: 4)
 ```
 
-
 <!--
   - test: `guided-tour`
   
@@ -2346,7 +2288,6 @@ enum OptionalValue<Wrapped> {
 var possibleInteger: OptionalValue<Int> = .none
 possibleInteger = .some(100)
 ```
-
 
 <!--
   - test: `guided-tour`
@@ -2385,7 +2326,6 @@ func anyCommonElements<T: Sequence, U: Sequence>(_ lhs: T, _ rhs: U) -> Bool
 anyCommonElements([1, 2, 3], [3])
 ```
 
-
 <!--
   - test: `guided-tour`
   
@@ -2415,7 +2355,6 @@ anyCommonElements([1, 2, 3], [3])
 
 Writing `<T: Equatable>`
 is the same as writing `<T> ... where T: Equatable`.
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/AccessControl.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/AccessControl.md
@@ -1,5 +1,3 @@
-
-
 # Access Control
 
 Manage the visibility of code by declaration, file, and module.
@@ -166,7 +164,6 @@ fileprivate func someFilePrivateFunction() {}
 private func somePrivateFunction() {}
 ```
 
-
 <!--
   - test: `accessControlSyntax`
   
@@ -193,7 +190,6 @@ and will still have an access level of internal:
 class SomeInternalClass {}              // implicitly internal
 let someInternalConstant = 0            // implicitly internal
 ```
-
 
 <!--
   - test: `accessControlDefaulted`
@@ -253,7 +249,6 @@ private class SomePrivateClass {                // explicitly private class
     func somePrivateMethod() {}                  // implicitly private class member
 }
 ```
-
 
 <!--
   - test: `accessControl, accessControlWrong`
@@ -384,7 +379,6 @@ func someFunction() -> (SomeInternalClass, SomePrivateClass) {
 }
 ```
 
-
 <!--
   - test: `accessControlWrong`
   
@@ -415,7 +409,6 @@ private func someFunction() -> (SomeInternalClass, SomePrivateClass) {
     // function implementation goes here
 }
 ```
-
 
 <!--
   - test: `accessControl`
@@ -453,7 +446,6 @@ public enum CompassPoint {
     case west
 }
 ```
-
 
 <!--
   - test: `enumerationCases`
@@ -678,7 +670,6 @@ internal class B: A {
 }
 ```
 
-
 <!--
   - test: `subclassingNoCall`
   
@@ -712,7 +703,6 @@ internal class B: A {
 }
 ```
 
-
 <!--
   - test: `subclassingWithCall`
   
@@ -745,7 +735,6 @@ the constant, variable, property, or subscript must also be marked as `private`:
 ```swift
 private var privateInstance = SomePrivateClass()
 ```
-
 
 <!--
   - test: `accessControl`
@@ -822,7 +811,6 @@ struct TrackedString {
 }
 ```
 
-
 <!--
   - test: `reducedSetterScope, reducedSetterScope_error`
   
@@ -892,7 +880,6 @@ print("The number of edits is \(stringToEdit.numberOfEdits)")
 // Prints "The number of edits is 3"
 ```
 
-
 <!--
   - test: `reducedSetterScope`
   
@@ -934,7 +921,6 @@ public struct TrackedString {
     public init() {}
 }
 ```
-
 
 <!--
   - test: `reducedSetterScopePublic`
@@ -1398,7 +1384,6 @@ protocol SomeProtocol {
 }
 ```
 
-
 <!--
   - test: `extensions_privatemembers`
   
@@ -1422,7 +1407,6 @@ extension SomeStruct: SomeProtocol {
     }
 }
 ```
-
 
 <!--
   - test: `extensions_privatemembers`
@@ -1498,7 +1482,6 @@ but a public type alias can't alias an internal, file-private, or private type.
   !! ^
   ```
 -->
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/AdvancedOperators.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/AdvancedOperators.md
@@ -1,5 +1,3 @@
-
-
 # Advanced Operators
 
 Define custom operators, perform bitwise operations, and use builder syntax.
@@ -47,7 +45,6 @@ The *bitwise NOT operator* (`~`) inverts all bits in a number:
 
 ![](bitwiseNOT)
 
-
 The bitwise NOT operator is a prefix operator,
 and appears immediately before the value it operates on,
 without any white space:
@@ -56,7 +53,6 @@ without any white space:
 let initialBits: UInt8 = 0b00001111
 let invertedBits = ~initialBits  // equals 11110000
 ```
-
 
 <!--
   - test: `bitwiseOperators`
@@ -95,7 +91,6 @@ only if the bits were equal to `1` in *both* input numbers:
 
 ![](bitwiseAND)
 
-
 In the example below,
 the values of `firstSixBits` and `lastSixBits`
 both have four middle bits equal to `1`.
@@ -107,7 +102,6 @@ let firstSixBits: UInt8 = 0b11111100
 let lastSixBits: UInt8  = 0b00111111
 let middleFourBits = firstSixBits & lastSixBits  // equals 00111100
 ```
-
 
 <!--
   - test: `bitwiseOperators`
@@ -128,7 +122,6 @@ if the bits are equal to `1` in *either* input number:
 
 ![](bitwiseOR)
 
-
 <!--
   iBooks Store screenshot ends here.
 -->
@@ -143,7 +136,6 @@ let someBits: UInt8 = 0b10110010
 let moreBits: UInt8 = 0b01011110
 let combinedbits = someBits | moreBits  // equals 11111110
 ```
-
 
 <!--
   - test: `bitwiseOperators`
@@ -166,7 +158,6 @@ and are set to `0` where the input bits are the same:
 
 ![](bitwiseXOR)
 
-
 In the example below,
 the values of `firstBits` and `otherBits` each have a bit set to `1`
 in a location that the other does not.
@@ -179,7 +170,6 @@ let firstBits: UInt8 = 0b00010100
 let otherBits: UInt8 = 0b00000101
 let outputBits = firstBits ^ otherBits  // equals 00010001
 ```
-
 
 <!--
   - test: `bitwiseOperators`
@@ -229,7 +219,6 @@ and orange zeros are inserted:
 
 ![](bitshiftUnsigned)
 
-
 Here's how bit shifting looks in Swift code:
 
 ```swift
@@ -240,7 +229,6 @@ shiftBits << 5             // 10000000
 shiftBits << 6             // 00000000
 shiftBits >> 2             // 00000001
 ```
-
 
 <!--
   - test: `bitwiseShiftOperators`
@@ -278,7 +266,6 @@ let redComponent = (pink & 0xFF0000) >> 16    // redComponent is 0xCC, or 204
 let greenComponent = (pink & 0x00FF00) >> 8   // greenComponent is 0x66, or 102
 let blueComponent = pink & 0x0000FF           // blueComponent is 0x99, or 153
 ```
-
 
 <!--
   - test: `bitwiseShiftOperators`
@@ -343,7 +330,6 @@ Here's how the bits inside an `Int8` look for the number `4`:
 
 ![](bitshiftSignedFour)
 
-
 The sign bit is `0` (meaning “positive”),
 and the seven value bits are just the number `4`,
 written in binary notation.
@@ -358,12 +344,10 @@ Here's how the bits inside an `Int8` look for the number `-4`:
 
 ![](bitshiftSignedMinusFour)
 
-
 This time, the sign bit is `1` (meaning “negative”),
 and the seven value bits have a binary value of `124` (which is `128 - 4`):
 
 ![](bitshiftSignedMinusFourValue)
-
 
 This encoding for negative numbers is known as a *two's complement* representation.
 It may seem an unusual way to represent negative numbers,
@@ -376,7 +360,6 @@ and discarding anything that doesn't fit in the eight bits once you're done:
 
 ![](bitshiftSignedAddition)
 
-
 Second, the two's complement representation also lets you
 shift the bits of negative numbers to the left and right like positive numbers,
 and still end up doubling them for every shift you make to the left,
@@ -388,7 +371,6 @@ but fill any empty bits on the left with the *sign bit*,
 rather than with a zero.
 
 ![](bitshiftSigned)
-
 
 This action ensures that signed integers have the same sign after they're shifted to the right,
 and is known as an *arithmetic shift*.
@@ -416,7 +398,6 @@ var potentialOverflow = Int16.max
 potentialOverflow += 1
 // this causes an error
 ```
-
 
 <!--
   - test: `overflowOperatorsWillFailToOverflow`
@@ -460,7 +441,6 @@ unsignedOverflow = unsignedOverflow &+ 1
 // unsignedOverflow is now equal to 0
 ```
 
-
 <!--
   - test: `overflowOperatorsWillOverflowInPositiveDirection`
   
@@ -485,7 +465,6 @@ after the overflow addition is `00000000`, or zero.
 
 ![](overflowAddition)
 
-
 Something similar happens when
 an unsigned integer is allowed to overflow in the negative direction.
 Here's an example using the overflow subtraction operator (`&-`):
@@ -496,7 +475,6 @@ var unsignedOverflow = UInt8.min
 unsignedOverflow = unsignedOverflow &- 1
 // unsignedOverflow is now equal to 255
 ```
-
 
 <!--
   - test: `overflowOperatorsWillOverflowInNegativeDirection`
@@ -519,7 +497,6 @@ or `255` in decimal.
 
 ![](overflowUnsignedSubtraction)
 
-
 Overflow also occurs for signed integers.
 All addition and subtraction for signed integers is performed in bitwise fashion,
 with the sign bit included as part of the numbers being added or subtracted,
@@ -531,7 +508,6 @@ var signedOverflow = Int8.min
 signedOverflow = signedOverflow &- 1
 // signedOverflow is now equal to 127
 ```
-
 
 <!--
   - test: `overflowOperatorsWillOverflowSigned`
@@ -554,7 +530,6 @@ which toggles the sign bit and gives positive `127`,
 the maximum positive value that an `Int8` can hold.
 
 ![](overflowSignedSubtraction)
-
 
 For both signed and unsigned integers,
 overflow in the positive direction
@@ -583,7 +558,6 @@ operator precedence explains why the following expression equals `17`.
 2 + 3 % 4 * 5
 // this equals 17
 ```
-
 
 <!--
   - test: `evaluationOrder`
@@ -627,7 +601,6 @@ starting from their left:
 2 + ((3 % 4) * 5)
 ```
 
-
 <!--
   - test: `evaluationOrder`
   
@@ -649,7 +622,6 @@ starting from their left:
 2 + (3 * 5)
 ```
 
-
 <!--
   - test: `evaluationOrder`
   
@@ -670,7 +642,6 @@ starting from their left:
 ```swift
 2 + 15
 ```
-
 
 <!--
   - test: `evaluationOrder`
@@ -727,7 +698,6 @@ extension Vector2D {
 }
 ```
 
-
 <!--
   - test: `customOperators`
   
@@ -771,7 +741,6 @@ let combinedVector = vector + anotherVector
 // combinedVector is a Vector2D instance with values of (5.0, 5.0)
 ```
 
-
 <!--
   - test: `customOperators`
   
@@ -788,7 +757,6 @@ This example adds together the vectors `(3.0, 1.0)` and `(2.0, 4.0)`
 to make the vector `(5.0, 5.0)`, as illustrated below.
 
 ![](vectorAddition)
-
 
 ### Prefix and Postfix Operators
 
@@ -810,7 +778,6 @@ extension Vector2D {
     }
 }
 ```
-
 
 <!--
   - test: `customOperators`
@@ -841,7 +808,6 @@ let negative = -positive
 let alsoPositive = -negative
 // alsoPositive is a Vector2D instance with values of (3.0, 4.0)
 ```
-
 
 <!--
   - test: `customOperators`
@@ -876,7 +842,6 @@ extension Vector2D {
 }
 ```
 
-
 <!--
   - test: `customOperators`
   
@@ -901,7 +866,6 @@ let vectorToAdd = Vector2D(x: 3.0, y: 4.0)
 original += vectorToAdd
 // original now has values of (4.0, 6.0)
 ```
-
 
 <!--
   - test: `customOperators`
@@ -965,7 +929,6 @@ extension Vector2D: Equatable {
 }
 ```
 
-
 <!--
   - test: `customOperators`
   
@@ -995,7 +958,6 @@ if twoThree == anotherTwoThree {
 }
 // Prints "These two vectors are equivalent."
 ```
-
 
 <!--
   - test: `customOperators`
@@ -1028,7 +990,6 @@ and are marked with the `prefix`, `infix` or `postfix` modifiers:
 prefix operator +++
 ```
 
-
 <!--
   - test: `customOperators`
   
@@ -1060,7 +1021,6 @@ let afterDoubling = +++toBeDoubled
 // toBeDoubled now has values of (2.0, 8.0)
 // afterDoubling also has values of (2.0, 8.0)
 ```
-
 
 <!--
   - test: `customOperators`
@@ -1110,7 +1070,6 @@ let secondVector = Vector2D(x: 3.0, y: 4.0)
 let plusMinusVector = firstVector +- secondVector
 // plusMinusVector is a Vector2D instance with values of (4.0, -2.0)
 ```
-
 
 <!--
   - test: `customOperators`
@@ -1212,7 +1171,6 @@ struct AllCaps: Drawable {
 }
 ```
 
-
 <!--
   - test: `result-builder`
   
@@ -1273,7 +1231,6 @@ print(manualDrawing.draw())
 // Prints "***Hello RAVI PATEL!**"
 ```
 
-
 <!--
   - test: `result-builder`
   
@@ -1320,7 +1277,6 @@ struct DrawingBuilder {
     }
 }
 ```
-
 
 <!--
   - test: `result-builder`
@@ -1387,7 +1343,6 @@ print(personalGreeting.draw())
 // Prints "***Hello RAVI PATEL!**"
 ```
 
-
 <!--
   - test: `result-builder`
   
@@ -1453,7 +1408,6 @@ let capsDrawing = caps {
 }
 ```
 
-
 <!--
   - test: `result-builder`
   
@@ -1498,7 +1452,6 @@ let manyStars = draw {
     }
 }
 ```
-
 
 <!--
   - test: `result-builder`
@@ -1611,7 +1564,6 @@ see <doc:Attributes#resultBuilder>.
 <!--
   TODO: generic operators
 -->
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/AutomaticReferenceCounting.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/AutomaticReferenceCounting.md
@@ -1,5 +1,3 @@
-
-
 # Automatic Reference Counting
 
 Model the lifetime of objects and their relationships.
@@ -74,7 +72,6 @@ class Person {
 }
 ```
 
-
 <!--
   - test: `howARCWorks`
   
@@ -110,7 +107,6 @@ var reference2: Person?
 var reference3: Person?
 ```
 
-
 <!--
   - test: `howARCWorks`
   
@@ -128,7 +124,6 @@ and assign it to one of these three variables:
 reference1 = Person(name: "John Appleseed")
 // Prints "John Appleseed is being initialized"
 ```
-
 
 <!--
   - test: `howARCWorks`
@@ -156,7 +151,6 @@ reference2 = reference1
 reference3 = reference1
 ```
 
-
 <!--
   - test: `howARCWorks`
   
@@ -178,7 +172,6 @@ reference1 = nil
 reference2 = nil
 ```
 
-
 <!--
   - test: `howARCWorks`
   
@@ -196,7 +189,6 @@ at which point it's clear that you are no longer using the `Person` instance:
 reference3 = nil
 // Prints "John Appleseed is being deinitialized"
 ```
-
 
 <!--
   - test: `howARCWorks`
@@ -247,7 +239,6 @@ class Apartment {
 }
 ```
 
-
 <!--
   - test: `referenceCycles`
   
@@ -291,7 +282,6 @@ var john: Person?
 var unit4A: Apartment?
 ```
 
-
 <!--
   - test: `referenceCycles`
   
@@ -309,7 +299,6 @@ john = Person(name: "John Appleseed")
 unit4A = Apartment(unit: "4A")
 ```
 
-
 <!--
   - test: `referenceCycles`
   
@@ -325,7 +314,6 @@ and the `unit4A` variable has a strong reference to the new `Apartment` instance
 
 ![](referenceCycle01)
 
-
 You can now link the two instances together
 so that the person has an apartment, and the apartment has a tenant.
 Note that an exclamation point (`!`) is used to unwrap and access
@@ -336,7 +324,6 @@ so that the properties of those instances can be set:
 john!.apartment = unit4A
 unit4A!.tenant = john
 ```
-
 
 <!--
   - test: `referenceCycles`
@@ -351,7 +338,6 @@ Here's how the strong references look after you link the two instances together:
 
 ![](referenceCycle02)
 
-
 Unfortunately, linking these two instances creates
 a strong reference cycle between them.
 The `Person` instance now has a strong reference to the `Apartment` instance,
@@ -365,7 +351,6 @@ and the instances aren't deallocated by ARC:
 john = nil
 unit4A = nil
 ```
-
 
 <!--
   - test: `referenceCycles`
@@ -385,7 +370,6 @@ Here's how the strong references look after you set
 the `john` and `unit4A` variables to `nil`:
 
 ![](referenceCycle03)
-
 
 The strong references between the `Person` instance
 and the `Apartment` instance remain and can't be broken.
@@ -481,7 +465,6 @@ class Apartment {
 }
 ```
 
-
 <!--
   - test: `weakReferences`
   
@@ -516,7 +499,6 @@ john!.apartment = unit4A
 unit4A!.tenant = john
 ```
 
-
 <!--
   - test: `weakReferences`
   
@@ -536,7 +518,6 @@ Here's how the references look now that you've linked the two instances together
 
 ![](weakReference01)
 
-
 The `Person` instance still has a strong reference to the `Apartment` instance,
 but the `Apartment` instance now has a *weak* reference to the `Person` instance.
 This means that when you break the strong reference held by
@@ -547,7 +528,6 @@ there are no more strong references to the `Person` instance:
 john = nil
 // Prints "John Appleseed is being deinitialized"
 ```
-
 
 <!--
   - test: `weakReferences`
@@ -564,7 +544,6 @@ and the `tenant` property is set to `nil`:
 
 ![](weakReference02)
 
-
 The only remaining strong reference to the `Apartment` instance
 is from the `unit4A` variable.
 If you break *that* strong reference,
@@ -574,7 +553,6 @@ there are no more strong references to the `Apartment` instance:
 unit4A = nil
 // Prints "Apartment 4A is being deinitialized"
 ```
-
 
 <!--
   - test: `weakReferences`
@@ -589,7 +567,6 @@ Because there are no more strong references to the `Apartment` instance,
 it too is deallocated:
 
 ![](weakReference03)
-
 
 > Note: In systems that use garbage collection,
 > weak pointers are sometimes used to implement a simple caching mechanism
@@ -682,7 +659,6 @@ class CreditCard {
 }
 ```
 
-
 <!--
   - test: `unownedReferences`
   
@@ -721,7 +697,6 @@ This variable has an initial value of nil, by virtue of being optional:
 var john: Customer?
 ```
 
-
 <!--
   - test: `unownedReferences`
   
@@ -739,7 +714,6 @@ john = Customer(name: "John Appleseed")
 john!.card = CreditCard(number: 1234_5678_9012_3456, customer: john!)
 ```
 
-
 <!--
   - test: `unownedReferences`
   
@@ -753,7 +727,6 @@ Here's how the references look, now that you've linked the two instances:
 
 ![](unownedReference01)
 
-
 The `Customer` instance now has a strong reference to the `CreditCard` instance,
 and the `CreditCard` instance has an unowned reference to the `Customer` instance.
 
@@ -762,7 +735,6 @@ when you break the strong reference held by the `john` variable,
 there are no more strong references to the `Customer` instance:
 
 ![](unownedReference02)
-
 
 Because there are no more strong references to the `Customer` instance,
 it's deallocated.
@@ -775,7 +747,6 @@ john = nil
 // Prints "John Appleseed is being deinitialized"
 // Prints "Card #1234567890123456 is being deinitialized"
 ```
-
 
 <!--
   - test: `unownedReferences`
@@ -844,7 +815,6 @@ class Course {
 }
 ```
 
-
 <!--
   - test: `unowned-optional-references`
   
@@ -898,7 +868,6 @@ intermediate.nextCourse = advanced
 department.courses = [intro, intermediate, advanced]
 ```
 
-
 <!--
   - test: `unowned-optional-references`
   
@@ -922,7 +891,6 @@ which maintains an unowned optional reference to
 the course a student should take after completing this one.
 
 ![](unownedOptionalReference)
-
 
 An unowned optional reference doesn't keep a strong hold
 on the instance of the class that it wraps,
@@ -1028,7 +996,6 @@ class City {
 }
 ```
 
-
 <!--
   - test: `implicitlyUnwrappedOptionals`
   
@@ -1090,7 +1057,6 @@ var country = Country(name: "Canada", capitalName: "Ottawa")
 print("\(country.name)'s capital city is called \(country.capitalCity.name)")
 // Prints "Canada's capital city is called Ottawa"
 ```
-
 
 <!--
   - test: `implicitlyUnwrappedOptionals`
@@ -1168,7 +1134,6 @@ class HTMLElement {
 }
 ```
 
-
 <!--
   - test: `strongReferenceCyclesForClosures`
   
@@ -1241,7 +1206,6 @@ print(heading.asHTML())
 // Prints "<h1>some default text</h1>"
 ```
 
-
 <!--
   - test: `strongReferenceCyclesForClosures`
   
@@ -1278,7 +1242,6 @@ print(paragraph!.asHTML())
 // Prints "<p>hello, world</p>"
 ```
 
-
 <!--
   - test: `strongReferenceCyclesForClosures`
   
@@ -1300,7 +1263,6 @@ Here's how the cycle looks:
 
 ![](closureReferenceCycle01)
 
-
 The instance's `asHTML` property holds a strong reference to its closure.
 However, because the closure refers to `self` within its body
 (as a way to reference `self.name` and `self.text`),
@@ -1321,7 +1283,6 @@ because of the strong reference cycle:
 ```swift
 paragraph = nil
 ```
-
 
 <!--
   - test: `strongReferenceCyclesForClosures`
@@ -1369,7 +1330,6 @@ lazy var someClosure = {
 }
 ```
 
-
 <!--
   - test: `strongReferenceCyclesForClosures`
   
@@ -1397,7 +1357,6 @@ lazy var someClosure = {
     // closure body goes here
 }
 ```
-
 
 <!--
   - test: `strongReferenceCyclesForClosures`
@@ -1466,7 +1425,6 @@ class HTMLElement {
 }
 ```
 
-
 <!--
   - test: `unownedReferencesForClosures`
   
@@ -1511,7 +1469,6 @@ print(paragraph!.asHTML())
 // Prints "<p>hello, world</p>"
 ```
 
-
 <!--
   - test: `unownedReferencesForClosures`
   
@@ -1526,7 +1483,6 @@ Here's how the references look with the capture list in place:
 
 ![](closureReferenceCycle02)
 
-
 This time, the capture of `self` by the closure is an unowned reference,
 and doesn't keep a strong hold on the `HTMLElement` instance it has captured.
 If you set the strong reference from the `paragraph` variable to `nil`,
@@ -1537,7 +1493,6 @@ as can be seen from the printing of its deinitializer message in the example bel
 paragraph = nil
 // Prints "p is being deinitialized"
 ```
-
 
 <!--
   - test: `unownedReferencesForClosures`
@@ -1550,7 +1505,6 @@ paragraph = nil
 
 For more information about capture lists,
 see <doc:Expressions#Capture-Lists>.
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/BasicOperators.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/BasicOperators.md
@@ -1,5 +1,3 @@
-
-
 # Basic Operators
 
 Perform assignment, arithmetic, comparison, and Boolean operations.
@@ -62,7 +60,6 @@ a = b
 // a is now equal to 10
 ```
 
-
 <!--
   - test: `assignmentOperator`
   
@@ -82,7 +79,6 @@ its elements can be decomposed into multiple constants or variables at once:
 let (x, y) = (1, 2)
 // x is equal to 1, and y is equal to 2
 ```
-
 
 <!--
   - test: `assignmentOperator`
@@ -120,7 +116,6 @@ if x = y {
     // This isn't valid, because x = y doesn't return a value.
 }
 ```
-
 
 <!--
   - test: `assignmentOperatorInvalid`
@@ -164,7 +159,6 @@ Swift supports the four standard *arithmetic operators* for all number types:
 10.0 / 2.5  // equals 4.0
 ```
 
-
 <!--
   - test: `arithmeticOperators`
   
@@ -194,7 +188,6 @@ The addition operator is also supported for `String` concatenation:
 ```swift
 "hello, " + "world"  // equals "hello, world"
 ```
-
 
 <!--
   - test: `arithmeticOperators`
@@ -239,7 +232,6 @@ To calculate `9 % 4`, you first work out how many `4`s will fit inside `9`:
 
 ![](remainderInteger)
 
-
 You can fit two `4`s inside `9`, and the remainder is `1` (shown in orange).
 
 In Swift, this would be written as:
@@ -247,7 +239,6 @@ In Swift, this would be written as:
 ```swift
 9 % 4    // equals 1
 ```
-
 
 <!--
   - test: `arithmeticOperators`
@@ -277,7 +268,6 @@ The same method is applied when calculating the remainder for a negative value o
 ```swift
 -9 % 4   // equals -1
 ```
-
 
 <!--
   - test: `arithmeticOperators`
@@ -309,7 +299,6 @@ let minusThree = -three       // minusThree equals -3
 let plusThree = -minusThree   // plusThree equals 3, or "minus minus three"
 ```
 
-
 <!--
   - test: `arithmeticOperators`
   
@@ -332,7 +321,6 @@ the value it operates on, without any change:
 let minusSix = -6
 let alsoMinusSix = +minusSix  // alsoMinusSix equals -6
 ```
-
 
 <!--
   - test: `arithmeticOperators`
@@ -358,7 +346,6 @@ var a = 1
 a += 2
 // a is now equal to 3
 ```
-
 
 <!--
   - test: `compoundAssignment`
@@ -407,7 +394,6 @@ Each of the comparison operators returns a `Bool` value to indicate whether or n
 2 <= 1   // false because 2 isn't less than or equal to 1
 ```
 
-
 <!--
   - test: `comparisonOperators`
   
@@ -446,7 +432,6 @@ if name == "world" {
 // Prints "hello, world", because name is indeed equal to "world".
 ```
 
-
 <!--
   - test: `comparisonOperators`
   
@@ -482,7 +467,6 @@ For example:
 (3, "apple") < (3, "bird")    // true because 3 is equal to 3, and "apple" is less than "bird"
 (4, "dog") == (4, "dog")      // true because 4 is equal to 4, and "dog" is equal to "dog"
 ```
-
 
 <!--
   - test: `tuple-comparison-operators`
@@ -525,7 +509,6 @@ with the `<` operator because the `<` operator can't be applied to
 ("blue", -1) < ("purple", 1)        // OK, evaluates to true
 ("blue", false) < ("purple", true)  // Error because < can't compare Boolean values
 ```
-
 
 <!--
   - test: `tuple-comparison-operators-err`
@@ -587,7 +570,6 @@ if question {
 }
 ```
 
-
 <!--
   - test: `ternaryConditionalOperatorOutline`
   
@@ -625,7 +607,6 @@ let rowHeight = contentHeight + (hasHeader ? 50 : 20)
 // rowHeight is equal to 90
 ```
 
-
 <!--
   - test: `ternaryConditionalOperatorPart1`
   
@@ -651,7 +632,6 @@ if hasHeader {
 }
 // rowHeight is equal to 90
 ```
-
 
 <!--
   - test: `ternaryConditionalOperatorPart2`
@@ -694,7 +674,6 @@ The nil-coalescing operator is shorthand for the code below:
 a != nil ? a! : b
 ```
 
-
 <!--
   - test: `nilCoalescingOperatorOutline`
   
@@ -729,7 +708,6 @@ var colorNameToUse = userDefinedColorName ?? defaultColorName
 // userDefinedColorName is nil, so colorNameToUse is set to the default of "red"
 ```
 
-
 <!--
   - test: `nilCoalescingOperator`
   
@@ -762,7 +740,6 @@ userDefinedColorName = "green"
 colorNameToUse = userDefinedColorName ?? defaultColorName
 // userDefinedColorName isn't nil, so colorNameToUse is set to "green"
 ```
-
 
 <!--
   - test: `nilCoalescingOperator`
@@ -828,7 +805,6 @@ for index in 1...5 {
 // 4 times 5 is 20
 // 5 times 5 is 25
 ```
-
 
 <!--
   - test: `rangeOperators`
@@ -902,7 +878,6 @@ for i in 0..<count {
 // Person 4 is called Jack
 ```
 
-
 <!--
   - test: `rangeOperators`
   
@@ -955,7 +930,6 @@ for name in names[...2] {
 // Brian
 ```
 
-
 <!--
   - test: `rangeOperators`
   
@@ -990,7 +964,6 @@ for name in names[..<2] {
 // Alex
 ```
 
-
 <!--
   - test: `rangeOperators`
   
@@ -1020,7 +993,6 @@ range.contains(7)   // false
 range.contains(4)   // true
 range.contains(-1)  // true
 ```
-
 
 <!--
   - test: `rangeOperators`
@@ -1067,7 +1039,6 @@ if !allowedEntry {
 }
 // Prints "ACCESS DENIED"
 ```
-
 
 <!--
   - test: `logicalOperators`
@@ -1116,7 +1087,6 @@ if enteredDoorCode && passedRetinaScan {
 // Prints "ACCESS DENIED"
 ```
 
-
 <!--
   - test: `logicalOperators`
   
@@ -1164,7 +1134,6 @@ if hasDoorKey || knowsOverridePassword {
 // Prints "Welcome!"
 ```
 
-
 <!--
   - test: `logicalOperators`
   
@@ -1192,7 +1161,6 @@ if enteredDoorCode && passedRetinaScan || hasDoorKey || knowsOverridePassword {
 }
 // Prints "Welcome!"
 ```
-
 
 <!--
   - test: `logicalOperators`
@@ -1243,7 +1211,6 @@ if (enteredDoorCode && passedRetinaScan) || hasDoorKey || knowsOverridePassword 
 // Prints "Welcome!"
 ```
 
-
 <!--
   - test: `logicalOperators`
   
@@ -1263,7 +1230,6 @@ The output of the compound expression doesn't change,
 but the overall intention is clearer to the reader.
 Readability is always preferred over brevity;
 use parentheses where they help to make your intentions clear.
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/ClassesAndStructures.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/ClassesAndStructures.md
@@ -1,5 +1,3 @@
-
-
 # Structures and Classes
 
 Model custom types that encapsulate data.
@@ -79,7 +77,6 @@ class SomeClass {
 }
 ```
 
-
 <!--
   - test: `ClassesAndStructures`
   
@@ -117,7 +114,6 @@ class VideoMode {
     var name: String?
 }
 ```
-
 
 <!--
   - test: `ClassesAndStructures`
@@ -171,7 +167,6 @@ let someResolution = Resolution()
 let someVideoMode = VideoMode()
 ```
 
-
 <!--
   - test: `ClassesAndStructures`
   
@@ -205,7 +200,6 @@ print("The width of someResolution is \(someResolution.width)")
 // Prints "The width of someResolution is 0"
 ```
 
-
 <!--
   - test: `ClassesAndStructures`
   
@@ -227,7 +221,6 @@ print("The width of someVideoMode is \(someVideoMode.resolution.width)")
 // Prints "The width of someVideoMode is 0"
 ```
 
-
 <!--
   - test: `ClassesAndStructures`
   
@@ -244,7 +237,6 @@ someVideoMode.resolution.width = 1280
 print("The width of someVideoMode is now \(someVideoMode.resolution.width)")
 // Prints "The width of someVideoMode is now 1280"
 ```
-
 
 <!--
   - test: `ClassesAndStructures`
@@ -266,7 +258,6 @@ can be passed to the memberwise initializer by name:
 ```swift
 let vga = Resolution(width: 640, height: 480)
 ```
-
 
 <!--
   - test: `ClassesAndStructures`
@@ -333,7 +324,6 @@ let hd = Resolution(width: 1920, height: 1080)
 var cinema = hd
 ```
 
-
 <!--
   - test: `ClassesAndStructures`
   
@@ -364,7 +354,6 @@ the width of the slightly wider 2K standard used for digital cinema projection
 cinema.width = 2048
 ```
 
-
 <!--
   - test: `ClassesAndStructures`
   
@@ -380,7 +369,6 @@ shows that it has indeed changed to be `2048`:
 print("cinema is now \(cinema.width) pixels wide")
 // Prints "cinema is now 2048 pixels wide"
 ```
-
 
 <!--
   - test: `ClassesAndStructures`
@@ -398,7 +386,6 @@ still has the old value of `1920`:
 print("hd is still \(hd.width) pixels wide")
 // Prints "hd is still 1920 pixels wide"
 ```
-
 
 <!--
   - test: `ClassesAndStructures`
@@ -420,7 +407,6 @@ as shown in the figure below:
 
 ![](sharedStateStruct)
 
-
 The same behavior applies to enumerations:
 
 ```swift
@@ -439,7 +425,6 @@ print("The remembered direction is \(rememberedDirection)")
 // Prints "The current direction is north"
 // Prints "The remembered direction is west"
 ```
-
 
 <!--
   - test: `ClassesAndStructures`
@@ -488,7 +473,6 @@ tenEighty.name = "1080i"
 tenEighty.frameRate = 25.0
 ```
 
-
 <!--
   - test: `ClassesAndStructures`
   
@@ -516,7 +500,6 @@ let alsoTenEighty = tenEighty
 alsoTenEighty.frameRate = 30.0
 ```
 
-
 <!--
   - test: `ClassesAndStructures`
   
@@ -533,7 +516,6 @@ as shown in the figure below:
 
 ![](sharedStateClass)
 
-
 Checking the `frameRate` property of `tenEighty`
 shows that it correctly reports the new frame rate of `30.0`
 from the underlying `VideoMode` instance:
@@ -542,7 +524,6 @@ from the underlying `VideoMode` instance:
 print("The frameRate property of tenEighty is now \(tenEighty.frameRate)")
 // Prints "The frameRate property of tenEighty is now 30.0"
 ```
-
 
 <!--
   - test: `ClassesAndStructures`
@@ -647,7 +628,6 @@ if tenEighty === alsoTenEighty {
 // Prints "tenEighty and alsoTenEighty refer to the same VideoMode instance."
 ```
 
-
 <!--
   - test: `ClassesAndStructures`
   
@@ -729,7 +709,6 @@ see [Manual Memory Management](https://developer.apple.com/documentation/swift/s
 <!--
   QUESTION: what's the deal with tuples and reference types / value types?
 -->
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Closures.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Closures.md
@@ -1,5 +1,3 @@
-
-
 # Closures
 
 Group code that executes together, without creating a named function.
@@ -72,7 +70,6 @@ Here's the initial array to be sorted:
 let names = ["Chris", "Alex", "Ewa", "Barry", "Daniella"]
 ```
 
-
 <!--
   - test: `closureSyntax`
   
@@ -102,7 +99,6 @@ func backward(_ s1: String, _ s2: String) -> Bool {
 var reversedNames = names.sorted(by: backward)
 // reversedNames is equal to ["Ewa", "Daniella", "Chris", "Barry", "Alex"]
 ```
-
 
 <!--
   - test: `closureSyntax`
@@ -142,7 +138,6 @@ Closure expression syntax has the following general form:
 }
 ```
 
-
 The *parameters* in closure expression syntax
 can be in-out parameters,
 but they can't have a default value.
@@ -157,7 +152,6 @@ reversedNames = names.sorted(by: { (s1: String, s2: String) -> Bool in
     return s1 > s2
 })
 ```
-
 
 <!--
   - test: `closureSyntax`
@@ -189,7 +183,6 @@ it can even be written on a single line:
 reversedNames = names.sorted(by: { (s1: String, s2: String) -> Bool in return s1 > s2 } )
 ```
 
-
 <!--
   - test: `closureSyntax`
   
@@ -219,7 +212,6 @@ can also be omitted:
 ```swift
 reversedNames = names.sorted(by: { s1, s2 in return s1 > s2 } )
 ```
-
 
 <!--
   - test: `closureSyntax`
@@ -252,7 +244,6 @@ as in this version of the previous example:
 ```swift
 reversedNames = names.sorted(by: { s1, s2 in s1 > s2 } )
 ```
-
 
 <!--
   - test: `closureSyntax`
@@ -287,7 +278,6 @@ because the closure expression is made up entirely of its body:
 ```swift
 reversedNames = names.sorted(by: { $0 > $1 } )
 ```
-
 
 <!--
   - test: `closureSyntax`
@@ -334,7 +324,6 @@ and Swift will infer that you want to use its string-specific implementation:
 reversedNames = names.sorted(by: >)
 ```
 
-
 <!--
   - test: `closureSyntax`
   
@@ -377,7 +366,6 @@ someFunctionThatTakesAClosure() {
 }
 ```
 
-
 <!--
   - test: `closureSyntax`
   
@@ -407,7 +395,6 @@ can be written outside of the `sorted(by:)` method's parentheses as a trailing c
 reversedNames = names.sorted() { $0 > $1 }
 ```
 
-
 <!--
   - test: `closureSyntax`
   
@@ -425,7 +412,6 @@ after the function or method's name when you call the function:
 ```swift
 reversedNames = names.sorted { $0 > $1 }
 ```
-
 
 <!--
   - test: `closureSyntax`
@@ -463,7 +449,6 @@ let digitNames = [
 let numbers = [16, 58, 510]
 ```
 
-
 <!--
   - test: `arrayMap`
   
@@ -496,7 +481,6 @@ let strings = numbers.map { (number) -> String in
 // strings is inferred to be of type [String]
 // its value is ["OneSix", "FiveEight", "FiveOneZero"]
 ```
-
 
 <!--
   - test: `arrayMap`
@@ -578,7 +562,6 @@ func loadPicture(from server: Server, completion: (Picture) -> Void, onFailure: 
 }
 ```
 
-
 <!--
   - test: `multiple-trailing-closures`
   
@@ -612,7 +595,6 @@ loadPicture(from: someServer) { picture in
     print("Couldn't download the next picture.")
 }
 ```
-
 
 <!--
   - test: `multiple-trailing-closures`
@@ -679,7 +661,6 @@ func makeIncrementer(forIncrement amount: Int) -> () -> Int {
 }
 ```
 
-
 <!--
   - test: `closures`
   
@@ -725,7 +706,6 @@ func incrementer() -> Int {
 }
 ```
 
-
 <!--
   - test: `closuresPullout`
   
@@ -760,7 +740,6 @@ Here's an example of `makeIncrementer` in action:
 let incrementByTen = makeIncrementer(forIncrement: 10)
 ```
 
-
 <!--
   - test: `closures`
   
@@ -782,7 +761,6 @@ incrementByTen()
 incrementByTen()
 // returns a value of 30
 ```
-
 
 <!--
   - test: `closures`
@@ -817,7 +795,6 @@ incrementBySeven()
 // returns a value of 7
 ```
 
-
 <!--
   - test: `closures`
   
@@ -838,7 +815,6 @@ and doesn't affect the variable captured by `incrementBySeven`:
 incrementByTen()
 // returns a value of 40
 ```
-
 
 <!--
   - test: `closures`
@@ -883,7 +859,6 @@ alsoIncrementByTen()
 incrementByTen()
 // returns a value of 60
 ```
-
 
 <!--
   - test: `closures`
@@ -932,7 +907,6 @@ func someFunctionWithEscapingClosure(completionHandler: @escaping () -> Void) {
     completionHandlers.append(completionHandler)
 }
 ```
-
 
 <!--
   - test: `noescape-closure-as-argument, implicit-self-struct`
@@ -994,7 +968,6 @@ print(instance.x)
 // Prints "100"
 ```
 
-
 <!--
   - test: `noescape-closure-as-argument`
   
@@ -1036,7 +1009,6 @@ class SomeOtherClass {
 }
 ```
 
-
 <!--
   - test: `noescape-closure-as-argument`
   
@@ -1076,7 +1048,6 @@ struct SomeStruct {
     }
 }
 ```
-
 
 <!--
   - test: `struct-capture-mutable-self`
@@ -1192,7 +1163,6 @@ print(customersInLine.count)
 // Prints "4"
 ```
 
-
 <!--
   - test: `autoclosures`
   
@@ -1248,7 +1218,6 @@ serve(customer: { customersInLine.remove(at: 0) } )
 // Prints "Now serving Alex!"
 ```
 
-
 <!--
   - test: `autoclosures-function`
   
@@ -1284,7 +1253,6 @@ func serve(customer customerProvider: @autoclosure () -> String) {
 serve(customer: customersInLine.remove(at: 0))
 // Prints "Now serving Ewa!"
 ```
-
 
 <!--
   - test: `autoclosures-function-with-autoclosure`
@@ -1327,7 +1295,6 @@ for customerProvider in customerProviders {
 // Prints "Now serving Daniella!"
 ```
 
-
 <!--
   - test: `autoclosures-function-with-escape`
   
@@ -1362,7 +1329,6 @@ which means the closures in the array can be executed after the function returns
 As a result,
 the value of the `customerProvider` argument
 must be allowed to escape the function's scope.
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/CollectionTypes.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/CollectionTypes.md
@@ -1,5 +1,3 @@
-
-
 # Collection Types
 
 Organize data using arrays, sets, and dictionaries.
@@ -12,7 +10,6 @@ Sets are unordered collections of unique values.
 Dictionaries are unordered collections of key-value associations.
 
 ![](CollectionTypes_intro)
-
 
 Arrays, sets, and dictionaries in Swift are always clear about
 the types of values and keys that they can store.
@@ -80,7 +77,6 @@ print("someInts is of type [Int] with \(someInts.count) items.")
 // Prints "someInts is of type [Int] with 0 items."
 ```
 
-
 <!--
   - test: `arraysEmpty`
   
@@ -106,7 +102,6 @@ someInts.append(3)
 someInts = []
 // someInts is now an empty array, but is still of type [Int]
 ```
-
 
 <!--
   - test: `arraysEmpty`
@@ -134,7 +129,6 @@ var threeDoubles = Array(repeating: 0.0, count: 3)
 // threeDoubles is of type [Double], and equals [0.0, 0.0, 0.0]
 ```
 
-
 <!--
   - test: `arraysEmpty`
   
@@ -158,7 +152,6 @@ var anotherThreeDoubles = Array(repeating: 2.5, count: 3)
 var sixDoubles = threeDoubles + anotherThreeDoubles
 // sixDoubles is inferred as [Double], and equals [0.0, 0.0, 0.0, 2.5, 2.5, 2.5]
 ```
-
 
 <!--
   - test: `arraysEmpty`
@@ -198,14 +191,12 @@ surrounded by a pair of square brackets:
 [<#value 1#>, <#value 2#>, <#value 3#>]
 ```
 
-
 The example below creates an array called `shoppingList` to store `String` values:
 
 ```swift
 var shoppingList: [String] = ["Eggs", "Milk"]
 // shoppingList has been initialized with two initial items
 ```
-
 
 <!--
   - test: `arrays`
@@ -242,7 +233,6 @@ The initialization of `shoppingList` could have been written in a shorter form i
 var shoppingList = ["Eggs", "Milk"]
 ```
 
-
 <!--
   - test: `arraysInferred`
   
@@ -267,7 +257,6 @@ print("The shopping list contains \(shoppingList.count) items.")
 // Prints "The shopping list contains 2 items."
 ```
 
-
 <!--
   - test: `arraysInferred`
   
@@ -289,7 +278,6 @@ if shoppingList.isEmpty {
 // Prints "The shopping list isn't empty."
 ```
 
-
 <!--
   - test: `arraysInferred`
   
@@ -310,7 +298,6 @@ shoppingList.append("Flour")
 // shoppingList now contains 3 items, and someone is making pancakes
 ```
 
-
 <!--
   - test: `arraysInferred`
   
@@ -330,7 +317,6 @@ shoppingList += ["Baking Powder"]
 shoppingList += ["Chocolate Spread", "Cheese", "Butter"]
 // shoppingList now contains 7 items
 ```
-
 
 <!--
   - test: `arraysInferred`
@@ -354,7 +340,6 @@ var firstItem = shoppingList[0]
 // firstItem is equal to "Eggs"
 ```
 
-
 <!--
   - test: `arraysInferred`
   
@@ -374,7 +359,6 @@ You can use subscript syntax to change an existing value at a given index:
 shoppingList[0] = "Six eggs"
 // the first item in the list is now equal to "Six eggs" rather than "Eggs"
 ```
-
 
 <!--
   - test: `arraysInferred`
@@ -408,7 +392,6 @@ shoppingList[4...6] = ["Bananas", "Apples"]
 // shoppingList now contains 6 items
 ```
 
-
 <!--
   - test: `arraysInferred`
   
@@ -427,7 +410,6 @@ shoppingList.insert("Maple Syrup", at: 0)
 // shoppingList now contains 7 items
 // "Maple Syrup" is now the first item in the list
 ```
-
 
 <!--
   - test: `arraysInferred`
@@ -455,7 +437,6 @@ let mapleSyrup = shoppingList.remove(at: 0)
 // shoppingList now contains 6 items, and no Maple Syrup
 // the mapleSyrup constant is now equal to the removed "Maple Syrup" string
 ```
-
 
 <!--
   - test: `arraysInferred`
@@ -488,7 +469,6 @@ firstItem = shoppingList[0]
 // firstItem is now equal to "Six eggs"
 ```
 
-
 <!--
   - test: `arraysInferred`
   
@@ -510,7 +490,6 @@ let apples = shoppingList.removeLast()
 // shoppingList now contains 5 items, and no apples
 // the apples constant is now equal to the removed "Apples" string
 ```
-
 
 <!--
   - test: `arraysInferred`
@@ -539,7 +518,6 @@ for item in shoppingList {
 // Baking Powder
 // Bananas
 ```
-
 
 <!--
   - test: `arraysInferred`
@@ -577,7 +555,6 @@ for (index, value) in shoppingList.enumerated() {
 // Item 4: Baking Powder
 // Item 5: Bananas
 ```
-
 
 <!--
   - test: `arraysInferred`
@@ -648,7 +625,6 @@ print("letters is of type Set<Character> with \(letters.count) items.")
 // Prints "letters is of type Set<Character> with 0 items."
 ```
 
-
 <!--
   - test: `setsEmpty`
   
@@ -673,7 +649,6 @@ letters = []
 // letters is now an empty set, but is still of type Set<Character>
 ```
 
-
 <!--
   - test: `setsEmpty`
   
@@ -697,7 +672,6 @@ The example below creates a set called `favoriteGenres` to store `String` values
 var favoriteGenres: Set<String> = ["Rock", "Classical", "Hip hop"]
 // favoriteGenres has been initialized with three initial items
 ```
-
 
 <!--
   - test: `sets`
@@ -731,7 +705,6 @@ The initialization of `favoriteGenres` could have been written in a shorter form
 var favoriteGenres: Set = ["Rock", "Classical", "Hip hop"]
 ```
 
-
 <!--
   - test: `setsInferred`
   
@@ -756,7 +729,6 @@ print("I have \(favoriteGenres.count) favorite music genres.")
 // Prints "I have 3 favorite music genres."
 ```
 
-
 <!--
   - test: `setUsage`
   
@@ -779,7 +751,6 @@ if favoriteGenres.isEmpty {
 // Prints "I have particular music preferences."
 ```
 
-
 <!--
   - test: `setUsage`
   
@@ -799,7 +770,6 @@ You can add a new item into a set by calling the set's `insert(_:)` method:
 favoriteGenres.insert("[Tool J]")
 // favoriteGenres now contains 4 items
 ```
-
 
 <!--
   - test: `setUsage`
@@ -826,7 +796,6 @@ if let removedGenre = favoriteGenres.remove("Rock") {
 // Prints "Rock? I'm over it."
 ```
 
-
 <!--
   - test: `setUsage`
   
@@ -850,7 +819,6 @@ if favoriteGenres.contains("Funk") {
 }
 // Prints "It's too funky in here."
 ```
-
 
 <!--
   - test: `setUsage`
@@ -877,7 +845,6 @@ for genre in favoriteGenres {
 // [Tool J]
 // Hip hop
 ```
-
 
 <!--
   - test: `setUsage`
@@ -909,7 +876,6 @@ for genre in favoriteGenres.sorted() {
 // [Tool J]
 ```
 
-
 <!--
   - test: `setUsage`
   
@@ -937,7 +903,6 @@ with the results of various set operations represented by the shaded regions.
 
 ![](setVennDiagram)
 
-
 - Use the `intersection(_:)` method to create a new set with only the values common to both sets.
 - Use the `symmetricDifference(_:)` method to create a new set with values in either set, but not both.
 - Use the `union(_:)` method to create a new set with all of the values in both sets.
@@ -957,7 +922,6 @@ oddDigits.subtracting(singleDigitPrimeNumbers).sorted()
 oddDigits.symmetricDifference(singleDigitPrimeNumbers).sorted()
 // [1, 2, 9]
 ```
-
 
 <!--
   - test: `setOperations`
@@ -1004,7 +968,6 @@ because they share no elements in common.
 
 ![](setEulerDiagram)
 
-
 - Use the “is equal” operator (`==`) to determine whether two sets contain all of the same values.
 - Use the `isSubset(of:)` method to determine whether all of the values of a set are contained in the specified set.
 - Use the `isSuperset(of:)` method to determine whether a set contains all of the values in a specified set.
@@ -1023,7 +986,6 @@ farmAnimals.isSuperset(of: houseAnimals)
 farmAnimals.isDisjoint(with: cityAnimals)
 // true
 ```
-
 
 <!--
   - test: `setOperations`
@@ -1092,7 +1054,6 @@ var namesOfIntegers: [Int: String] = [:]
 // namesOfIntegers is an empty [Int: String] dictionary
 ```
 
-
 <!--
   - test: `dictionariesEmpty`
   
@@ -1117,7 +1078,6 @@ namesOfIntegers[16] = "sixteen"
 namesOfIntegers = [:]
 // namesOfIntegers is once again an empty dictionary of type [Int: String]
 ```
-
 
 <!--
   - test: `dictionariesEmpty`
@@ -1148,7 +1108,6 @@ surrounded by a pair of square brackets:
 [<#key 1#>: <#value 1#>, <#key 2#>: <#value 2#>, <#key 3#>: <#value 3#>]
 ```
 
-
 The example below creates a dictionary to store the names of international airports.
 In this dictionary, the keys are three-letter International Air Transport Association codes,
 and the values are airport names:
@@ -1156,7 +1115,6 @@ and the values are airport names:
 ```swift
 var airports: [String: String] = ["YYZ": "Toronto Pearson", "DUB": "Dublin"]
 ```
-
 
 <!--
   - test: `dictionaries`
@@ -1194,7 +1152,6 @@ The initialization of `airports` could have been written in a shorter form inste
 var airports = ["YYZ": "Toronto Pearson", "DUB": "Dublin"]
 ```
 
-
 <!--
   - test: `dictionariesInferred`
   
@@ -1221,7 +1178,6 @@ print("The airports dictionary contains \(airports.count) items.")
 // Prints "The airports dictionary contains 2 items."
 ```
 
-
 <!--
   - test: `dictionariesInferred`
   
@@ -1242,7 +1198,6 @@ if airports.isEmpty {
 }
 // Prints "The airports dictionary isn't empty."
 ```
-
 
 <!--
   - test: `dictionariesInferred`
@@ -1266,7 +1221,6 @@ airports["LHR"] = "London"
 // the airports dictionary now contains 3 items
 ```
 
-
 <!--
   - test: `dictionariesInferred`
   
@@ -1283,7 +1237,6 @@ You can also use subscript syntax to change the value associated with a particul
 airports["LHR"] = "London Heathrow"
 // the value for "LHR" has been changed to "London Heathrow"
 ```
-
 
 <!--
   - test: `dictionariesInferred`
@@ -1320,7 +1273,6 @@ if let oldValue = airports.updateValue("Dublin Airport", forKey: "DUB") {
 // Prints "The old value for DUB was Dublin."
 ```
 
-
 <!--
   - test: `dictionariesInferred`
   
@@ -1348,7 +1300,6 @@ if let airportName = airports["DUB"] {
 // Prints "The name of the airport is Dublin Airport."
 ```
 
-
 <!--
   - test: `dictionariesInferred`
   
@@ -1371,7 +1322,6 @@ airports["APL"] = "Apple International"
 airports["APL"] = nil
 // APL has now been removed from the dictionary
 ```
-
 
 <!--
   - test: `dictionariesInferred`
@@ -1406,7 +1356,6 @@ if let removedValue = airports.removeValue(forKey: "DUB") {
 // Prints "The removed airport's name is Dublin Airport."
 ```
 
-
 <!--
   - test: `dictionariesInferred`
   
@@ -1434,7 +1383,6 @@ for (airportCode, airportName) in airports {
 // LHR: London Heathrow
 // YYZ: Toronto Pearson
 ```
-
 
 <!--
   - test: `dictionariesInferred`
@@ -1467,7 +1415,6 @@ for airportName in airports.values {
 // Airport name: Toronto Pearson
 ```
 
-
 <!--
   - test: `dictionariesInferred`
   
@@ -1498,7 +1445,6 @@ let airportNames = [String](airports.values)
 // airportNames is ["London Heathrow", "Toronto Pearson"]
 ```
 
-
 <!--
   - test: `dictionariesInferred`
   
@@ -1516,7 +1462,6 @@ let airportNames = [String](airports.values)
 Swift's `Dictionary` type doesn't have a defined ordering.
 To iterate over the keys or values of a dictionary in a specific order,
 use the `sorted()` method on its `keys` or `values` property.
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Concurrency.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Concurrency.md
@@ -1,5 +1,3 @@
-
-
 # Concurrency
 
 Perform asynchronous operations.
@@ -66,7 +64,6 @@ listPhotos(inGallery: "Summer Vacation") { photoNames in
 }
 ```
 
-
 <!--
   - test: `async-via-nested-completion-handlers`
   
@@ -122,7 +119,6 @@ func listPhotos(inGallery name: String) async -> [String] {
 }
 ```
 
-
 <!--
   - test: `async-function-shape`
   
@@ -173,7 +169,6 @@ let name = sortedNames[0]
 let photo = await downloadPhoto(named: name)
 show(photo)
 ```
-
 
 <!--
   - test: `defining-async-function`
@@ -264,7 +259,6 @@ add(firstPhoto, toGallery: "Road Trip")
 remove(firstPhoto, fromGallery: "Summer Vacation")
 ```
 
-
 There's no way for other code to run in between
 the call to `add(_:toGallery:)` and `remove(_:fromGallery:)`.
 During that time, the first photo appears in both galleries,
@@ -282,7 +276,6 @@ func move(_ photoName: String, from source: String, to destination: String) {
 let firstPhoto = await listPhotos(inGallery: "Summer Vacation")[0]
 move(firstPhoto, from: "Summer Vacation", to: "Road Trip")
 ```
-
 
 In the example above,
 because the `move(_:from:to:)` function is synchronous,
@@ -366,7 +359,6 @@ for try await line in handle.bytes.lines {
     print(line)
 }
 ```
-
 
 <!--
   - test: `async-sequence`
@@ -457,7 +449,6 @@ let photos = [firstPhoto, secondPhoto, thirdPhoto]
 show(photos)
 ```
 
-
 <!--
   - test: `defining-async-function`
   
@@ -496,7 +487,6 @@ async let thirdPhoto = downloadPhoto(named: photoNames[2])
 let photos = await [firstPhoto, secondPhoto, thirdPhoto]
 show(photos)
 ```
-
 
 <!--
   - test: `calling-with-async-let`
@@ -575,7 +565,6 @@ await withTaskGroup(of: Data.self) { taskGroup in
     }
 }
 ```
-
 
 <!--
   TODO walk through the example
@@ -725,7 +714,6 @@ let handle = Task {
 let result = await handle.value
 ```
 
-
 For more information about managing detached tasks,
 see [Task](https://developer.apple.com/documentation/swift/task).
 
@@ -821,7 +809,6 @@ actor TemperatureLogger {
 }
 ```
 
-
 <!--
   - test: `actors, actors-implicitly-sendable`
   
@@ -859,7 +846,6 @@ print(await logger.max)
 // Prints "25"
 ```
 
-
 In this example,
 accessing `logger.max` is a possible suspension point.
 Because the actor allows only one task at a time to access its mutable state,
@@ -882,7 +868,6 @@ extension TemperatureLogger {
     }
 }
 ```
-
 
 The `update(with:)` method is already running on the actor,
 so it doesn't mark its access to properties like `max` with `await`.
@@ -924,7 +909,6 @@ For example:
 ```
 print(logger.max)  // Error
 ```
-
 
 Accessing `logger.max` without writing `await` fails because
 the properties of an actor are part of that actor's isolated local state.
@@ -1079,7 +1063,6 @@ let reading = TemperatureReading(measurement: 45)
 await logger.addReading(from: reading)
 ```
 
-
 <!--
   - test: `actors`
   
@@ -1111,7 +1094,6 @@ struct TemperatureReading {
     var measurement: Int
 }
 ```
-
 
 <!--
   - test: `actors-implicitly-sendable`
@@ -1184,7 +1166,6 @@ struct TemperatureReading {
   Probably don't cover unsafe continuations (SE-0300) in TSPL,
   but maybe link to them?
 -->
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/ControlFlow.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/ControlFlow.md
@@ -1,5 +1,3 @@
-
-
 # Control Flow
 
 Structure code with branches, loops, and early exits.
@@ -40,7 +38,6 @@ for name in names {
 // Hello, Jack!
 ```
 
-
 <!--
   - test: `forLoops`
   
@@ -73,7 +70,6 @@ for (animalName, legCount) in numberOfLegs {
 // ants have 6 legs
 // spiders have 8 legs
 ```
-
 
 <!--
   - test: `forLoops`
@@ -115,7 +111,6 @@ for index in 1...5 {
 // 4 times 5 is 20
 // 5 times 5 is 25
 ```
-
 
 <!--
   - test: `forLoops`
@@ -164,7 +159,6 @@ print("\(base) to the power of \(power) is \(answer)")
 // Prints "3 to the power of 10 is 59049"
 ```
 
-
 <!--
   - test: `forLoops`
   
@@ -208,7 +202,6 @@ for tickMark in 0..<minutes {
 }
 ```
 
-
 <!--
   - test: `forLoops`
   
@@ -235,7 +228,6 @@ for tickMark in stride(from: 0, to: minutes, by: minuteInterval) {
 }
 ```
 
-
 <!--
   - test: `forLoops`
   
@@ -260,7 +252,6 @@ for tickMark in stride(from: 3, through: hours, by: hourInterval) {
     // render the tick mark every 3 hours (3, 6, 9, 12)
 }
 ```
-
 
 <!--
   - test: `forLoops`
@@ -314,7 +305,6 @@ while <#condition#> {
 }
 ```
 
-
 This example plays a simple game of *Snakes and Ladders*
 (also known as *Chutes and Ladders*):
 
@@ -323,7 +313,6 @@ This example plays a simple game of *Snakes and Ladders*
 -->
 
 ![](snakesAndLadders)
-
 
 The rules of the game are as follows:
 
@@ -347,7 +336,6 @@ let finalSquare = 25
 var board = [Int](repeating: 0, count: finalSquare + 1)
 ```
 
-
 <!--
   - test: `snakesAndLadders1`
   
@@ -366,7 +354,6 @@ whereas squares with a snake head have a negative number to move you back down t
 board[03] = +08; board[06] = +11; board[09] = +09; board[10] = +02
 board[14] = -10; board[19] = -11; board[22] = -02; board[24] = -08
 ```
-
 
 <!--
   - test: `snakesAndLadders1`
@@ -408,7 +395,6 @@ while square < finalSquare {
 }
 print("Game over!")
 ```
-
 
 <!--
   - test: `snakesAndLadders1`
@@ -516,7 +502,6 @@ repeat {
 } while <#condition#>
 ```
 
-
 Here's the *Snakes and Ladders* example again,
 written as a `repeat`-`while` loop rather than a `while` loop.
 The values of `finalSquare`, `board`, `square`, and `diceRoll`
@@ -530,7 +515,6 @@ board[14] = -10; board[19] = -11; board[22] = -02; board[24] = -08
 var square = 0
 var diceRoll = 0
 ```
-
 
 <!--
   - test: `snakesAndLadders2`
@@ -567,7 +551,6 @@ repeat {
 } while square < finalSquare
 print("Game over!")
 ```
-
 
 <!--
   - test: `snakesAndLadders2`
@@ -664,7 +647,6 @@ if temperatureInFahrenheit <= 32 {
 // Prints "It's very cold. Consider wearing a scarf."
 ```
 
-
 <!--
   - test: `ifElse`
   
@@ -698,7 +680,6 @@ if temperatureInFahrenheit <= 32 {
 }
 // Prints "It's not that cold. Wear a t-shirt."
 ```
-
 
 <!--
   - test: `ifElse`
@@ -734,7 +715,6 @@ if temperatureInFahrenheit <= 32 {
 // Prints "It's really warm. Don't forget to wear sunscreen."
 ```
 
-
 <!--
   - test: `ifElse`
   
@@ -766,7 +746,6 @@ if temperatureInFahrenheit <= 32 {
     print("It's really warm. Don't forget to wear sunscreen.")
 }
 ```
-
 
 <!--
   - test: `ifElse`
@@ -808,7 +787,6 @@ default:
 }
 ```
 
-
 Every `switch` statement consists of multiple possible *cases*,
 each of which begins with the `case` keyword.
 In addition to comparing against specific values,
@@ -843,7 +821,6 @@ default:
 }
 // Prints "The last letter of the alphabet"
 ```
-
 
 <!--
   - test: `switch`
@@ -902,7 +879,6 @@ default:
 // This will report a compile-time error.
 ```
 
-
 <!--
   - test: `noFallthrough`
   
@@ -945,7 +921,6 @@ default:
 }
 // Prints "The letter A"
 ```
-
 
 <!--
   - test: `compoundCaseInsteadOfFallthrough`
@@ -1003,7 +978,6 @@ default:
 print("There are \(naturalCount) \(countedThings).")
 // Prints "There are dozens of moons orbiting Saturn."
 ```
-
 
 <!--
   - test: `intervalMatching`
@@ -1066,7 +1040,6 @@ default:
 // Prints "(1, 1) is inside the box"
 ```
 
-
 <!--
   - test: `tuples`
   
@@ -1089,7 +1062,6 @@ default:
 -->
 
 ![](coordinateGraphSimple)
-
 
 The `switch` statement determines whether the point is
 at the origin (0, 0),
@@ -1129,7 +1101,6 @@ case let (x, y):
 // Prints "on the x-axis with an x value of 2"
 ```
 
-
 <!--
   - test: `valueBindings`
   
@@ -1148,7 +1119,6 @@ case let (x, y):
 -->
 
 ![](coordinateGraphMedium)
-
 
 The `switch` statement determines whether the point is
 on the red x-axis,
@@ -1194,7 +1164,6 @@ case let (x, y):
 // Prints "(1, -1) is on the line x == -y"
 ```
 
-
 <!--
   - test: `where`
   
@@ -1213,7 +1182,6 @@ case let (x, y):
 -->
 
 ![](coordinateGraphComplex)
-
 
 The `switch` statement determines whether the point is
 on the green diagonal line where `x == y`,
@@ -1252,7 +1220,6 @@ default:
 }
 // Prints "e is a vowel"
 ```
-
 
 <!--
   - test: `compound-switch-case`
@@ -1298,7 +1265,6 @@ default:
 }
 // Prints "On an axis, 9 from the origin"
 ```
-
 
 <!--
   - test: `compound-switch-case`
@@ -1362,7 +1328,6 @@ for character in puzzleInput {
 print(puzzleOutput)
 // Prints "grtmndsthnklk"
 ```
-
 
 <!--
   - test: `continue`
@@ -1452,7 +1417,6 @@ if let integerValue = possibleIntegerValue {
 // Prints "The integer value of 三 is 3."
 ```
 
-
 <!--
   - test: `breakInASwitchStatement`
   
@@ -1532,7 +1496,6 @@ print(description)
 // Prints "The number 5 is a prime number, and also an integer."
 ```
 
-
 <!--
   - test: `fallthrough`
   
@@ -1610,7 +1573,6 @@ although the principle is the same for all loops and `switch` statements:
 }
 ```
 
-
 The following example uses the `break` and `continue` statements
 with a labeled `while` loop for an adapted version of the *Snakes and Ladders* game
 that you saw earlier in this chapter.
@@ -1625,7 +1587,6 @@ The game board is the same as before.
 
 ![](snakesAndLadders)
 
-
 The values of `finalSquare`, `board`, `square`, and `diceRoll`
 are initialized in the same way as before:
 
@@ -1637,7 +1598,6 @@ board[14] = -10; board[19] = -11; board[22] = -02; board[24] = -08
 var square = 0
 var diceRoll = 0
 ```
-
 
 <!--
   - test: `labels`
@@ -1680,7 +1640,6 @@ gameLoop: while square != finalSquare {
 }
 print("Game over!")
 ```
-
 
 <!--
   - test: `labels`
@@ -1819,7 +1778,6 @@ greet(person: ["name": "Jane", "location": "Cupertino"])
 // Prints "I hope the weather is nice in Cupertino."
 ```
 
-
 <!--
   - test: `guard`
   
@@ -1898,7 +1856,6 @@ if #available(iOS 10, macOS 10.12, *) {
 }
 ```
 
-
 <!--
   - test: `availability`
   
@@ -1932,7 +1889,6 @@ if #available(<#platform name#> <#version#>, <#...#>, *) {
 }
 ```
 
-
 When you use an availability condition with a `guard` statement,
 it refines the availability information that’s used
 for the rest of the code in that code block.
@@ -1951,7 +1907,6 @@ func chooseBestColor() -> String {
     return colors.bestColor
 }
 ```
-
 
 <!--
   - test: `guard-with-pound-available`
@@ -1997,7 +1952,6 @@ if #unavailable(iOS 10) {
 }
 ```
 
-
 <!--
   - test: `availability-and-unavailability`
   
@@ -2021,7 +1975,6 @@ when the check contains only fallback code.
   Not a general purpose condition; can't combine with &&, etc.
   You can use it with if-let, and other Boolean conditions, using a comma
 -->
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Deinitialization.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Deinitialization.md
@@ -1,5 +1,3 @@
-
-
 # Deinitialization
 
 Release resources that require custom cleanup.
@@ -31,7 +29,6 @@ deinit {
     // perform the deinitialization
 }
 ```
-
 
 <!--
   - test: `deinitializer`
@@ -82,7 +79,6 @@ class Bank {
 }
 ```
 
-
 <!--
   - test: `deinitializer`
   
@@ -132,7 +128,6 @@ class Player {
 }
 ```
 
-
 <!--
   - test: `deinitializer`
   
@@ -172,7 +167,6 @@ print("There are now \(Bank.coinsInBank) coins left in the bank")
 // Prints "There are now 9900 coins left in the bank"
 ```
 
-
 <!--
   - test: `deinitializer`
   
@@ -202,7 +196,6 @@ print("The bank now only has \(Bank.coinsInBank) coins left")
 // Prints "The bank now only has 7900 coins left"
 ```
 
-
 <!--
   - test: `deinitializer`
   
@@ -227,7 +220,6 @@ print("The bank now has \(Bank.coinsInBank) coins")
 // Prints "The bank now has 10000 coins"
 ```
 
-
 <!--
   - test: `deinitializer`
   
@@ -249,7 +241,6 @@ No other properties or variables are still referring to the `Player` instance,
 and so it's deallocated in order to free up its memory.
 Just before this happens, its deinitializer is called automatically,
 and its coins are returned to the bank.
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Enumerations.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Enumerations.md
@@ -1,5 +1,3 @@
-
-
 # Enumerations
 
 Model custom types that define a list of possible values.
@@ -51,7 +49,6 @@ enum SomeEnumeration {
 }
 ```
 
-
 <!--
   - test: `enums`
   
@@ -72,7 +69,6 @@ enum CompassPoint {
     case west
 }
 ```
-
 
 <!--
   - test: `enums`
@@ -109,7 +105,6 @@ enum Planet {
 }
 ```
 
-
 <!--
   - test: `enums`
   
@@ -131,7 +126,6 @@ so that they read as self-evident:
 var directionToHead = CompassPoint.west
 ```
 
-
 <!--
   - test: `enums`
   
@@ -148,7 +142,6 @@ you can set it to a different `CompassPoint` value using a shorter dot syntax:
 ```swift
 directionToHead = .east
 ```
-
 
 <!--
   - test: `enums`
@@ -180,7 +173,6 @@ case .west:
 }
 // Prints "Watch out for penguins"
 ```
-
 
 <!--
   - test: `enums`
@@ -232,7 +224,6 @@ default:
 // Prints "Mostly harmless"
 ```
 
-
 <!--
   - test: `enums`
   
@@ -267,7 +258,6 @@ print("\(numberOfChoices) beverages available")
 // Prints "3 beverages available"
 ```
 
-
 <!--
   - test: `enums`
   
@@ -298,7 +288,6 @@ for beverage in Beverage.allCases {
 // tea
 // juice
 ```
-
 
 <!--
   - test: `enums`
@@ -348,13 +337,11 @@ These are followed by a check digit to verify that the code has been scanned cor
 
 ![](barcode_UPC)
 
-
 Other products are labeled with 2D barcodes in QR code format,
 which can use any ISO 8859-1 character
 and can encode a string up to 2,953 characters long:
 
 ![](barcode_QR)
-
 
 It's convenient for an inventory tracking system to store UPC barcodes
 as a tuple of four integers,
@@ -368,7 +355,6 @@ enum Barcode {
     case qrCode(String)
 }
 ```
-
 
 <!--
   - test: `enums`
@@ -399,7 +385,6 @@ You can then create new barcodes using either type:
 var productBarcode = Barcode.upc(8, 85909, 51226, 3)
 ```
 
-
 <!--
   - test: `enums`
   
@@ -417,7 +402,6 @@ You can assign the same product a different type of barcode:
 ```swift
 productBarcode = .qrCode("ABCDEFGHIJKLMNOP")
 ```
-
 
 <!--
   - test: `enums`
@@ -453,7 +437,6 @@ case .qrCode(let productCode):
 // Prints "QR code: ABCDEFGHIJKLMNOP."
 ```
 
-
 <!--
   - test: `enums`
   
@@ -481,7 +464,6 @@ case let .qrCode(productCode):
 }
 // Prints "QR code: ABCDEFGHIJKLMNOP."
 ```
-
 
 <!--
   - test: `enums`
@@ -516,7 +498,6 @@ enum ASCIIControlCharacter: Character {
     case carriageReturn = "\r"
 }
 ```
-
 
 <!--
   - test: `rawValues`
@@ -567,7 +548,6 @@ enum Planet: Int {
 }
 ```
 
-
 <!--
   - test: `rawValues`
   
@@ -594,7 +574,6 @@ enum CompassPoint: String {
 }
 ```
 
-
 <!--
   - test: `rawValues`
   
@@ -617,7 +596,6 @@ let earthsOrder = Planet.earth.rawValue
 let sunsetDirection = CompassPoint.west.rawValue
 // sunsetDirection is "west"
 ```
-
 
 <!--
   - test: `rawValues`
@@ -647,7 +625,6 @@ This example identifies Uranus from its raw value of `7`:
 let possiblePlanet = Planet(rawValue: 7)
 // possiblePlanet is of type Planet? and equals Planet.uranus
 ```
-
 
 <!--
   - test: `rawValues`
@@ -687,7 +664,6 @@ if let somePlanet = Planet(rawValue: positionToFind) {
 }
 // Prints "There isn't a planet at position 11"
 ```
-
 
 <!--
   - test: `rawValues`
@@ -738,7 +714,6 @@ enum ArithmeticExpression {
 }
 ```
 
-
 <!--
   - test: `recursive-enum-intro`
   
@@ -761,7 +736,6 @@ indirect enum ArithmeticExpression {
     case multiplication(ArithmeticExpression, ArithmeticExpression)
 }
 ```
-
 
 <!--
   - test: `recursive-enum`
@@ -798,7 +772,6 @@ let sum = ArithmeticExpression.addition(five, four)
 let product = ArithmeticExpression.multiplication(sum, ArithmeticExpression.number(2))
 ```
 
-
 <!--
   - test: `recursive-enum`
   
@@ -830,7 +803,6 @@ print(evaluate(product))
 // Prints "18"
 ```
 
-
 <!--
   - test: `recursive-enum`
   
@@ -857,7 +829,6 @@ It evaluates an addition or multiplication
 by evaluating the expression on the left-hand side,
 evaluating the expression on the right-hand side,
 and then adding them or multiplying them.
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/ErrorHandling.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/ErrorHandling.md
@@ -1,5 +1,3 @@
-
-
 # Error Handling
 
 Respond to and recover from errors.
@@ -53,7 +51,6 @@ enum VendingMachineError: Error {
 }
 ```
 
-
 <!--
   - test: `throw-enum-error`
   
@@ -76,7 +73,6 @@ that five additional coins are needed by the vending machine:
 ```swift
 throw VendingMachineError.insufficientFunds(coinsNeeded: 5)
 ```
-
 
 <!--
   - test: `throw-enum-error`
@@ -139,7 +135,6 @@ func canThrowErrors() throws -> String
 
 func cannotThrowErrors() -> String
 ```
-
 
 <!--
   - test: `throwingFunctionDeclaration`
@@ -238,7 +233,6 @@ class VendingMachine {
 }
 ```
 
-
 <!--
   - test: `errorHandling`
   
@@ -314,7 +308,6 @@ func buyFavoriteSnack(person: String, vendingMachine: VendingMachine) throws {
 }
 ```
 
-
 <!--
   - test: `errorHandling`
   
@@ -356,7 +349,6 @@ struct PurchasedSnack {
     }
 }
 ```
-
 
 <!--
   - test: `errorHandling`
@@ -412,7 +404,6 @@ do {
 }
 ```
 
-
 You write a pattern after `catch` to indicate what errors
 that clause can handle.
 If a `catch` clause doesn't have a pattern,
@@ -447,7 +438,6 @@ do {
 }
 // Prints "Insufficient funds. Please insert an additional 2 coins."
 ```
-
 
 <!--
   - test: `errorHandling`
@@ -520,7 +510,6 @@ do {
 // Prints "Couldn't buy that from the vending machine."
 ```
 
-
 <!--
   - test: `errorHandling`
   
@@ -563,7 +552,6 @@ func eat(item: String) throws {
     }
 }
 ```
-
 
 <!--
   - test: `errorHandling`
@@ -619,7 +607,6 @@ do {
 }
 ```
 
-
 <!--
   - test: `optional-try`
   
@@ -665,7 +652,6 @@ func fetchData() -> Data? {
 }
 ```
 
-
 <!--
   - test: `optional-try-cached-data`
   
@@ -700,7 +686,6 @@ so it's appropriate to disable error propagation.
 ```swift
 let photo = try! loadImage(atPath: "./Resources/John Appleseed.jpg")
 ```
-
 
 <!--
   - test: `forceTryStatement`
@@ -755,7 +740,6 @@ func processFile(filename: String) throws {
 }
 ```
 
-
 <!--
   - test: `defer`
   
@@ -788,7 +772,6 @@ has a corresponding call to `close(_:)`.
 
 > Note: You can use a `defer` statement
 > even when no error handling code is involved.
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Extensions.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Extensions.md
@@ -1,5 +1,3 @@
-
-
 # Extensions
 
 Add functionality to an existing type.
@@ -87,7 +85,6 @@ extension SomeType {
 }
 ```
 
-
 <!--
   - test: `extensionSyntax`
   
@@ -109,7 +106,6 @@ extension SomeType: SomeProtocol, AnotherProtocol {
     // implementation of protocol requirements goes here
 }
 ```
-
 
 <!--
   - test: `extensionSyntax`
@@ -156,7 +152,6 @@ let threeFeet = 3.ft
 print("Three feet is \(threeFeet) meters")
 // Prints "Three feet is 0.914399970739201 meters"
 ```
-
 
 <!--
   - test: `extensionsComputedProperties`
@@ -207,7 +202,6 @@ let aMarathon = 42.km + 195.m
 print("A marathon is \(aMarathon) meters long")
 // Prints "A marathon is 42195.0 meters long"
 ```
-
 
 <!--
   - test: `extensionsComputedProperties`
@@ -282,7 +276,6 @@ struct Rect {
 }
 ```
 
-
 <!--
   - test: `extensionsInitializers`
   
@@ -311,7 +304,6 @@ let memberwiseRect = Rect(origin: Point(x: 2.0, y: 2.0),
     size: Size(width: 5.0, height: 5.0))
 ```
 
-
 <!--
   - test: `extensionsInitializers`
   
@@ -334,7 +326,6 @@ extension Rect {
     }
 }
 ```
-
 
 <!--
   - test: `extensionsInitializers`
@@ -361,7 +352,6 @@ let centerRect = Rect(center: Point(x: 4.0, y: 4.0),
     size: Size(width: 3.0, height: 3.0))
 // centerRect's origin is (2.5, 2.5) and its size is (3.0, 3.0)
 ```
-
 
 <!--
   - test: `extensionsInitializers`
@@ -393,7 +383,6 @@ extension Int {
 }
 ```
 
-
 <!--
   - test: `extensionsInstanceMethods`
   
@@ -423,7 +412,6 @@ to perform a task that many number of times:
 // Hello!
 // Hello!
 ```
-
 
 <!--
   - test: `extensionsInstanceMethods`
@@ -458,7 +446,6 @@ var someInt = 3
 someInt.square()
 // someInt is now 9
 ```
-
 
 <!--
   - test: `extensionsInstanceMethods`
@@ -507,7 +494,6 @@ extension Int {
 746381295[8]
 // returns 7
 ```
-
 
 <!--
   - test: `extensionsSubscripts`
@@ -562,7 +548,6 @@ as if the number had been padded with zeros to the left:
 0746381295[9]
 ```
 
-
 <!--
   - test: `extensionsSubscripts`
   
@@ -606,7 +591,6 @@ extension Int {
     }
 }
 ```
-
 
 <!--
   - test: `extensionsNestedTypes`
@@ -660,7 +644,6 @@ printIntegerKinds([3, 19, -27, 0, -6, 0, 7])
 // Prints "+ + - 0 - 0 + "
 ```
 
-
 <!--
   - test: `extensionsNestedTypes`
   
@@ -698,7 +681,6 @@ and prints an appropriate description.
 > Because of this, all of the `Int.Kind` case values
 > can be written in shorthand form inside the `switch` statement,
 > such as `.negative` rather than `Int.Kind.negative`.
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Functions.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Functions.md
@@ -1,5 +1,3 @@
-
-
 # Functions
 
 Define and call functions, label their arguments, and use their return values.
@@ -56,7 +54,6 @@ func greet(person: String) -> String {
 }
 ```
 
-
 <!--
   - test: `definingAndCalling`
   
@@ -86,7 +83,6 @@ print(greet(person: "Anna"))
 print(greet(person: "Brian"))
 // Prints "Hello, Brian!"
 ```
-
 
 <!--
   - test: `definingAndCalling`
@@ -136,7 +132,6 @@ print(greetAgain(person: "Anna"))
 // Prints "Hello again, Anna!"
 ```
 
-
 <!--
   - test: `definingAndCalling`
   
@@ -168,7 +163,6 @@ func sayHelloWorld() -> String {
 print(sayHelloWorld())
 // Prints "hello, world"
 ```
-
 
 <!--
   - test: `functionsWithoutParameters`
@@ -207,7 +201,6 @@ func greet(person: String, alreadyGreeted: Bool) -> String {
 print(greet(person: "Tim", alreadyGreeted: true))
 // Prints "Hello again, Tim!"
 ```
-
 
 <!--
   - test: `definingAndCalling`
@@ -249,7 +242,6 @@ greet(person: "Dave")
 // Prints "Hello, Dave!"
 ```
 
-
 <!--
   - test: `functionsWithoutReturnValues`
   
@@ -287,7 +279,6 @@ printAndCount(string: "hello, world")
 printWithoutCounting(string: "hello, world")
 // prints "hello, world" but doesn't return a value
 ```
-
 
 <!--
   - test: `functionsWithoutReturnValues`
@@ -359,7 +350,6 @@ func minMax(array: [Int]) -> (min: Int, max: Int) {
 }
 ```
 
-
 <!--
   - test: `tupleTypesAsReturnTypes`
   
@@ -400,7 +390,6 @@ let bounds = minMax(array: [8, -6, 2, 109, 3, 71])
 print("min is \(bounds.min) and max is \(bounds.max)")
 // Prints "min is -6 and max is 109"
 ```
-
 
 <!--
   - test: `tupleTypesAsReturnTypes`
@@ -458,7 +447,6 @@ func minMax(array: [Int]) -> (min: Int, max: Int)? {
 }
 ```
 
-
 <!--
   - test: `tupleTypesAsReturnTypes2`
   
@@ -488,7 +476,6 @@ if let bounds = minMax(array: [8, -6, 2, 109, 3, 71]) {
 }
 // Prints "min is -6 and max is 109"
 ```
-
 
 <!--
   - test: `tupleTypesAsReturnTypes2`
@@ -521,7 +508,6 @@ func anotherGreeting(for person: String) -> String {
 print(anotherGreeting(for: "Dave"))
 // Prints "Hello, Dave!"
 ```
-
 
 <!--
   - test: `implicit-func-return`
@@ -598,7 +584,6 @@ func someFunction(firstParameterName: Int, secondParameterName: Int) {
 someFunction(firstParameterName: 1, secondParameterName: 2)
 ```
 
-
 <!--
   - test: `functionParameterNames`
   
@@ -637,7 +622,6 @@ func someFunction(argumentLabel parameterName: Int) {
 }
 ```
 
-
 <!--
   - test: `externalParameterNames`
   
@@ -660,7 +644,6 @@ func greet(person: String, from hometown: String) -> String {
 print(greet(person: "Bill", from: "Cupertino"))
 // Prints "Hello Bill!  Glad you could visit from Cupertino."
 ```
-
 
 <!--
   - test: `externalParameterNames`
@@ -691,7 +674,6 @@ func someFunction(_ firstParameterName: Int, secondParameterName: Int) {
 someFunction(1, secondParameterName: 2)
 ```
 
-
 <!--
   - test: `omittedExternalParameterNames`
   
@@ -721,7 +703,6 @@ func someFunction(parameterWithoutDefault: Int, parameterWithDefault: Int = 12) 
 someFunction(parameterWithoutDefault: 3, parameterWithDefault: 6) // parameterWithDefault is 6
 someFunction(parameterWithoutDefault: 4) // parameterWithDefault is 12
 ```
-
 
 <!--
   - test: `omittedExternalParameterNames`
@@ -775,7 +756,6 @@ arithmeticMean(1, 2, 3, 4, 5)
 arithmeticMean(3, 8.25, 18.75)
 // returns 10.0, which is the arithmetic mean of these three numbers
 ```
-
 
 <!--
   - test: `variadicParameters`
@@ -879,7 +859,6 @@ func swapTwoInts(_ a: inout Int, _ b: inout Int) {
 }
 ```
 
-
 <!--
   - test: `inoutParameters`
   
@@ -910,7 +889,6 @@ swapTwoInts(&someInt, &anotherInt)
 print("someInt is now \(someInt), and anotherInt is now \(anotherInt)")
 // Prints "someInt is now 107, and anotherInt is now 3"
 ```
-
 
 <!--
   - test: `inoutParameters`
@@ -956,7 +934,6 @@ func multiplyTwoInts(_ a: Int, _ b: Int) -> Int {
 }
 ```
 
-
 <!--
   - test: `functionTypes`
   
@@ -994,7 +971,6 @@ func printHelloWorld() {
 }
 ```
 
-
 <!--
   - test: `functionTypes`
   
@@ -1019,7 +995,6 @@ and assign an appropriate function to that variable:
 ```swift
 var mathFunction: (Int, Int) -> Int = addTwoInts
 ```
-
 
 <!--
   - test: `functionTypes`
@@ -1046,7 +1021,6 @@ print("Result: \(mathFunction(2, 3))")
 // Prints "Result: 5"
 ```
 
-
 <!--
   - test: `functionTypes`
   
@@ -1064,7 +1038,6 @@ mathFunction = multiplyTwoInts
 print("Result: \(mathFunction(2, 3))")
 // Prints "Result: 6"
 ```
-
 
 <!--
   - test: `functionTypes`
@@ -1084,7 +1057,6 @@ when you assign a function to a constant or variable:
 let anotherMathFunction = addTwoInts
 // anotherMathFunction is inferred to be of type (Int, Int) -> Int
 ```
-
 
 <!--
   - test: `functionTypes`
@@ -1117,7 +1089,6 @@ func printMathResult(_ mathFunction: (Int, Int) -> Int, _ a: Int, _ b: Int) {
 printMathResult(addTwoInts, 3, 5)
 // Prints "Result: 8"
 ```
-
 
 <!--
   - test: `functionTypes`
@@ -1168,7 +1139,6 @@ func stepBackward(_ input: Int) -> Int {
 }
 ```
 
-
 <!--
   - test: `functionTypes`
   
@@ -1193,7 +1163,6 @@ func chooseStepFunction(backward: Bool) -> (Int) -> Int {
 }
 ```
 
-
 <!--
   - test: `functionTypes`
   
@@ -1212,7 +1181,6 @@ var currentValue = 3
 let moveNearerToZero = chooseStepFunction(backward: currentValue > 0)
 // moveNearerToZero now refers to the stepBackward() function
 ```
-
 
 <!--
   - test: `functionTypes`
@@ -1249,7 +1217,6 @@ print("zero!")
 // 1...
 // zero!
 ```
-
 
 <!--
   - test: `functionTypes`
@@ -1305,7 +1272,6 @@ print("zero!")
 // zero!
 ```
 
-
 <!--
   - test: `nestedFunctions`
   
@@ -1332,7 +1298,6 @@ print("zero!")
   </ zero!
   ```
 -->
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Generics.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Generics.md
@@ -1,5 +1,3 @@
-
-
 # Generics
 
 Write code that works for multiple types and specify requirements for those types.
@@ -34,7 +32,6 @@ func swapTwoInts(_ a: inout Int, _ b: inout Int) {
 }
 ```
 
-
 <!--
   - test: `whyGenerics`
   
@@ -61,7 +58,6 @@ swapTwoInts(&someInt, &anotherInt)
 print("someInt is now \(someInt), and anotherInt is now \(anotherInt)")
 // Prints "someInt is now 107, and anotherInt is now 3"
 ```
-
 
 <!--
   - test: `whyGenerics`
@@ -94,7 +90,6 @@ func swapTwoDoubles(_ a: inout Double, _ b: inout Double) {
     b = temporaryA
 }
 ```
-
 
 <!--
   - test: `whyGenerics`
@@ -148,7 +143,6 @@ func swapTwoValues<T>(_ a: inout T, _ b: inout T) {
 }
 ```
 
-
 <!--
   - test: `genericFunctions`
   
@@ -178,7 +172,6 @@ Here's how the first lines compare:
 func swapTwoInts(_ a: inout Int, _ b: inout Int)
 func swapTwoValues<T>(_ a: inout T, _ b: inout T)
 ```
-
 
 <!--
   - test: `genericFunctionsComparison`
@@ -234,7 +227,6 @@ var anotherString = "world"
 swapTwoValues(&someString, &anotherString)
 // someString is now "world", and anotherString is now "hello"
 ```
-
 
 <!--
   - test: `genericFunctions`
@@ -328,7 +320,6 @@ The illustration below shows the push and pop behavior for a stack:
 
 ![](stackPushPop)
 
-
 - There are currently three values on the stack.
 - A fourth value is pushed onto the top of the stack.
 - The stack now holds four values, with the most recent one at the top.
@@ -349,7 +340,6 @@ struct IntStack {
     }
 }
 ```
-
 
 <!--
   - test: `genericStack`
@@ -397,7 +387,6 @@ struct Stack<Element> {
     }
 }
 ```
-
 
 <!--
   - test: `genericStack`
@@ -453,7 +442,6 @@ stackOfStrings.push("cuatro")
 // the stack now contains 4 strings
 ```
 
-
 <!--
   - test: `genericStack`
   
@@ -472,14 +460,12 @@ Here's how `stackOfStrings` looks after pushing these four values on to the stac
 
 ![](stackPushedFourStrings)
 
-
 Popping a value from the stack removes and returns the top value, `"cuatro"`:
 
 ```swift
 let fromTheTop = stackOfStrings.pop()
 // fromTheTop is equal to "cuatro", and the stack now contains 3 strings
 ```
-
 
 <!--
   - test: `genericStack`
@@ -494,7 +480,6 @@ let fromTheTop = stackOfStrings.pop()
 Here's how the stack looks after popping its top value:
 
 ![](stackPoppedOneString)
-
 
 ## Extending a Generic Type
 
@@ -516,7 +501,6 @@ extension Stack {
     }
 }
 ```
-
 
 <!--
   - test: `genericStack`
@@ -548,7 +532,6 @@ if let topItem = stackOfStrings.topItem {
 }
 // Prints "The top item on the stack is tres."
 ```
-
 
 <!--
   - test: `genericStack`
@@ -617,7 +600,6 @@ func someFunction<T: SomeClass, U: SomeProtocol>(someT: T, someU: U) {
 }
 ```
 
-
 <!--
   - test: `typeConstraints`
   
@@ -656,7 +638,6 @@ func findIndex(ofString valueToFind: String, in array: [String]) -> Int? {
 }
 ```
 
-
 <!--
   - test: `typeConstraints`
   
@@ -681,7 +662,6 @@ if let foundIndex = findIndex(ofString: "llama", in: strings) {
 }
 // Prints "The index of llama is 2"
 ```
-
 
 <!--
   - test: `typeConstraints`
@@ -717,7 +697,6 @@ func findIndex<T>(of valueToFind: T, in array:[T]) -> Int? {
     return nil
 }
 ```
-
 
 <!--
   - test: `typeConstraints-err`
@@ -778,7 +757,6 @@ func findIndex<T: Equatable>(of valueToFind: T, in array:[T]) -> Int? {
 }
 ```
 
-
 @Comment {
   - test: `typeConstraintsEquatable`
   
@@ -806,7 +784,6 @@ let doubleIndex = findIndex(of: 9.3, in: [3.14159, 0.1, 0.25])
 let stringIndex = findIndex(of: "Andrea", in: ["Mike", "Malcolm", "Andrea"])
 // stringIndex is an optional Int containing a value of 2
 ```
-
 
 @Comment {
   - test: `typeConstraintsEquatable`
@@ -853,7 +830,6 @@ protocol Container {
     subscript(i: Int) -> Item { get }
 }
 ```
-
 
 @Comment {
   - test: `associatedTypes, associatedTypes-err`
@@ -938,7 +914,6 @@ struct IntStack: Container {
 }
 ```
 
-
 @Comment {
   - test: `associatedTypes`
   
@@ -1011,7 +986,6 @@ struct Stack<Element>: Container {
 }
 ```
 
-
 @Comment {
   - test: `associatedTypes, associatedTypes-err`
   
@@ -1063,7 +1037,6 @@ as described in <doc:Protocols#Declaring-Protocol-Adoption-with-an-Extension>:
 extension Array: Container {}
 ```
 
-
 @Comment {
   - test: `associatedTypes`
   
@@ -1093,7 +1066,6 @@ protocol Container {
     subscript(i: Int) -> Item { get }
 }
 ```
-
 
 @Comment {
   - test: `associatedTypes-equatable`
@@ -1127,7 +1099,6 @@ protocol SuffixableContainer: Container {
     func suffix(_ size: Int) -> Suffix
 }
 ```
-
 
 @Comment {
   - test: `associatedTypes`
@@ -1173,7 +1144,6 @@ stackOfInts.append(30)
 let suffix = stackOfInts.suffix(2)
 // suffix contains 20 and 30
 ```
-
 
 @Comment {
   - test: `associatedTypes`
@@ -1224,7 +1194,6 @@ extension IntStack: SuffixableContainer {
     // Inferred that Suffix is Stack<Int>.
 }
 ```
-
 
 @Comment {
   - test: `associatedTypes`
@@ -1299,7 +1268,6 @@ func allItemsMatch<C1: Container, C2: Container>
     return true
 }
 ```
-
 
 @Comment {
   - test: `associatedTypes`
@@ -1394,7 +1362,6 @@ if allItemsMatch(stackOfStrings, arrayOfStrings) {
 // Prints "All items match."
 ```
 
-
 @Comment {
   - test: `associatedTypes`
   
@@ -1445,7 +1412,6 @@ extension Stack where Element: Equatable {
 }
 ```
 
-
 @Comment {
   - test: `associatedTypes`
   
@@ -1487,7 +1453,6 @@ if stackOfStrings.isTop("tres") {
 // Prints "Top element is tres."
 ```
 
-
 @Comment {
   - test: `associatedTypes`
   
@@ -1512,7 +1477,6 @@ let notEquatableValue = NotEquatable()
 notEquatableStack.push(notEquatableValue)
 notEquatableStack.isTop(notEquatableValue)  // Error
 ```
-
 
 @Comment {
   - test: `associatedTypes-err`
@@ -1540,7 +1504,6 @@ extension Container where Item: Equatable {
     }
 }
 ```
-
 
 @Comment {
   - test: `associatedTypes`
@@ -1578,7 +1541,6 @@ if [9, 9, 9].startsWith(42) {
 // Prints "Starts with something else."
 ```
 
-
 @Comment {
   - test: `associatedTypes`
   
@@ -1611,7 +1573,6 @@ extension Container where Item == Double {
 print([1260.0, 1200.0, 98.6, 37.0].average())
 // Prints "648.9"
 ```
-
 
 @Comment {
   - test: `associatedTypes`
@@ -1683,7 +1644,6 @@ print(numbers.endsWith(37))
 // Prints "true"
 ```
 
-
 @Comment {
   - test: `associatedTypes`
   
@@ -1737,7 +1697,6 @@ extension Container where Item: Equatable {
 }
 ```
 
-
 @Comment {
   - test: `associatedTypes-err`
   
@@ -1788,7 +1747,6 @@ protocol Container {
     func makeIterator() -> Iterator
 }
 ```
-
 
 @Comment {
   - test: `associatedTypes-iterator`
@@ -1858,7 +1816,6 @@ that requires `Item` to conform to `Comparable`:
 protocol ComparableContainer: Container where Item: Comparable { }
 ```
 
-
 @Comment {
   - test: `associatedTypes`
   
@@ -1922,7 +1879,6 @@ extension Container {
     }
 }
 ```
-
 
 @Comment {
   - test: `genericSubscript`
@@ -2007,7 +1963,6 @@ is a sequence of integers.
 @Comment {
   TODO: Describe how Optional<Wrapped> works
 }
-
 
 @Comment {
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Inheritance.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Inheritance.md
@@ -1,5 +1,3 @@
-
-
 # Inheritance
 
 Subclass to add or override functionality.
@@ -55,7 +53,6 @@ class Vehicle {
 }
 ```
 
-
 <!--
   - test: `inheritance`
   
@@ -79,7 +76,6 @@ which is written as a type name followed by empty parentheses:
 let someVehicle = Vehicle()
 ```
 
-
 <!--
   - test: `inheritance`
   
@@ -96,7 +92,6 @@ a human-readable description of the vehicle's current speed:
 print("Vehicle: \(someVehicle.description)")
 // Vehicle: traveling at 0.0 miles per hour
 ```
-
 
 <!--
   - test: `inheritance`
@@ -128,7 +123,6 @@ class SomeSubclass: SomeSuperclass {
 }
 ```
 
-
 <!--
   - test: `protocolSyntax`
   
@@ -148,7 +142,6 @@ class Bicycle: Vehicle {
     var hasBasket = false
 }
 ```
-
 
 <!--
   - test: `inheritance`
@@ -177,7 +170,6 @@ let bicycle = Bicycle()
 bicycle.hasBasket = true
 ```
 
-
 <!--
   - test: `inheritance`
   
@@ -195,7 +187,6 @@ bicycle.currentSpeed = 15.0
 print("Bicycle: \(bicycle.description)")
 // Bicycle: traveling at 15.0 miles per hour
 ```
-
 
 <!--
   - test: `inheritance`
@@ -216,7 +207,6 @@ class Tandem: Bicycle {
     var currentNumberOfPassengers = 0
 }
 ```
-
 
 <!--
   - test: `inheritance`
@@ -245,7 +235,6 @@ tandem.currentSpeed = 22.0
 print("Tandem: \(tandem.description)")
 // Tandem: traveling at 22.0 miles per hour
 ```
-
 
 <!--
   - test: `inheritance`
@@ -315,7 +304,6 @@ class Train: Vehicle {
 }
 ```
 
-
 <!--
   - test: `inheritance`
   
@@ -336,7 +324,6 @@ let train = Train()
 train.makeNoise()
 // Prints "Choo Choo"
 ```
-
 
 <!--
   - test: `inheritance`
@@ -394,7 +381,6 @@ class Car: Vehicle {
 }
 ```
 
-
 <!--
   - test: `inheritance`
   
@@ -425,7 +411,6 @@ car.gear = 3
 print("Car: \(car.description)")
 // Car: traveling at 25.0 miles per hour in gear 3
 ```
-
 
 <!--
   - test: `inheritance`
@@ -471,7 +456,6 @@ class AutomaticCar: Car {
 }
 ```
 
-
 <!--
   - test: `inheritance`
   
@@ -500,7 +484,6 @@ automatic.currentSpeed = 35.0
 print("AutomaticCar: \(automatic.description)")
 // AutomaticCar: traveling at 35.0 miles per hour in gear 4
 ```
-
 
 <!--
   - test: `inheritance`
@@ -620,7 +603,6 @@ Any attempt to subclass a final class is reported as a compile-time error.
   TODO: Overriding Type Methods
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 -->
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Initialization.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Initialization.md
@@ -1,5 +1,3 @@
-
-
 # Initialization
 
 Set the initial values for a type's stored properties and perform one-time setup.
@@ -49,7 +47,6 @@ init() {
 }
 ```
 
-
 <!--
   - test: `initializerSyntax`
   
@@ -78,7 +75,6 @@ var f = Fahrenheit()
 print("The default temperature is \(f.temperature)° Fahrenheit")
 // Prints "The default temperature is 32.0° Fahrenheit"
 ```
-
 
 <!--
   - test: `fahrenheitInit`
@@ -129,7 +125,6 @@ struct Fahrenheit {
 }
 ```
 
-
 <!--
   - test: `fahrenheitDefault`
   
@@ -176,7 +171,6 @@ let boilingPointOfWater = Celsius(fromFahrenheit: 212.0)
 let freezingPointOfWater = Celsius(fromKelvin: 273.15)
 // freezingPointOfWater.temperatureInCelsius is 0.0
 ```
-
 
 <!--
   - test: `initialization`
@@ -254,7 +248,6 @@ struct Color {
 }
 ```
 
-
 <!--
   - test: `externalParameterNames, externalParameterNames-err`
   
@@ -283,7 +276,6 @@ let magenta = Color(red: 1.0, green: 0.0, blue: 1.0)
 let halfGray = Color(white: 0.5)
 ```
 
-
 <!--
   - test: `externalParameterNames`
   
@@ -305,7 +297,6 @@ and omitting them is a compile-time error:
 let veryGreen = Color(0.0, 1.0, 0.0)
 // this reports a compile-time error - argument labels are required
 ```
-
 
 <!--
   - test: `externalParameterNames-err`
@@ -347,7 +338,6 @@ struct Celsius {
 let bodyTemperature = Celsius(37.0)
 // bodyTemperature.temperatureInCelsius is 37.0
 ```
-
 
 <!--
   - test: `initializersWithoutExternalParameterNames`
@@ -405,7 +395,6 @@ cheeseQuestion.ask()
 // Prints "Do you like cheese?"
 cheeseQuestion.response = "Yes, I do like cheese."
 ```
-
 
 <!--
   - test: `surveyQuestionVariable`
@@ -514,7 +503,6 @@ beetsQuestion.ask()
 beetsQuestion.response = "I also like beets. (But not with cheese.)"
 ```
 
-
 <!--
   - test: `surveyQuestionConstant`
   
@@ -571,7 +559,6 @@ class ShoppingListItem {
 }
 var item = ShoppingListItem()
 ```
-
 
 <!--
   - test: `initialization`
@@ -639,7 +626,6 @@ struct Size {
 let twoByTwo = Size(width: 2.0, height: 2.0)
 ```
 
-
 <!--
   - test: `initialization`
   
@@ -670,7 +656,6 @@ let zeroByZero = Size()
 print(zeroByZero.width, zeroByZero.height)
 // Prints "0.0 0.0"
 ```
-
 
 <!--
   - test: `initialization`
@@ -736,7 +721,6 @@ struct Point {
 }
 ```
 
-
 <!--
   - test: `valueDelegation`
   
@@ -773,7 +757,6 @@ struct Rect {
     }
 }
 ```
-
 
 <!--
   - test: `valueDelegation`
@@ -812,7 +795,6 @@ let basicRect = Rect()
 // basicRect's origin is (0.0, 0.0) and its size is (0.0, 0.0)
 ```
 
-
 <!--
   - test: `valueDelegation`
   
@@ -834,7 +816,6 @@ let originRect = Rect(origin: Point(x: 2.0, y: 2.0),
     size: Size(width: 5.0, height: 5.0))
 // originRect's origin is (2.0, 2.0) and its size is (5.0, 5.0)
 ```
-
 
 <!--
   - test: `valueDelegation`
@@ -858,7 +839,6 @@ let centerRect = Rect(center: Point(x: 4.0, y: 4.0),
     size: Size(width: 3.0, height: 3.0))
 // centerRect's origin is (2.5, 2.5) and its size is (3.0, 3.0)
 ```
-
 
 <!--
   - test: `valueDelegation`
@@ -930,7 +910,6 @@ init(<#parameters#>) {
 }
 ```
 
-
 Convenience initializers are written in the same style,
 but with the `convenience` modifier placed before the `init` keyword,
 separated by a space:
@@ -940,7 +919,6 @@ convenience init(<#parameters#>) {
    <#statements#>
 }
 ```
-
 
 ### Initializer Delegation for Class Types
 
@@ -959,7 +937,6 @@ A simple way to remember this is:
 These rules are illustrated in the figure below:
 
 ![](initializerDelegation01)
-
 
 Here, the superclass has a single designated initializer and two convenience initializers.
 One convenience initializer calls another convenience initializer,
@@ -985,7 +962,6 @@ act as “funnel” points for class initialization,
 simplifying the interrelationships among classes in the chain:
 
 ![](initializerDelegation02)
-
 
 ### Two-Phase Initialization
 
@@ -1071,7 +1047,6 @@ Here's how phase 1 looks for an initialization call for a hypothetical subclass 
 
 ![](twoPhaseInitialization01)
 
-
 In this example, initialization begins with a call to
 a convenience initializer on the subclass.
 This convenience initializer can't yet modify any properties.
@@ -1092,7 +1067,6 @@ its memory is considered fully initialized, and phase 1 is complete.
 Here's how phase 2 looks for the same initialization call:
 
 ![](twoPhaseInitialization02)
-
 
 The superclass's designated initializer now has an opportunity
 to customize the instance further
@@ -1251,7 +1225,6 @@ class Vehicle {
 }
 ```
 
-
 <!--
   - test: `initializerInheritance`
   
@@ -1278,7 +1251,6 @@ print("Vehicle: \(vehicle.description)")
 // Vehicle: 0 wheel(s)
 ```
 
-
 <!--
   - test: `initializerInheritance`
   
@@ -1299,7 +1271,6 @@ class Bicycle: Vehicle {
     }
 }
 ```
-
 
 <!--
   - test: `initializerInheritance`
@@ -1334,7 +1305,6 @@ let bicycle = Bicycle()
 print("Bicycle: \(bicycle.description)")
 // Bicycle: 2 wheel(s)
 ```
-
 
 <!--
   - test: `initializerInheritance`
@@ -1373,7 +1343,6 @@ class Hoverboard: Vehicle {
 }
 ```
 
-
 <!--
   - test: `initializerInheritance`
   
@@ -1399,7 +1368,6 @@ let hoverboard = Hoverboard(color: "silver")
 print("Hoverboard: \(hoverboard.description)")
 // Hoverboard: 0 wheel(s) in a beautiful silver
 ```
-
 
 <!--
   - test: `initializerInheritance`
@@ -1512,7 +1480,6 @@ class Food {
 }
 ```
 
-
 <!--
   - test: `designatedConvenience`
   
@@ -1533,7 +1500,6 @@ The figure below shows the initializer chain for the `Food` class:
 
 ![](initializersExample01)
 
-
 Classes don't have a default memberwise initializer,
 and so the `Food` class provides a designated initializer
 that takes a single argument called `name`.
@@ -1543,7 +1509,6 @@ This initializer can be used to create a new `Food` instance with a specific nam
 let namedMeat = Food(name: "Bacon")
 // namedMeat's name is "Bacon"
 ```
-
 
 <!--
   - test: `designatedConvenience`
@@ -1572,7 +1537,6 @@ a `name` value of `[Unnamed]`:
 let mysteryMeat = Food()
 // mysteryMeat's name is "[Unnamed]"
 ```
-
 
 <!--
   - test: `designatedConvenience`
@@ -1603,7 +1567,6 @@ class RecipeIngredient: Food {
 }
 ```
 
-
 <!--
   - test: `designatedConvenience`
   
@@ -1624,7 +1587,6 @@ class RecipeIngredient: Food {
 The figure below shows the initializer chain for the `RecipeIngredient` class:
 
 ![](initializersExample02)
-
 
 The `RecipeIngredient` class has a single designated initializer,
 `init(name: String, quantity: Int)`,
@@ -1676,7 +1638,6 @@ let oneBacon = RecipeIngredient(name: "Bacon")
 let sixEggs = RecipeIngredient(name: "Eggs", quantity: 6)
 ```
 
-
 <!--
   - test: `designatedConvenience`
   
@@ -1709,7 +1670,6 @@ class ShoppingListItem: RecipeIngredient {
 }
 ```
 
-
 <!--
   - test: `designatedConvenience`
   
@@ -1738,7 +1698,6 @@ The figure below shows the overall initializer chain for all three classes:
 
 ![](initializersExample03)
 
-
 You can use all three of the inherited initializers
 to create a new `ShoppingListItem` instance:
 
@@ -1757,7 +1716,6 @@ for item in breakfastList {
 // 1 x Bacon ✘
 // 6 x Eggs ✘
 ```
-
 
 <!--
   - test: `designatedConvenience`
@@ -1875,7 +1833,6 @@ if valueChanged == nil {
 // Prints "3.14159 conversion to Int doesn't maintain value"
 ```
 
-
 <!--
   - test: `failableInitializers`
   
@@ -1916,7 +1873,6 @@ struct Animal {
 }
 ```
 
-
 <!--
   - test: `failableInitializers`
   
@@ -1944,7 +1900,6 @@ if let giraffe = someCreature {
 // Prints "An animal was initialized with a species of Giraffe"
 ```
 
-
 <!--
   - test: `failableInitializers`
   
@@ -1971,7 +1926,6 @@ if anonymousCreature == nil {
 }
 // Prints "The anonymous creature couldn't be initialized"
 ```
-
 
 <!--
   - test: `failableInitializers`
@@ -2025,7 +1979,6 @@ enum TemperatureUnit {
 }
 ```
 
-
 <!--
   - test: `failableInitializers`
   
@@ -2066,7 +2019,6 @@ if unknownUnit == nil {
 }
 // Prints "This isn't a defined temperature unit, so initialization failed."
 ```
-
 
 <!--
   - test: `failableInitializers`
@@ -2115,7 +2067,6 @@ if unknownUnit == nil {
 }
 // Prints "This isn't a defined temperature unit, so initialization failed."
 ```
-
 
 <!--
   - test: `failableInitializersForEnumerations`
@@ -2227,7 +2178,6 @@ class CartItem: Product {
 }
 ```
 
-
 <!--
   - test: `failableInitializers`
   
@@ -2272,7 +2222,6 @@ if let twoSocks = CartItem(name: "sock", quantity: 2) {
 // Prints "Item: sock, quantity: 2"
 ```
 
-
 <!--
   - test: `failableInitializers`
   
@@ -2295,7 +2244,6 @@ if let zeroShirts = CartItem(name: "shirt", quantity: 0) {
 }
 // Prints "Unable to initialize zero shirts"
 ```
-
 
 <!--
   - test: `failableInitializers`
@@ -2321,7 +2269,6 @@ if let oneUnnamed = CartItem(name: "", quantity: 1) {
 }
 // Prints "Unable to initialize one unnamed product"
 ```
-
 
 <!--
   - test: `failableInitializers`
@@ -2389,7 +2336,6 @@ class Document {
 }
 ```
 
-
 <!--
   - test: `failableInitializers`
   
@@ -2431,7 +2377,6 @@ class AutomaticallyNamedDocument: Document {
     }
 }
 ```
-
 
 <!--
   - test: `failableInitializers`
@@ -2475,7 +2420,6 @@ class UntitledDocument: Document {
     }
 }
 ```
-
 
 <!--
   - test: `failableInitializers`
@@ -2697,7 +2641,6 @@ class SomeClass {
 }
 ```
 
-
 <!--
   - test: `requiredInitializers`
   
@@ -2763,7 +2706,6 @@ class SomeSubclass: SomeClass {
     }
 }
 ```
-
 
 <!--
   - test: `requiredInitializers`
@@ -2868,7 +2810,6 @@ class SomeClass {
 }
 ```
 
-
 <!--
   - test: `defaultPropertyWithClosure`
   
@@ -2914,7 +2855,6 @@ with alternating black and white squares.
 
 ![](chessBoard)
 
-
 To represent this game board,
 the `Chessboard` structure has a single property called `boardColors`,
 which is an array of 64 `Bool` values.
@@ -2944,7 +2884,6 @@ struct Chessboard {
     }
 }
 ```
-
 
 <!--
   - test: `chessboard`
@@ -2988,7 +2927,6 @@ print(board.squareIsBlackAt(row: 7, column: 7))
 // Prints "false"
 ```
 
-
 <!--
   - test: `chessboard`
   
@@ -3001,7 +2939,6 @@ print(board.squareIsBlackAt(row: 7, column: 7))
   <- false
   ```
 -->
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/MemorySafety.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/MemorySafety.md
@@ -1,5 +1,3 @@
-
-
 # Memory Safety
 
 Structure your code to avoid conflicts when accessing memory.
@@ -46,7 +44,6 @@ var one = 1
 print("We're number \(one)!")
 ```
 
-
 <!--
   - test: `memory-read-write`
   
@@ -88,7 +85,6 @@ and get a correct answer,
 as shown in the figure below.
 
 ![](memory_shopping)
-
 
 While you're adding items to the budget,
 it's in a temporary, invalid state
@@ -183,7 +179,6 @@ print(myNumber)
 // Prints "2"
 ```
 
-
 <!--
   - test: `memory-instantaneous`
   
@@ -244,7 +239,6 @@ increment(&stepSize)
 // Error: conflicting accesses to stepSize
 ```
 
-
 <!--
   - test: `memory-increment`
   
@@ -277,7 +271,6 @@ producing a conflict.
 
 ![](memory_increment)
 
-
 One way to solve this conflict
 is to make an explicit copy of `stepSize`:
 
@@ -290,7 +283,6 @@ increment(&copyOfStepSize)
 stepSize = copyOfStepSize
 // stepSize is now 2
 ```
-
 
 <!--
   - test: `memory-increment-copy`
@@ -337,7 +329,6 @@ balance(&playerOneScore, &playerTwoScore)  // OK
 balance(&playerOneScore, &playerOneScore)
 // Error: conflicting accesses to playerOneScore
 ```
-
 
 <!--
   - test: `memory-balance`
@@ -422,7 +413,6 @@ struct Player {
 }
 ```
 
-
 <!--
   - test: `memory-player-share-with-self`
   
@@ -467,7 +457,6 @@ var maria = Player(name: "Maria", health: 5, energy: 10)
 oscar.shareHealth(with: &maria)  // OK
 ```
 
-
 <!--
   - test: `memory-player-share-with-self`
   
@@ -500,7 +489,6 @@ they don't conflict.
 
 ![](memory_share_health_maria)
 
-
 However,
 if you pass `oscar` as the argument to `shareHealth(with:)`,
 there's a conflict:
@@ -509,7 +497,6 @@ there's a conflict:
 oscar.shareHealth(with: &oscar)
 // Error: conflicting accesses to oscar
 ```
-
 
 <!--
   - test: `memory-player-share-with-self`
@@ -546,7 +533,6 @@ producing a conflict.
 
 ![](memory_share_health_oscar)
 
-
 ## Conflicting Access to Properties
 
 Types like structures, tuples, and enumerations
@@ -565,7 +551,6 @@ var playerInformation = (health: 10, energy: 20)
 balance(&playerInformation.health, &playerInformation.energy)
 // Error: conflicting access to properties of playerInformation
 ```
-
 
 <!--
   - test: `memory-tuple`
@@ -609,7 +594,6 @@ var holly = Player(name: "Holly", health: 10, energy: 10)
 balance(&holly.health, &holly.energy)  // Error
 ```
 
-
 <!--
   - test: `memory-share-health-global`
   
@@ -647,7 +631,6 @@ func someFunction() {
     balance(&oscar.health, &oscar.energy)  // OK
 }
 ```
-
 
 <!--
   - test: `memory-share-health-local`
@@ -756,7 +739,6 @@ it doesn't allow the access.
   However, the copying approach has a negative impact
   on performance and memory usage.
 -->
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Methods.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Methods.md
@@ -1,5 +1,3 @@
-
-
 # Methods
 
 Define and call functions that are part of an instance or type.
@@ -50,7 +48,6 @@ class Counter {
 }
 ```
 
-
 <!--
   - test: `instanceMethods`
   
@@ -92,7 +89,6 @@ counter.reset()
 // the counter's value is now 0
 ```
 
-
 <!--
   - test: `instanceMethods`
   
@@ -132,7 +128,6 @@ func increment() {
     self.count += 1
 }
 ```
-
 
 <!--
   - test: `instanceMethodsIncrement`
@@ -181,7 +176,6 @@ if somePoint.isToTheRightOf(x: 1.0) {
 }
 // Prints "This point is to the right of the line where x == 1.0"
 ```
-
 
 <!--
   - test: `self`
@@ -239,7 +233,6 @@ print("The point is now at (\(somePoint.x), \(somePoint.y))")
 // Prints "The point is now at (3.0, 4.0)"
 ```
 
-
 <!--
   - test: `selfStructures`
   
@@ -274,7 +267,6 @@ let fixedPoint = Point(x: 3.0, y: 3.0)
 fixedPoint.moveBy(x: 2.0, y: 3.0)
 // this will report an error
 ```
-
 
 <!--
   - test: `selfStructures-err`
@@ -321,7 +313,6 @@ struct Point {
 }
 ```
 
-
 <!--
   - test: `selfStructuresAssign`
   
@@ -367,7 +358,6 @@ ovenLight.next()
 ovenLight.next()
 // ovenLight is now equal to .off
 ```
-
 
 <!--
   - test: `selfEnumerations`
@@ -426,7 +416,6 @@ class SomeClass {
 }
 SomeClass.someTypeMethod()
 ```
-
 
 <!--
   - test: `typeMethods`
@@ -491,7 +480,6 @@ struct LevelTracker {
     }
 }
 ```
-
 
 <!--
   - test: `typeMethods`
@@ -569,7 +557,6 @@ class Player {
 }
 ```
 
-
 <!--
   - test: `typeMethods`
   
@@ -608,7 +595,6 @@ print("highest unlocked level is now \(LevelTracker.highestUnlockedLevel)")
 // Prints "highest unlocked level is now 2"
 ```
 
-
 <!--
   - test: `typeMethods`
   
@@ -633,7 +619,6 @@ if player.tracker.advance(to: 6) {
 }
 // Prints "level 6 hasn't yet been unlocked"
 ```
-
 
 <!--
   - test: `typeMethods`
@@ -664,7 +649,6 @@ if player.tracker.advance(to: 6) {
   TODO: selector-style methods can be referenced as foo.bar:bas:
   (see Doug's comments from the 2014-03-12 release notes)
 -->
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/NestedTypes.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/NestedTypes.md
@@ -1,5 +1,3 @@
-
-
 # Nested Types
 
 Define one data type inside of another data type.
@@ -65,7 +63,6 @@ struct BlackjackCard {
     }
 }
 ```
-
 
 <!--
   - test: `nestedTypes`
@@ -153,7 +150,6 @@ print("theAceOfSpades: \(theAceOfSpades.description)")
 // Prints "theAceOfSpades: suit is ♠, value is 1 or 11"
 ```
 
-
 <!--
   - test: `nestedTypes`
   
@@ -181,7 +177,6 @@ let heartsSymbol = BlackjackCard.Suit.hearts.rawValue
 // heartsSymbol is "♡"
 ```
 
-
 <!--
   - test: `nestedTypes`
   
@@ -195,7 +190,6 @@ let heartsSymbol = BlackjackCard.Suit.hearts.rawValue
 For the example above,
 this enables the names of `Suit`, `Rank`, and `Values` to be kept deliberately short,
 because their names are naturally qualified by the context in which they're defined.
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/OpaqueTypes.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/OpaqueTypes.md
@@ -1,5 +1,3 @@
-
-
 # Opaque Types
 
 Hide implementation details about a value's type.
@@ -46,7 +44,6 @@ print(smallTriangle.draw())
 // **
 // ***
 ```
-
 
 <!--
   - test: `opaque-result`
@@ -95,7 +92,6 @@ print(flippedTriangle.draw())
 // *
 ```
 
-
 <!--
   - test: `opaque-result`
   
@@ -137,7 +133,6 @@ print(joinedTriangles.draw())
 // **
 // *
 ```
-
 
 <!--
   - test: `opaque-result`
@@ -190,7 +185,6 @@ returns a type that depends on its caller:
 func max<T>(_ x: T, _ y: T) -> T where T: Comparable { ... }
 ```
 
-
 <!--
   From https://developer.apple.com/documentation/swift/1538951-max
   Not test code because it won't actually compile
@@ -242,7 +236,6 @@ print(trapezoid.draw())
 // **
 // *
 ```
-
 
 <!--
   - test: `opaque-result`
@@ -325,7 +318,6 @@ print(opaqueJoinedTriangles.draw())
 // *
 ```
 
-
 <!--
   - test: `opaque-result`
   
@@ -378,7 +370,6 @@ func invalidFlip<T: Shape>(_ shape: T) -> some Shape {
     return FlippedShape(shape: shape) // Error: return types don't match
 }
 ```
-
 
 <!--
   - test: `opaque-result-err`
@@ -433,7 +424,6 @@ struct FlippedShape<T: Shape>: Shape {
 }
 ```
 
-
 <!--
   - test: `opaque-result-special-flip`
   
@@ -473,7 +463,6 @@ func `repeat`<T: Shape>(shape: T, count: Int) -> some Collection {
     return Array<T>(repeating: shape, count: count)
 }
 ```
-
 
 <!--
   - test: `opaque-result`
@@ -520,7 +509,6 @@ func protoFlip<T: Shape>(_ shape: T) -> Shape {
     return FlippedShape(shape: shape)
 }
 ```
-
 
 <!--
   - test: `opaque-result-existential-error`
@@ -569,7 +557,6 @@ func protoFlip<T: Shape>(_ shape: T) -> Shape {
 }
 ```
 
-
 <!--
   - test: `opaque-result-existential-error`
   
@@ -608,7 +595,6 @@ let protoFlippedTriangle = protoFlip(smallTriangle)
 let sameThing = protoFlip(smallTriangle)
 protoFlippedTriangle == sameThing  // Error
 ```
-
 
 <!--
   - test: `opaque-result-existential-error`
@@ -671,7 +657,6 @@ protocol Container {
 extension Array: Container { }
 ```
 
-
 <!--
   - test: `opaque-result, opaque-result-existential-error`
   
@@ -702,7 +687,6 @@ func makeProtocolContainer<T, C: Container>(item: T) -> C {
     return [item]
 }
 ```
-
 
 <!--
   - test: `opaque-result-existential-error`
@@ -741,7 +725,6 @@ let twelve = opaqueContainer[0]
 print(type(of: twelve))
 // Prints "Int"
 ```
-
 
 <!--
   - test: `opaque-result`
@@ -800,7 +783,6 @@ which means that the type of `twelve` is also inferred to be `Int`.
       return AnyP(p: result)
   }
 -->
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/OptionalChaining.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/OptionalChaining.md
@@ -1,5 +1,3 @@
-
-
 # Optional Chaining
 
 Access members of an optional value without unwrapping.
@@ -55,7 +53,6 @@ class Residence {
 }
 ```
 
-
 <!--
   - test: `optionalChainingIntro, optionalChainingIntroAssert`
   
@@ -83,7 +80,6 @@ In the code below, `john` has a `residence` property value of `nil`:
 let john = Person()
 ```
 
-
 <!--
   - test: `optionalChainingIntro, optionalChainingIntroAssert`
   
@@ -101,7 +97,6 @@ because there's no `residence` value to unwrap:
 let roomCount = john.residence!.numberOfRooms
 // this triggers a runtime error
 ```
-
 
 <!--
   - test: `optionalChainingIntroAssert`
@@ -129,7 +124,6 @@ if let roomCount = john.residence?.numberOfRooms {
 }
 // Prints "Unable to retrieve the number of rooms."
 ```
-
 
 <!--
   - test: `optionalChainingIntro`
@@ -168,7 +162,6 @@ so that it no longer has a `nil` value:
 john.residence = Residence()
 ```
 
-
 <!--
   - test: `optionalChainingIntro`
   
@@ -190,7 +183,6 @@ if let roomCount = john.residence?.numberOfRooms {
 }
 // Prints "John's residence has 1 room(s)."
 ```
-
 
 <!--
   - test: `optionalChainingIntro`
@@ -229,7 +221,6 @@ class Person {
 }
 ```
 
-
 <!--
   - test: `optionalChaining`
   
@@ -264,7 +255,6 @@ class Residence {
     var address: Address?
 }
 ```
-
 
 <!--
   - test: `optionalChaining`
@@ -319,7 +309,6 @@ class Room {
 }
 ```
 
-
 <!--
   - test: `optionalChaining`
   
@@ -353,7 +342,6 @@ class Address {
     }
 }
 ```
-
 
 <!--
   - test: `optionalChaining`
@@ -402,7 +390,6 @@ if let roomCount = john.residence?.numberOfRooms {
 // Prints "Unable to retrieve the number of rooms."
 ```
 
-
 <!--
   - test: `optionalChaining`
   
@@ -428,7 +415,6 @@ someAddress.buildingNumber = "29"
 someAddress.street = "Acacia Road"
 john.residence?.address = someAddress
 ```
-
 
 <!--
   - test: `optionalChaining`
@@ -470,7 +456,6 @@ func createAddress() -> Address {
 john.residence?.address = createAddress()
 ```
 
-
 <!--
   - test: `optionalChaining`
   
@@ -509,7 +494,6 @@ func printNumberOfRooms() {
 }
 ```
 
-
 <!--
   - test: `optionalChainingCallouts`
   
@@ -544,7 +528,6 @@ if john.residence?.printNumberOfRooms() != nil {
 // Prints "It was not possible to print the number of rooms."
 ```
 
-
 <!--
   - test: `optionalChaining`
   
@@ -573,7 +556,6 @@ if (john.residence?.address = someAddress) != nil {
 }
 // Prints "It was not possible to set the address."
 ```
-
 
 <!--
   - test: `optionalChaining`
@@ -614,7 +596,6 @@ if let firstRoomName = john.residence?[0].name {
 // Prints "Unable to retrieve the first room name."
 ```
 
-
 <!--
   - test: `optionalChaining`
   
@@ -638,7 +619,6 @@ Similarly, you can try to set a new value through a subscript with optional chai
 ```swift
 john.residence?[0] = Room(name: "Bathroom")
 ```
-
 
 <!--
   - test: `optionalChaining`
@@ -668,7 +648,6 @@ if let firstRoomName = john.residence?[0].name {
 }
 // Prints "The first room name is Living Room."
 ```
-
 
 <!--
   - test: `optionalChaining`
@@ -702,7 +681,6 @@ testScores["Bev"]?[0] += 1
 testScores["Brian"]?[0] = 72
 // the "Dave" array is now [91, 82, 84] and the "Bev" array is now [80, 94, 81]
 ```
-
 
 <!--
   - test: `optionalChaining`
@@ -767,7 +745,6 @@ if let johnsStreet = john.residence?.address?.street {
 // Prints "Unable to retrieve the address."
 ```
 
-
 <!--
   - test: `optionalChaining`
   
@@ -809,7 +786,6 @@ if let johnsStreet = john.residence?.address?.street {
 }
 // Prints "John's street name is Laurel Street."
 ```
-
 
 <!--
   - test: `optionalChaining`
@@ -853,7 +829,6 @@ if let buildingIdentifier = john.residence?.address?.buildingIdentifier() {
 // Prints "John's building identifier is The Larches."
 ```
 
-
 <!--
   - test: `optionalChaining`
   
@@ -879,7 +854,6 @@ if let beginsWithThe =
 }
 // Prints "John's building identifier begins with "The"."
 ```
-
 
 <!--
   - test: `optionalChaining`
@@ -908,7 +882,6 @@ if let beginsWithThe =
   This can then be tied in to a revised description of how
   the sugar for optional protocol requirements works.
 -->
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Properties.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Properties.md
@@ -1,5 +1,3 @@
-
-
 # Properties
 
 Access stored and computed values that are part of an instance or type.
@@ -89,7 +87,6 @@ rangeOfThreeItems.firstValue = 6
 // the range now represents integer values 6, 7, and 8
 ```
 
-
 <!--
   - test: `storedProperties, storedProperties-err`
   
@@ -124,7 +121,6 @@ let rangeOfFourItems = FixedLengthRange(firstValue: 0, length: 4)
 rangeOfFourItems.firstValue = 6
 // this will report an error, even though firstValue is a variable property
 ```
-
 
 <!--
   - test: `storedProperties-err`
@@ -229,7 +225,6 @@ manager.data.append("Some more data")
 // the DataImporter instance for the importer property hasn't yet been created
 ```
 
-
 <!--
   - test: `lazyProperties`
   
@@ -289,7 +284,6 @@ print(manager.importer.filename)
 // the DataImporter instance for the importer property has now been created
 // Prints "data.txt"
 ```
-
 
 <!--
   - test: `lazyProperties`
@@ -370,7 +364,6 @@ print("square.origin is now at (\(square.origin.x), \(square.origin.y))")
 // Prints "square.origin is now at (10.0, 10.0)"
 ```
 
-
 <!--
   - test: `computedProperties`
   
@@ -444,7 +437,6 @@ and moves the square to its new position.
 
 ![](computedProperties)
 
-
 ### Shorthand Setter Declaration
 
 If a computed property's setter doesn't define a name for the new value to be set,
@@ -469,7 +461,6 @@ struct AlternativeRect {
     }
 }
 ```
-
 
 <!--
   - test: `computedProperties`
@@ -521,7 +512,6 @@ struct CompactRect {
     }
 }
 ```
-
 
 <!--
   - test: `computedProperties`
@@ -593,7 +583,6 @@ let fourByFiveByTwo = Cuboid(width: 4.0, height: 5.0, depth: 2.0)
 print("the volume of fourByFiveByTwo is \(fourByFiveByTwo.volume)")
 // Prints "the volume of fourByFiveByTwo is 40.0"
 ```
-
 
 <!--
   - test: `computedProperties`
@@ -815,7 +804,6 @@ stepCounter.totalSteps = 896
 // Added 536 steps
 ```
 
-
 <!--
   - test: `storedProperties`
   
@@ -927,7 +915,6 @@ struct TwelveOrLess {
 }
 ```
 
-
 <!--
   - test: `small-number-wrapper, property-wrapper-expansion`
   
@@ -1030,7 +1017,6 @@ print(rectangle.height)
 // Prints "12"
 ```
 
-
 <!--
   - test: `small-number-wrapper`
   
@@ -1090,7 +1076,6 @@ struct SmallRectangle {
     }
 }
 ```
-
 
 <!--
   - test: `property-wrapper-expansion`
@@ -1158,7 +1143,6 @@ struct SmallNumber {
 }
 ```
 
-
 <!--
   - test: `property-wrapper-init, property-wrapper-mixed-init`
   
@@ -1220,7 +1204,6 @@ var zeroRectangle = ZeroRectangle()
 print(zeroRectangle.height, zeroRectangle.width)
 // Prints "0 0"
 ```
-
 
 <!--
   - test: `property-wrapper-init`
@@ -1284,7 +1267,6 @@ var unitRectangle = UnitRectangle()
 print(unitRectangle.height, unitRectangle.width)
 // Prints "1 1"
 ```
-
 
 <!--
   - test: `property-wrapper-init`
@@ -1350,7 +1332,6 @@ narrowRectangle.width = 100
 print(narrowRectangle.height, narrowRectangle.width)
 // Prints "5 4"
 ```
-
 
 <!--
   - test: `property-wrapper-init`
@@ -1430,7 +1411,6 @@ mixedRectangle.height = 20
 print(mixedRectangle.height)
 // Prints "12"
 ```
-
 
 <!--
   - test: `property-wrapper-mixed-init`
@@ -1513,7 +1493,6 @@ someStructure.someNumber = 55
 print(someStructure.$someNumber)
 // Prints "true"
 ```
-
 
 <!--
   - test: `small-number-wrapper-projection`
@@ -1603,7 +1582,6 @@ struct SizedRectangle {
     }
 }
 ```
-
 
 <!--
   - test: `small-number-wrapper-projection`
@@ -1721,7 +1699,6 @@ func someFunction() {
 }
 ```
 
-
 <!--
   - test: `property-wrapper-init`
   
@@ -1833,7 +1810,6 @@ class SomeClass {
 }
 ```
 
-
 <!--
   - test: `typePropertySyntax`
   
@@ -1910,7 +1886,6 @@ print(SomeClass.computedTypeProperty)
 // Prints "27"
 ```
 
-
 <!--
   - test: `typePropertySyntax`
   
@@ -1940,7 +1915,6 @@ and the right channel has a current level of `7`:
 
 ![](staticPropertiesVUMeter)
 
-
 The audio channels described above are represented by
 instances of the `AudioChannel` structure:
 
@@ -1962,7 +1936,6 @@ struct AudioChannel {
     }
 }
 ```
-
 
 <!--
   - test: `staticProperties`
@@ -2027,7 +2000,6 @@ var leftChannel = AudioChannel()
 var rightChannel = AudioChannel()
 ```
 
-
 <!--
   - test: `staticProperties`
   
@@ -2048,7 +2020,6 @@ print(leftChannel.currentLevel)
 print(AudioChannel.maxInputLevelForAllChannels)
 // Prints "7"
 ```
-
 
 <!--
   - test: `staticProperties`
@@ -2075,7 +2046,6 @@ print(AudioChannel.maxInputLevelForAllChannels)
 // Prints "10"
 ```
 
-
 <!--
   - test: `staticProperties`
   
@@ -2087,7 +2057,6 @@ print(AudioChannel.maxInputLevelForAllChannels)
   <- 10
   ```
 -->
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Protocols.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Protocols.md
@@ -1,5 +1,3 @@
-
-
 # Protocols
 
 Define requirements that conforming types must implement.
@@ -37,7 +35,6 @@ protocol SomeProtocol {
 }
 ```
 
-
 <!--
   - test: `protocolSyntax`
   
@@ -59,7 +56,6 @@ struct SomeStructure: FirstProtocol, AnotherProtocol {
 }
 ```
 
-
 <!--
   - test: `protocolSyntax`
   
@@ -80,7 +76,6 @@ class SomeClass: SomeSuperclass, FirstProtocol, AnotherProtocol {
     // class definition goes here
 }
 ```
-
 
 <!--
   - test: `protocolSyntax`
@@ -124,7 +119,6 @@ protocol SomeProtocol {
 }
 ```
 
-
 <!--
   - test: `instanceProperties`
   
@@ -147,7 +141,6 @@ protocol AnotherProtocol {
 }
 ```
 
-
 <!--
   - test: `instanceProperties`
   
@@ -165,7 +158,6 @@ protocol FullyNamed {
     var fullName: String { get }
 }
 ```
-
 
 <!--
   - test: `instanceProperties`
@@ -193,7 +185,6 @@ struct Person: FullyNamed {
 let john = Person(fullName: "John Appleseed")
 // john.fullName is "John Appleseed"
 ```
-
 
 <!--
   - test: `instanceProperties`
@@ -236,7 +227,6 @@ class Starship: FullyNamed {
 var ncc1701 = Starship(name: "Enterprise", prefix: "USS")
 // ncc1701.fullName is "USS Enterprise"
 ```
-
 
 <!--
   - test: `instanceProperties`
@@ -291,7 +281,6 @@ protocol SomeProtocol {
 }
 ```
 
-
 <!--
   - test: `typeMethods`
   
@@ -309,7 +298,6 @@ protocol RandomNumberGenerator {
     func random() -> Double
 }
 ```
-
 
 <!--
   - test: `protocols`
@@ -356,7 +344,6 @@ print("Here's a random number: \(generator.random())")
 print("And another one: \(generator.random())")
 // Prints "And another one: 0.729023776863283"
 ```
-
 
 <!--
   - test: `protocols`
@@ -419,7 +406,6 @@ protocol Togglable {
 }
 ```
 
-
 <!--
   - test: `mutatingRequirements`
   
@@ -458,7 +444,6 @@ lightSwitch.toggle()
 // lightSwitch is now equal to .on
 ```
 
-
 <!--
   - test: `mutatingRequirements`
   
@@ -494,7 +479,6 @@ protocol SomeProtocol {
 }
 ```
 
-
 <!--
   - test: `initializers`
   
@@ -519,7 +503,6 @@ class SomeClass: SomeProtocol {
     }
 }
 ```
-
 
 <!--
   - test: `initializers`
@@ -649,7 +632,6 @@ class SomeSubClass: SomeSuperClass, SomeProtocol {
     }
 }
 ```
-
 
 <!--
   - test: `requiredOverrideInitializers`
@@ -801,7 +783,6 @@ class Dice {
 }
 ```
 
-
 <!--
   - test: `protocols`
   
@@ -871,7 +852,6 @@ for _ in 1...5 {
 // Random dice roll is 4
 ```
 
-
 <!--
   - test: `protocols`
   
@@ -914,7 +894,6 @@ protocol DiceGameDelegate: AnyObject {
     func gameDidEnd(_ game: DiceGame)
 }
 ```
-
 
 <!--
   - test: `protocols`
@@ -985,7 +964,6 @@ class SnakesAndLadders: DiceGame {
     }
 }
 ```
-
 
 <!--
   - test: `protocols`
@@ -1088,7 +1066,6 @@ class DiceGameTracker: DiceGameDelegate {
 }
 ```
 
-
 <!--
   - test: `protocols`
   
@@ -1152,7 +1129,6 @@ game.play()
 // The game lasted for 4 turns
 ```
 
-
 <!--
   - test: `protocols`
   
@@ -1192,7 +1168,6 @@ protocol TextRepresentable {
 }
 ```
 
-
 <!--
   - test: `protocols`
   
@@ -1218,7 +1193,6 @@ extension Dice: TextRepresentable {
     }
 }
 ```
-
 
 <!--
   - test: `protocols`
@@ -1246,7 +1220,6 @@ print(d12.textualDescription)
 // Prints "A 12-sided dice"
 ```
 
-
 <!--
   - test: `protocols`
   
@@ -1269,7 +1242,6 @@ extension SnakesAndLadders: TextRepresentable {
 print(game.textualDescription)
 // Prints "A game of Snakes and Ladders with 25 squares"
 ```
-
 
 <!--
   - test: `protocols`
@@ -1312,7 +1284,6 @@ print(myDice.textualDescription)
 // Prints "[A 6-sided dice, A 12-sided dice]"
 ```
 
-
 <!--
   - test: `protocols`
   
@@ -1345,7 +1316,6 @@ struct Hamster {
 extension Hamster: TextRepresentable {}
 ```
 
-
 <!--
   - test: `protocols`
   
@@ -1368,7 +1338,6 @@ let somethingTextRepresentable: TextRepresentable = simonTheHamster
 print(somethingTextRepresentable.textualDescription)
 // Prints "A hamster named Simon"
 ```
-
 
 <!--
   - test: `protocols`
@@ -1449,7 +1418,6 @@ if twoThreeFour == anotherTwoThreeFour {
 // Prints "These two vectors are also equivalent."
 ```
 
-
 <!--
   - test: `equatable_synthesis`
   
@@ -1519,7 +1487,6 @@ for level in levels.sorted() {
 // Prints "expert(stars: 3)"
 // Prints "expert(stars: 5)"
 ```
-
 
 <!--
   - test: `comparable-enum-synthesis`
@@ -1597,7 +1564,6 @@ This example creates an array of `TextRepresentable` things:
 let things: [TextRepresentable] = [game, d12, simonTheHamster]
 ```
 
-
 <!--
   - test: `protocols`
   
@@ -1617,7 +1583,6 @@ for thing in things {
 // A 12-sided dice
 // A hamster named Simon
 ```
-
 
 <!--
   - test: `protocols`
@@ -1652,7 +1617,6 @@ protocol InheritingProtocol: SomeProtocol, AnotherProtocol {
 }
 ```
 
-
 <!--
   - test: `protocols`
   
@@ -1673,7 +1637,6 @@ protocol PrettyTextRepresentable: TextRepresentable {
     var prettyTextualDescription: String { get }
 }
 ```
-
 
 <!--
   - test: `protocols`
@@ -1713,7 +1676,6 @@ extension SnakesAndLadders: PrettyTextRepresentable {
     }
 }
 ```
-
 
 <!--
   - test: `protocols`
@@ -1766,7 +1728,6 @@ print(game.prettyTextualDescription)
 // ○ ○ ▲ ○ ○ ▲ ○ ○ ▲ ▲ ○ ○ ○ ▼ ○ ○ ○ ○ ▼ ○ ○ ▼ ○ ▼ ○
 ```
 
-
 <!--
   - test: `protocols`
   
@@ -1787,7 +1748,6 @@ protocol SomeClassOnlyProtocol: AnyObject, SomeInheritedProtocol {
     // class-only protocol definition goes here
 }
 ```
-
 
 <!--
   - test: `classOnlyProtocols`
@@ -1865,7 +1825,6 @@ wishHappyBirthday(to: birthdayPerson)
 // Prints "Happy birthday, Malcolm, you're 21!"
 ```
 
-
 <!--
   - test: `protocolComposition`
   
@@ -1936,7 +1895,6 @@ beginConcert(in: seattle)
 // Prints "Hello, Seattle!"
 ```
 
-
 <!--
   - test: `protocolComposition`
   
@@ -2004,7 +1962,6 @@ protocol HasArea {
 }
 ```
 
-
 <!--
   - test: `protocolConformance`
   
@@ -2030,7 +1987,6 @@ class Country: HasArea {
     init(area: Double) { self.area = area }
 }
 ```
-
 
 <!--
   - test: `protocolConformance`
@@ -2063,7 +2019,6 @@ class Animal {
 }
 ```
 
-
 <!--
   - test: `protocolConformance`
   
@@ -2086,7 +2041,6 @@ let objects: [AnyObject] = [
     Animal(legs: 4)
 ]
 ```
-
 
 <!--
   - test: `protocolConformance`
@@ -2122,7 +2076,6 @@ for object in objects {
 // Area is 243610.0
 // Something that doesn't have an area
 ```
-
 
 <!--
   - test: `protocolConformance`
@@ -2224,7 +2177,6 @@ which has two optional requirements:
 }
 ```
 
-
 <!--
   - test: `protocolConformance`
   
@@ -2265,7 +2217,6 @@ class Counter {
     }
 }
 ```
-
 
 <!--
   - test: `protocolConformance`
@@ -2346,7 +2297,6 @@ class ThreeSource: NSObject, CounterDataSource {
 }
 ```
 
-
 <!--
   - test: `protocolConformance`
   
@@ -2371,7 +2321,6 @@ for _ in 1...4 {
 // 9
 // 12
 ```
-
 
 <!--
   - test: `protocolConformance`
@@ -2413,7 +2362,6 @@ class TowardsZeroSource: NSObject, CounterDataSource {
     }
 }
 ```
-
 
 <!--
   - test: `protocolConformance`
@@ -2457,7 +2405,6 @@ for _ in 1...5 {
 // 0
 ```
 
-
 <!--
   - test: `protocolConformance`
   
@@ -2497,7 +2444,6 @@ extension RandomNumberGenerator {
 }
 ```
 
-
 <!--
   - test: `protocols`
   
@@ -2521,7 +2467,6 @@ print("Here's a random number: \(generator.random())")
 print("And here's a random Boolean: \(generator.randomBool())")
 // Prints "And here's a random Boolean: true"
 ```
-
 
 <!--
   - test: `protocols`
@@ -2570,7 +2515,6 @@ extension PrettyTextRepresentable  {
     }
 }
 ```
-
 
 <!--
   - test: `protocols`
@@ -2643,7 +2587,6 @@ extension Collection where Element: Equatable {
 }
 ```
 
-
 <!--
   - test: `protocols`
   
@@ -2673,7 +2616,6 @@ let equalNumbers = [100, 100, 100, 100, 100]
 let differentNumbers = [100, 100, 200, 100, 200]
 ```
 
-
 <!--
   - test: `protocols`
   
@@ -2693,7 +2635,6 @@ print(equalNumbers.allEqual())
 print(differentNumbers.allEqual())
 // Prints "false"
 ```
-
 
 <!--
   - test: `protocols`
@@ -2729,7 +2670,6 @@ print(differentNumbers.allEqual())
   Protocol requirements can be marked as @unavailable, but this currently only works if they're also marked as @objc.
   Checking for (and calling) optional implementations via optional binding and closures
 -->
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/StringsAndCharacters.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/StringsAndCharacters.md
@@ -1,5 +1,3 @@
-
-
 # Strings and Characters
 
 Store and manipulate text.
@@ -46,7 +44,6 @@ Use a string literal as an initial value for a constant or variable:
 let someString = "Some string literal value"
 ```
 
-
 <!--
   - test: `stringLiterals`
   
@@ -80,7 +77,6 @@ till you come to the end; then stop."
 """
 ```
 
-
 <!--
   - test: `multiline-string-literals`
   
@@ -111,7 +107,6 @@ let multilineString = """
 These are the same.
 """
 ```
-
 
 <!--
   - test: `multiline-string-literals`
@@ -144,7 +139,6 @@ till you come to the end; then stop."
 """
 ```
 
-
 <!--
   - test: `multiline-string-literals`
   
@@ -175,7 +169,6 @@ It also ends with a line break.
 """
 ```
 
-
 <!--
   - test: `multiline-string-literals`
   
@@ -201,7 +194,6 @@ in addition to what's before the closing quotation marks,
 that whitespace *is* included.
 
 ![](multilineStringWhitespace)
-
 
 <!--
   Using an image here is a little clearer,
@@ -270,7 +262,6 @@ let blackHeart = "\u{2665}"      // ♥,  Unicode scalar U+2665
 let sparklingHeart = "\u{1F496}" // 💖, Unicode scalar U+1F496
 ```
 
-
 <!--
   - test: `specialCharacters`
   
@@ -300,7 +291,6 @@ Escaping the first quotation mark \"""
 Escaping all three quotation marks \"\"\"
 """
 ```
-
 
 <!--
   - test: `multiline-string-literals`
@@ -345,7 +335,6 @@ Here are three more double quotes: """
 """#
 ```
 
-
 <!--
   - test: `extended-string-delimiters`
   
@@ -371,7 +360,6 @@ var anotherEmptyString = String()  // initializer syntax
 // these two strings are both empty, and are equivalent to each other
 ```
 
-
 <!--
   - test: `emptyStrings`
   
@@ -392,7 +380,6 @@ if emptyString.isEmpty {
 }
 // Prints "Nothing to see here"
 ```
-
 
 <!--
   - test: `emptyStrings`
@@ -424,7 +411,6 @@ let constantString = "Highlander"
 constantString += " and another Highlander"
 // this reports a compile-time error - a constant string cannot be modified
 ```
-
 
 <!--
   - test: `stringMutability`
@@ -500,7 +486,6 @@ for character in "Dog!🐶" {
 // 🐶
 ```
 
-
 <!--
   - test: `characters`
   
@@ -525,7 +510,6 @@ from a single-character string literal by providing a `Character` type annotatio
 let exclamationMark: Character = "!"
 ```
 
-
 <!--
   - test: `characters`
   
@@ -543,7 +527,6 @@ let catString = String(catCharacters)
 print(catString)
 // Prints "Cat!🐱"
 ```
-
 
 <!--
   - test: `characters`
@@ -568,7 +551,6 @@ var welcome = string1 + string2
 // welcome now equals "hello there"
 ```
 
-
 <!--
   - test: `concatenation`
   
@@ -590,7 +572,6 @@ instruction += string2
 // instruction now equals "look over there"
 ```
 
-
 <!--
   - test: `concatenation`
   
@@ -610,7 +591,6 @@ let exclamationMark: Character = "!"
 welcome.append(exclamationMark)
 // welcome now equals "hello there!"
 ```
-
 
 <!--
   - test: `concatenation`
@@ -656,7 +636,6 @@ print(goodStart + end)
 // two
 // three
 ```
-
 
 <!--
   - test: `concatenate-multiline-string-literals`
@@ -716,7 +695,6 @@ let message = "\(multiplier) times 2.5 is \(Double(multiplier) * 2.5)"
 // message is "3 times 2.5 is 7.5"
 ```
 
-
 <!--
   - test: `stringInterpolation`
   
@@ -748,7 +726,6 @@ print(#"Write an interpolated string in Swift using \(multiplier)."#)
 // Prints "Write an interpolated string in Swift using \(multiplier)."
 ```
 
-
 <!--
   - test: `stringInterpolation`
   
@@ -768,7 +745,6 @@ For example:
 print(#"6 times 7 is \#(6 * 7)."#)
 // Prints "6 times 7 is 42."
 ```
-
 
 <!--
   - test: `stringInterpolation`
@@ -834,7 +810,6 @@ let combinedEAcute: Character = "\u{65}\u{301}"          // e followed by ́
 // eAcute is é, combinedEAcute is é
 ```
 
-
 <!--
   - test: `graphemeClusters1`
   
@@ -861,7 +836,6 @@ let decomposed: Character = "\u{1112}\u{1161}\u{11AB}"   // ᄒ, ᅡ, ᆫ
 // precomposed is 한, decomposed is 한
 ```
 
-
 <!--
   - test: `graphemeClusters2`
   
@@ -884,7 +858,6 @@ let enclosedEAcute: Character = "\u{E9}\u{20DD}"
 // enclosedEAcute is é⃝
 ```
 
-
 <!--
   - test: `graphemeClusters3`
   
@@ -905,7 +878,6 @@ and `REGIONAL INDICATOR SYMBOL LETTER S` (`U+1F1F8`):
 let regionalIndicatorForUS: Character = "\u{1F1FA}\u{1F1F8}"
 // regionalIndicatorForUS is 🇺🇸
 ```
-
 
 <!--
   - test: `graphemeClusters4`
@@ -928,7 +900,6 @@ let unusualMenagerie = "Koala 🐨, Snail 🐌, Penguin 🐧, Dromedary 🐪"
 print("unusualMenagerie has \(unusualMenagerie.count) characters")
 // Prints "unusualMenagerie has 40 characters"
 ```
-
 
 <!--
   - test: `characterCount`
@@ -959,7 +930,6 @@ word += "\u{301}"    // COMBINING ACUTE ACCENT, U+0301
 print("the number of characters in \(word) is \(word.count)")
 // Prints "the number of characters in café is 4"
 ```
-
 
 <!--
   - test: `characterCount`
@@ -1041,7 +1011,6 @@ greeting[index]
 // a
 ```
 
-
 <!--
   - test: `stringIndex`
   
@@ -1080,7 +1049,6 @@ greeting[greeting.endIndex] // Error
 greeting.index(after: greeting.endIndex) // Error
 ```
 
-
 <!--
   The code above triggers an assertion failure in the stdlib, causing a stack
   trace, which makes it a poor candidate for being tested.
@@ -1106,7 +1074,6 @@ for index in greeting.indices {
 }
 // Prints "G u t e n   T a g ! "
 ```
-
 
 <!--
   - test: `stringIndex`
@@ -1147,7 +1114,6 @@ welcome.insert(contentsOf: " there", at: welcome.index(before: welcome.endIndex)
 // welcome now equals "hello there!"
 ```
 
-
 <!--
   - test: `stringInsertionAndRemoval`
   
@@ -1176,7 +1142,6 @@ let range = welcome.index(welcome.endIndex, offsetBy: -6)..<welcome.endIndex
 welcome.removeSubrange(range)
 // welcome now equals "hello"
 ```
-
 
 <!--
   - test: `stringInsertionAndRemoval`
@@ -1229,7 +1194,6 @@ let beginning = greeting[..<index]
 // Convert the result to a String for long-term storage.
 let newString = String(beginning)
 ```
-
 
 <!--
   - test: `string-and-substring`
@@ -1284,7 +1248,6 @@ The figure below shows these relationships:
 
 ![](stringSubstring)
 
-
 > Note: Both `String` and `Substring` conform to the
 > [StringProtocol](https://developer.apple.com/documentation/swift/stringprotocol) protocol,
 > which means it's often convenient for string-manipulation functions
@@ -1310,7 +1273,6 @@ if quotation == sameQuotation {
 }
 // Prints "These two strings are considered equal"
 ```
-
 
 <!--
   - test: `stringEquality`
@@ -1380,7 +1342,6 @@ if eAcuteQuestion == combinedEAcuteQuestion {
 // Prints "These two strings are considered equal"
 ```
 
-
 <!--
   - test: `stringEquality`
   
@@ -1415,7 +1376,6 @@ if latinCapitalLetterA != cyrillicCapitalLetterA {
 }
 // Prints "These two characters aren't equivalent."
 ```
-
 
 <!--
   - test: `stringEquality`
@@ -1507,7 +1467,6 @@ let romeoAndJuliet = [
 ]
 ```
 
-
 <!--
   - test: `prefixesAndSuffixes`
   
@@ -1542,7 +1501,6 @@ print("There are \(act1SceneCount) scenes in Act 1")
 // Prints "There are 5 scenes in Act 1"
 ```
 
-
 <!--
   - test: `prefixesAndSuffixes`
   
@@ -1574,7 +1532,6 @@ for scene in romeoAndJuliet {
 print("\(mansionCount) mansion scenes; \(cellCount) cell scenes")
 // Prints "6 mansion scenes; 2 cell scenes"
 ```
-
 
 <!--
   - test: `prefixesAndSuffixes`
@@ -1632,7 +1589,6 @@ and the 🐶 character (`DOG FACE`, or Unicode scalar `U+1F436`):
 let dogString = "Dog‼🐶"
 ```
 
-
 <!--
   - test: `unicodeRepresentations`
   
@@ -1651,7 +1607,6 @@ one for each byte in the string's UTF-8 representation:
 
 ![](UTF8)
 
-
 ```swift
 for codeUnit in dogString.utf8 {
     print("\(codeUnit) ", terminator: "")
@@ -1659,7 +1614,6 @@ for codeUnit in dogString.utf8 {
 print("")
 // Prints "68 111 103 226 128 188 240 159 144 182 "
 ```
-
 
 <!--
   - test: `unicodeRepresentations`
@@ -1707,7 +1661,6 @@ one for each 16-bit code unit in the string's UTF-16 representation:
 
 ![](UTF16)
 
-
 ```swift
 for codeUnit in dogString.utf16 {
     print("\(codeUnit) ", terminator: "")
@@ -1715,7 +1668,6 @@ for codeUnit in dogString.utf16 {
 print("")
 // Prints "68 111 103 8252 55357 56374 "
 ```
-
 
 <!--
   - test: `unicodeRepresentations`
@@ -1763,7 +1715,6 @@ the scalar's 21-bit value, represented within a `UInt32` value:
 
 ![](UnicodeScalar)
 
-
 ```swift
 for scalar in dogString.unicodeScalars {
     print("\(scalar.value) ", terminator: "")
@@ -1771,7 +1722,6 @@ for scalar in dogString.unicodeScalars {
 print("")
 // Prints "68 111 103 8252 128054 "
 ```
-
 
 <!--
   - test: `unicodeRepresentations`
@@ -1818,7 +1768,6 @@ for scalar in dogString.unicodeScalars {
 // 🐶
 ```
 
-
 <!--
   - test: `unicodeRepresentations`
   
@@ -1833,7 +1782,6 @@ for scalar in dogString.unicodeScalars {
   </ 🐶
   ```
 -->
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Subscripts.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Subscripts.md
@@ -1,5 +1,3 @@
-
-
 # Subscripts
 
 Access the elements of a collection.
@@ -46,7 +44,6 @@ subscript(index: Int) -> Int {
 }
 ```
 
-
 <!--
   - test: `subscriptSyntax`
   
@@ -81,7 +78,6 @@ subscript(index: Int) -> Int {
 }
 ```
 
-
 <!--
   - test: `subscriptSyntax`
   
@@ -109,7 +105,6 @@ let threeTimesTable = TimesTable(multiplier: 3)
 print("six times three is \(threeTimesTable[6])")
 // Prints "six times three is 18"
 ```
-
 
 <!--
   - test: `timesTable`
@@ -159,7 +154,6 @@ and assigning a value of the dictionary's value type to the subscript:
 var numberOfLegs = ["spider": 8, "ant": 6, "cat": 4]
 numberOfLegs["bird"] = 2
 ```
-
 
 <!--
   - test: `dictionarySubscript`
@@ -256,7 +250,6 @@ struct Matrix {
 }
 ```
 
-
 <!--
   - test: `matrixSubscript, matrixSubscriptAssert`
   
@@ -301,7 +294,6 @@ an appropriate row and column count to its initializer:
 var matrix = Matrix(rows: 2, columns: 2)
 ```
 
-
 <!--
   - test: `matrixSubscript, matrixSubscriptAssert`
   
@@ -318,7 +310,6 @@ as read from top left to bottom right:
 
 ![](subscriptMatrix01)
 
-
 Values in the matrix can be set by passing row and column values into the subscript,
 separated by a comma:
 
@@ -326,7 +317,6 @@ separated by a comma:
 matrix[0, 1] = 1.5
 matrix[1, 0] = 3.2
 ```
-
 
 <!--
   - test: `matrixSubscript, matrixSubscriptAssert`
@@ -349,7 +339,6 @@ and `3.2` in the bottom left position
 
 ![](subscriptMatrix02)
 
-
 The `Matrix` subscript's getter and setter both contain an assertion
 to check that the subscript's  `row` and `column` values are valid.
 To assist with these assertions,
@@ -362,7 +351,6 @@ func indexIsValid(row: Int, column: Int) -> Bool {
     return row >= 0 && row < rows && column >= 0 && column < columns
 }
 ```
-
 
 <!--
   - test: `matrixSubscript`
@@ -383,7 +371,6 @@ that's outside of the matrix bounds:
 let someValue = matrix[2, 2]
 // This triggers an assert, because [2, 2] is outside of the matrix bounds.
 ```
-
 
 <!--
   - test: `matrixSubscriptAssert`
@@ -418,7 +405,6 @@ let mars = Planet[4]
 print(mars)
 ```
 
-
 <!--
   - test: `static-subscript`
   
@@ -435,7 +421,6 @@ print(mars)
   << mars
   ```
 -->
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/TheBasics.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/TheBasics.md
@@ -1,5 +1,3 @@
-
-
 # The Basics
 
 Work with common kinds of data and write basic syntax.
@@ -66,7 +64,6 @@ let maximumNumberOfLoginAttempts = 10
 var currentLoginAttempt = 0
 ```
 
-
 <!--
   - test: `constantsAndVariables`
   
@@ -96,7 +93,6 @@ separated by commas:
 var x = 0.0, y = 0.0, z = 0.0
 ```
 
-
 <!--
   - test: `multipleDeclarations`
   
@@ -125,7 +121,6 @@ to indicate that the variable can store `String` values:
 var welcomeMessage: String
 ```
 
-
 <!--
   - test: `typeAnnotations`
   
@@ -148,7 +143,6 @@ The `welcomeMessage` variable can now be set to any string value without error:
 welcomeMessage = "Hello"
 ```
 
-
 <!--
   - test: `typeAnnotations`
   
@@ -165,7 +159,6 @@ separated by commas, with a single type annotation after the final variable name
 ```swift
 var red, green, blue: Double
 ```
-
 
 <!--
   - test: `typeAnnotations`
@@ -193,7 +186,6 @@ let π = 3.14159
 let 你好 = "你好世界"
 let 🐶🐮 = "dogcow"
 ```
-
 
 <!--
   - test: `constantsAndVariables`
@@ -231,7 +223,6 @@ friendlyWelcome = "Bonjour!"
 // friendlyWelcome is now "Bonjour!"
 ```
 
-
 <!--
   - test: `constantsAndVariables`
   
@@ -251,7 +242,6 @@ let languageName = "Swift"
 languageName = "Swift++"
 // This is a compile-time error: languageName cannot be changed.
 ```
-
 
 <!--
   - test: `constantsAndVariables_err`
@@ -278,7 +268,6 @@ You can print the current value of a constant or variable with the `print(_:sepa
 print(friendlyWelcome)
 // Prints "Bonjour!"
 ```
-
 
 <!--
   - test: `constantsAndVariables`
@@ -334,7 +323,6 @@ print("The current value of friendlyWelcome is \(friendlyWelcome)")
 // Prints "The current value of friendlyWelcome is Bonjour!"
 ```
 
-
 <!--
   - test: `constantsAndVariables`
   
@@ -360,7 +348,6 @@ Single-line comments begin with two forward-slashes (`//`):
 // This is a comment.
 ```
 
-
 <!--
   - test: `comments`
   
@@ -376,7 +363,6 @@ and end with an asterisk followed by a forward-slash (`*/`):
 /* This is also a comment
 but is written over multiple lines. */
 ```
-
 
 <!--
   - test: `comments`
@@ -398,7 +384,6 @@ The second block is then closed, followed by the first block:
     /* This is the second, nested multiline comment. */
 This is the end of the first multiline comment. */
 ```
-
 
 <!--
   - test: `comments`
@@ -425,7 +410,6 @@ if you want to write multiple separate statements on a single line:
 let cat = "🐱"; print(cat)
 // Prints "🐱"
 ```
-
 
 <!--
   - test: `semiColons`
@@ -458,7 +442,6 @@ with its `min` and `max` properties:
 let minValue = UInt8.min  // minValue is equal to 0, and is of type UInt8
 let maxValue = UInt8.max  // maxValue is equal to 255, and is of type UInt8
 ```
-
 
 <!--
   - test: `integerBounds`
@@ -576,7 +559,6 @@ let meaningOfLife = 42
 // meaningOfLife is inferred to be of type Int
 ```
 
-
 <!--
   - test: `typeInference`
   
@@ -595,7 +577,6 @@ Swift infers that you want to create a `Double`:
 let pi = 3.14159
 // pi is inferred to be of type Double
 ```
-
 
 <!--
   - test: `typeInference`
@@ -618,7 +599,6 @@ a type of `Double` will be inferred from the context:
 let anotherPi = 3 + 0.14159
 // anotherPi is also inferred to be of type Double
 ```
-
 
 <!--
   - test: `typeInference`
@@ -652,7 +632,6 @@ let binaryInteger = 0b10001       // 17 in binary notation
 let octalInteger = 0o21           // 17 in octal notation
 let hexadecimalInteger = 0x11     // 17 in hexadecimal notation
 ```
-
 
 <!--
   - test: `numberLiterals`
@@ -716,7 +695,6 @@ let exponentDouble = 1.21875e1
 let hexadecimalDouble = 0xC.3p0
 ```
 
-
 <!--
   - test: `numberLiterals`
   
@@ -737,7 +715,6 @@ let paddedDouble = 000123.456
 let oneMillion = 1_000_000
 let justOverOneMillion = 1_000_000.000_000_1
 ```
-
 
 <!--
   - test: `numberLiterals`
@@ -781,7 +758,6 @@ let tooBig: Int8 = Int8.max + 1
 // and so this will also report an error
 ```
 
-
 <!--
   - test: `constantsAndVariablesOverflowError`
   
@@ -822,7 +798,6 @@ let one: UInt8 = 1
 let twoThousandAndOne = twoThousand + UInt16(one)
 ```
 
-
 <!--
   - test: `typeConversion`
   
@@ -861,7 +836,6 @@ let pi = Double(three) + pointOneFourOneFiveNine
 // pi equals 3.14159, and is inferred to be of type Double
 ```
 
-
 <!--
   - test: `typeConversion`
   
@@ -885,7 +859,6 @@ An integer type can be initialized with a `Double` or `Float` value:
 let integerPi = Int(pi)
 // integerPi equals 3, and is inferred to be of type Int
 ```
-
 
 <!--
   - test: `typeConversion`
@@ -925,7 +898,6 @@ such as when working with data of a specific size from an external source:
 typealias AudioSample = UInt16
 ```
 
-
 <!--
   - test: `typeAliases`
   
@@ -941,7 +913,6 @@ you can use the alias anywhere you might use the original name:
 var maxAmplitudeFound = AudioSample.min
 // maxAmplitudeFound is now 0
 ```
-
 
 <!--
   - test: `typeAliases`
@@ -970,7 +941,6 @@ Swift provides two Boolean constant values,
 let orangesAreOrange = true
 let turnipsAreDelicious = false
 ```
-
 
 <!--
   - test: `booleans`
@@ -1002,7 +972,6 @@ if turnipsAreDelicious {
 // Prints "Eww, turnips are horrible."
 ```
 
-
 <!--
   - test: `booleans`
   
@@ -1028,7 +997,6 @@ if i {
 }
 ```
 
-
 <!--
   - test: `booleansNotBoolean`
   
@@ -1052,7 +1020,6 @@ if i == 1 {
     // this example will compile successfully
 }
 ```
-
 
 <!--
   - test: `booleansIsBoolean`
@@ -1088,7 +1055,6 @@ let http404Error = (404, "Not Found")
 // http404Error is of type (Int, String), and equals (404, "Not Found")
 ```
 
-
 <!--
   - test: `tuples`
   
@@ -1121,7 +1087,6 @@ print("The status message is \(statusMessage)")
 // Prints "The status message is Not Found"
 ```
 
-
 <!--
   - test: `tuples`
   
@@ -1144,7 +1109,6 @@ print("The status code is \(justTheStatusCode)")
 // Prints "The status code is 404"
 ```
 
-
 <!--
   - test: `tuples`
   
@@ -1165,7 +1129,6 @@ print("The status message is \(http404Error.1)")
 // Prints "The status message is Not Found"
 ```
 
-
 <!--
   - test: `tuples`
   
@@ -1182,7 +1145,6 @@ You can name the individual elements in a tuple when the tuple is defined:
 ```swift
 let http200Status = (statusCode: 200, description: "OK")
 ```
-
 
 <!--
   - test: `tuples`
@@ -1201,7 +1163,6 @@ print("The status code is \(http200Status.statusCode)")
 print("The status message is \(http200Status.description)")
 // Prints "The status message is OK"
 ```
-
 
 <!--
   - test: `tuples`
@@ -1265,7 +1226,6 @@ let convertedNumber = Int(possibleNumber)
 // convertedNumber is inferred to be of type "Int?", or "optional Int"
 ```
 
-
 <!--
   - test: `optionals`
   
@@ -1299,7 +1259,6 @@ serverResponseCode = nil
 // serverResponseCode now contains no value
 ```
 
-
 <!--
   - test: `optionals`
   
@@ -1324,7 +1283,6 @@ the variable is automatically set to `nil` for you:
 var surveyAnswer: String?
 // surveyAnswer is automatically set to nil
 ```
-
 
 <!--
   - test: `optionals`
@@ -1356,7 +1314,6 @@ if convertedNumber != nil {
 // Prints "convertedNumber contains some integer value."
 ```
 
-
 <!--
   - test: `optionals`
   
@@ -1381,7 +1338,6 @@ if convertedNumber != nil {
 }
 // Prints "convertedNumber has an integer value of 123."
 ```
-
 
 <!--
   - test: `optionals`
@@ -1419,7 +1375,6 @@ if let <#constantName#> = <#someOptional#> {
 }
 ```
 
-
 You can rewrite the `possibleNumber` example from
 the <doc:TheBasics#Optionals> section
 to use optional binding rather than forced unwrapping:
@@ -1432,7 +1387,6 @@ if let actualNumber = Int(possibleNumber) {
 }
 // Prints "The string "123" has an integer value of 123"
 ```
-
 
 <!--
   - test: `optionals`
@@ -1473,7 +1427,6 @@ if let myNumber = myNumber {
 // Prints "My number is 123"
 ```
 
-
 <!--
   - test: `optionals`
   
@@ -1509,7 +1462,6 @@ if let myNumber {
 }
 // Prints "My number is 123"
 ```
-
 
 <!--
   - test: `optionals`
@@ -1556,7 +1508,6 @@ if let firstNumber = Int("4") {
 }
 // Prints "4 < 42 < 100"
 ```
-
 
 <!--
   - test: `multipleOptionalBindings`
@@ -1634,7 +1585,6 @@ let assumedString: String! = "An implicitly unwrapped optional string."
 let implicitString: String = assumedString // no need for an exclamation point
 ```
 
-
 <!--
   - test: `implicitlyUnwrappedOptionals`
   
@@ -1665,7 +1615,6 @@ let optionalString = assumedString
 // The type of optionalString is "String?" and assumedString isn't force-unwrapped.
 ```
 
-
 <!--
   - test: `implicitlyUnwrappedOptionals`
   
@@ -1692,7 +1641,6 @@ if assumedString != nil {
 // Prints "An implicitly unwrapped optional string."
 ```
 
-
 <!--
   - test: `implicitlyUnwrappedOptionals`
   
@@ -1713,7 +1661,6 @@ if let definiteString = assumedString {
 }
 // Prints "An implicitly unwrapped optional string."
 ```
-
 
 <!--
   - test: `implicitlyUnwrappedOptionals`
@@ -1751,7 +1698,6 @@ func canThrowAnError() throws {
 }
 ```
 
-
 <!--
   - test: `errorHandling`
   
@@ -1785,7 +1731,6 @@ do {
     // an error was thrown
 }
 ```
-
 
 <!--
   - test: `errorHandling`
@@ -1823,7 +1768,6 @@ do {
     buyGroceries(ingredients)
 }
 ```
-
 
 <!--
   - test: `errorHandlingTwo`
@@ -1944,7 +1888,6 @@ assert(age >= 0, "A person's age can't be less than zero.")
 // This assertion fails because -3 isn't >= 0.
 ```
 
-
 <!--
   - test: `assertions-1`
   
@@ -1968,7 +1911,6 @@ for example, when it would just repeat the condition as prose.
 ```swift
 assert(age >= 0)
 ```
-
 
 <!--
   - test: `assertions-2`
@@ -2006,7 +1948,6 @@ if age > 10 {
 }
 ```
 
-
 <!--
   - test: `assertions-3`
   
@@ -2040,7 +1981,6 @@ For example:
 // In the implementation of a subscript...
 precondition(index > 0, "Index must be greater than zero.")
 ```
-
 
 <!--
   - test: `preconditions`
@@ -2095,7 +2035,6 @@ by one of the switch's other cases.
   In LLDB, 'breakpoint set -E swift' catches when errors are thrown,
   but doesn't stop at assertions.
 -->
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/TypeCasting.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/TypeCasting.md
@@ -1,5 +1,3 @@
-
-
 # Type Casting
 
 Determine a value's runtime type and give it more specific type information.
@@ -40,7 +38,6 @@ class MediaItem {
 }
 ```
 
-
 <!--
   - test: `typeCasting, typeCasting-err`
   
@@ -78,7 +75,6 @@ class Song: MediaItem {
     }
 }
 ```
-
 
 <!--
   - test: `typeCasting, typeCasting-err`
@@ -120,7 +116,6 @@ let library = [
 ]
 // the type of "library" is inferred to be [MediaItem]
 ```
-
 
 <!--
   - test: `typeCasting`
@@ -173,7 +168,6 @@ for item in library {
 print("Media library contains \(movieCount) movies and \(songCount) songs")
 // Prints "Media library contains 2 movies and 3 songs"
 ```
-
 
 <!--
   - test: `typeCasting`
@@ -259,7 +253,6 @@ for item in library {
 // Song: The One And Only, by Chesney Hawkes
 // Song: Never Gonna Give You Up, by Rick Astley
 ```
-
 
 <!--
   - test: `typeCasting`
@@ -352,7 +345,6 @@ things.append(Movie(name: "Ghostbusters", director: "Ivan Reitman"))
 things.append({ (name: String) -> String in "Hello, \(name)" })
 ```
 
-
 <!--
   - test: `typeCasting, typeCasting-err`
   
@@ -420,7 +412,6 @@ for thing in things {
 // a movie called Ghostbusters, dir. Ivan Reitman
 // Hello, Michael
 ```
-
 
 <!--
   - test: `typeCasting`
@@ -530,7 +521,6 @@ for thing in things {
   }
   ```
 -->
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/AboutTheLanguageReference.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/AboutTheLanguageReference.md
@@ -1,5 +1,3 @@
-
-
 # About the Language Reference
 
 Read the notation that the formal grammar uses.
@@ -40,7 +38,6 @@ Grammar of a getter-setter block
 getter-setter-block --> ``{`` getter-clause setter-clause-OPT ``}`` | ``{`` setter-clause getter-clause ``}``
 ```
 
-
 This definition indicates that a getter-setter block can consist of a getter clause
 followed by an optional setter clause, enclosed in braces,
 *or* a setter clause followed by a getter clause, enclosed in braces.
@@ -54,11 +51,9 @@ getter-setter-block --> ``{`` getter-clause setter-clause-OPT ``}``
 getter-setter-block --> ``{`` setter-clause getter-clause ``}``
 ```
 
-
 *getter-setter-block* → `{` *getter-clause* *setter-clause?* `}`
 
 *getter-setter-block* → `{` *setter-clause* *getter-clause* `}`
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Attributes.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Attributes.md
@@ -1,5 +1,3 @@
-
-
 # Attributes
 
 Add information to declarations and types.
@@ -19,7 +17,6 @@ and any arguments that the attribute accepts:
 @<#attribute name#>
 @<#attribute name#>(<#attribute arguments#>)
 ```
-
 
 Some declaration attributes accept arguments
 that specify more information about the attribute
@@ -205,7 +202,6 @@ you can use the following shorthand syntax instead:
 @available(swift <#version number#>)
 ```
 
-
 The shorthand syntax for `available` attributes
 concisely expresses availability for multiple platforms.
 Although the two forms are functionally equivalent,
@@ -217,7 +213,6 @@ class MyClass {
     // class definition
 }
 ```
-
 
 <!--
   - test: `availableShorthand`
@@ -243,7 +238,6 @@ struct MyStruct {
     // struct definition
 }
 ```
-
 
 <!--
   - test: `availableMultipleAvailabilities`
@@ -299,7 +293,6 @@ dial(8, 6, 7, 5, 3, 0, 9)
 // Call the underlying method directly.
 dial.dynamicallyCall(withArguments: [4, 1, 1])
 ```
-
 
 <!--
   - test: `dynamicCallable`
@@ -361,7 +354,6 @@ print(repeatLabels(a: 1, b: 2, c: 3, b: 2, a: 1))
 // a
 ```
 
-
 <!--
   - test: `dynamicCallable`
   
@@ -415,7 +407,6 @@ that takes `KeyValuePairs<String, String>`.
 ```swift
 repeatLabels(a: "four") // Error
 ```
-
 
 <!--
   - test: `dynamicCallable-err`
@@ -492,7 +483,6 @@ print(dynamic == equivalent)
 // Prints "true"
 ```
 
-
 <!--
   - test: `dynamicMemberLookup`
   
@@ -539,7 +529,6 @@ let point = Point(x: 381, y: 431)
 let wrapper = PassthroughWrapper(value: point)
 print(wrapper.x)
 ```
-
 
 <!--
   - test: `dynamicMemberLookup`
@@ -820,7 +809,6 @@ struct MyTopLevel {
 }
 ```
 
-
 <!--
   - test: `atMain`
   
@@ -846,7 +834,6 @@ protocol ProvidesMain {
     static func main() throws
 }
 ```
-
 
 <!--
   - test: `atMain_ProvidesMain`
@@ -944,7 +931,6 @@ that calls the `NSApplicationMain(_:_:)` function as follows:
 import AppKit
 NSApplicationMain(CommandLine.argc, CommandLine.unsafeArgv)
 ```
-
 
 <!--
   Above code isn't tested because it hangs the REPL indefinitely,
@@ -1050,7 +1036,6 @@ class ExampleClass: NSObject {
     }
 }
 ```
-
 
 <!--
   - test: `objc-attribute`
@@ -1226,7 +1211,6 @@ struct SomeStruct {
 }
 ```
 
-
 <!--
   - test: `propertyWrapper`
   
@@ -1314,7 +1298,6 @@ s.x           // Int value
 s.$x          // SomeProjection value
 s.$x.wrapper  // WrapperWithProjection value
 ```
-
 
 <!--
   - test: `propertyWrapper-projection`
@@ -1449,7 +1432,6 @@ struct ArrayBuilder {
     }
 }
 ```
-
 
 <!--
   - test: `array-result-builder`
@@ -1820,7 +1802,6 @@ into code that calls the static methods of the result builder type:
 - If the result builder has a `buildFinalResult(_:)` method,
   the final result becomes a call to that method.
   This transformation is always last.
-
 
 <!--
   - test: `result-builder-limited-availability-broken, result-builder-limited-availability-ok`
@@ -2252,8 +2233,6 @@ balanced-token --> ``{`` balanced-tokens-OPT ``}``
 balanced-token --> Any identifier, keyword, literal, or operator
 balanced-token --> Any punctuation except ``(``, ``)``, ``[``, ``]``, ``{``, or ``}``
 ```
-
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Declarations.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Declarations.md
@@ -1,5 +1,3 @@
-
-
 # Declarations
 
 Introduce types, operators, variables, and other names and constructs.
@@ -39,7 +37,6 @@ declaration --> precedence-group-declaration
 declarations --> declaration declarations-OPT
 ```
 
-
 ## Top-Level Code
 
 The top-level code in a Swift source file consists of zero or more statements,
@@ -75,7 +72,6 @@ Grammar of a top-level declaration
 top-level-declaration --> statements-OPT
 ```
 
-
 ## Code Blocks
 
 A *code block* is used by a variety of declarations and control structures
@@ -87,7 +83,6 @@ It has the following form:
    <#statements#>
 }
 ```
-
 
 The *statements* inside a code block include declarations,
 expressions, and other kinds of statements and are executed in order
@@ -107,7 +102,6 @@ Grammar of a code block
 code-block --> ``{`` statements-OPT ``}``
 ```
 
-
 ## Import Declaration
 
 An *import declaration* lets you access symbols
@@ -118,7 +112,6 @@ it consists of the `import` keyword followed by a module name:
 ```swift
 import <#module#>
 ```
-
 
 Providing more detail limits which symbols are imported ---
 you can specify a specific submodule
@@ -133,7 +126,6 @@ import <#import kind#> <#module#>.<#symbol name#>
 import <#module#>.<#submodule#>
 ```
 
-
 <!--
   TODO: Need to add more to this section.
 -->
@@ -147,7 +139,6 @@ import-kind --> ``typealias`` | ``struct`` | ``class`` | ``enum`` | ``protocol``
 import-path --> identifier | identifier ``.`` import-path
 ```
 
-
 ## Constant Declaration
 
 A *constant declaration* introduces a constant named value into your program.
@@ -156,7 +147,6 @@ Constant declarations are declared using the `let` keyword and have the followin
 ```swift
 let <#constant name#>: <#type#> = <#expression#>
 ```
-
 
 A constant declaration defines an immutable binding between the *constant name*
 and the value of the initializer *expression*;
@@ -186,7 +176,6 @@ in the initializer *expression*.
 let (firstNumber, secondNumber) = (10, 42)
 ```
 
-
 <!--
   - test: `constant-decl`
   
@@ -206,7 +195,6 @@ print("The first number is \(firstNumber).")
 print("The second number is \(secondNumber).")
 // Prints "The second number is 42."
 ```
-
 
 <!--
   - test: `constant-decl`
@@ -259,7 +247,6 @@ pattern-initializer --> pattern initializer-OPT
 initializer --> ``=`` expression
 ```
 
-
 ## Variable Declaration
 
 A *variable declaration* introduces a variable named value into your program
@@ -285,7 +272,6 @@ The following form declares a stored variable or stored variable property:
 ```swift
 var <#variable name#>: <#type#> = <#expression#>
 ```
-
 
 You define this form of a variable declaration at global scope, the local scope
 of a function, or in the context of a class or structure declaration.
@@ -321,7 +307,6 @@ var <#variable name#>: <#type#> {
    }
 }
 ```
-
 
 You define this form of a variable declaration at global scope, the local scope
 of a function, or in the context of a class, structure, enumeration, or extension declaration.
@@ -365,7 +350,6 @@ var <#variable name#>: <#type#> = <#expression#> {
    }
 }
 ```
-
 
 You define this form of a variable declaration at global scope, the local scope
 of a function, or in the context of a class or structure declaration.
@@ -475,7 +459,6 @@ newAndOld.x = 200
 // Prints "Old value 12 - new value 200"
 ```
 
-
 <!--
   - test: `didSet-calls-superclass-getter`
   
@@ -576,7 +559,6 @@ willSet-clause --> attributes-OPT ``willSet`` setter-name-OPT code-block
 didSet-clause --> attributes-OPT ``didSet`` setter-name-OPT code-block
 ```
 
-
 <!--
   NOTE: Type annotations are required for computed properties -- the
   types of those properties aren't computed/inferred.
@@ -590,7 +572,6 @@ Type alias declarations are declared using the `typealias` keyword and have the 
 ```swift
 typealias <#name#> = <#existing type#>
 ```
-
 
 After a type alias is declared, the aliased *name* can be used
 instead of the *existing type* everywhere in your program.
@@ -612,7 +593,6 @@ var dictionary1: StringDictionary<Int> = [:]
 var dictionary2: Dictionary<String, Int> = [:]
 ```
 
-
 <!--
   - test: `typealias-with-generic`
   
@@ -632,7 +612,6 @@ For example:
 ```swift
 typealias DictionaryOfInts<Key: Hashable> = Dictionary<Key, Int>
 ```
-
 
 <!--
   - test: `typealias-with-generic-constraint`
@@ -654,7 +633,6 @@ has the same generic parameters and constraints as `Dictionary`.
 ```swift
 typealias Diccionario = Dictionary
 ```
-
 
 <!--
   - test: `typealias-using-shorthand`
@@ -693,7 +671,6 @@ func sum<T: Sequence>(_ sequence: T) -> Int where T.Element == Int {
 }
 ```
 
-
 <!--
   - test: `typealias-in-protocol`
   
@@ -724,7 +701,6 @@ typealias-name --> identifier
 typealias-assignment --> ``=`` type
 ```
 
-
 <!--
   Old grammar:
   typealias-declaration -> typealias-head typealias-assignment
@@ -746,7 +722,6 @@ func <#function name#>(<#parameters#>) -> <#return type#> {
 }
 ```
 
-
 If the function has a return type of `Void`,
 the return type can be omitted as follows:
 
@@ -755,7 +730,6 @@ func <#function name#>(<#parameters#>) {
    <#statements#>
 }
 ```
-
 
 The type of each parameter must be included ---
 it can't be inferred.
@@ -809,7 +783,6 @@ The simplest entry in a parameter list has the following form:
 <#parameter name#>: <#parameter type#>
 ```
 
-
 A parameter has a name,
 which is used within the function body,
 as well as an argument label,
@@ -822,7 +795,6 @@ For example:
 func f(x: Int, y: Int) -> Int { return x + y }
 f(x: 1, y: 2) // both x and y are labeled
 ```
-
 
 <!--
   - test: `default-parameter-names`
@@ -848,7 +820,6 @@ with one of the following forms:
 _ <#parameter name#>: <#parameter type#>
 ```
 
-
 A name before the parameter name
 gives the parameter an explicit argument label,
 which can be different from the parameter name.
@@ -863,7 +834,6 @@ The corresponding argument must have no label in function or method calls.
 func repeatGreeting(_ greeting: String, count n: Int) { /* Greet n times */ }
 repeatGreeting("Hello, world!", count: 2) //  count is labeled, greeting is not
 ```
-
 
 <!--
   - test: `overridden-parameter-names`
@@ -934,7 +904,6 @@ func someFunction(a: inout Int) -> () -> Int {
 }
 ```
 
-
 <!--
   - test: `explicit-capture-for-inout`
   
@@ -968,7 +937,6 @@ func multithreadedFunction(queue: DispatchQueue, x: inout Int) {
     queue.sync {}
 }
 ```
-
 
 <!--
   - test: `cant-pass-inout-aliasing`
@@ -1038,7 +1006,6 @@ _ : <#parameter type#>
 <#parameter name#>: <#parameter type#> = <#default argument value#>
 ```
 
-
 An underscore (`_`) parameter
 is explicitly ignored and can't be accessed within the body of the function.
 
@@ -1064,7 +1031,6 @@ f()       // Valid, uses default value
 f(x: 7)   // Valid, uses the value provided
 f(7)      // Invalid, missing argument label
 ```
-
 
 <!--
   - test: `default-args-and-labels`
@@ -1211,7 +1177,6 @@ callable.callAsFunction(4, scale: 2)
 // Both function calls print 208.
 ```
 
-
 <!--
   - test: `call-as-function`
   
@@ -1253,7 +1218,6 @@ let someFunction1: (Int, Int) -> Void = callable(_:scale:)  // Error
 let someFunction2: (Int, Int) -> Void = callable.callAsFunction(_:scale:)
 ```
 
-
 <!--
   - test: `call-as-function-err`
   
@@ -1290,7 +1254,6 @@ func <#function name#>(<#parameters#>) throws -> <#return type#> {
 }
 ```
 
-
 Calls to a throwing function or method must be wrapped in a `try` or `try!` expression
 (that is, in the scope of a `try` or `try!` operator).
 
@@ -1322,7 +1285,6 @@ func someFunction(callback: () throws -> Void) rethrows {
     try callback()
 }
 ```
-
 
 <!--
   - test: `rethrows`
@@ -1359,7 +1321,6 @@ func someFunction(callback: () throws -> Void) rethrows {
     }
 }
 ```
-
 
 <!--
   - test: `double-negative-rethrows`
@@ -1422,7 +1383,6 @@ func <#function name#>(<#parameters#>) async -> <#return type#> {
    <#statements#>
 }
 ```
-
 
 Calls to an asynchronous function or method
 must be wrapped in an `await` expression ---
@@ -1503,7 +1463,6 @@ local-parameter-name --> identifier
 default-argument-clause --> ``=`` expression
 ```
 
-
 <!--
   NOTE: Code block is optional in the context of a protocol.
   Everywhere else, it's required.
@@ -1556,7 +1515,6 @@ enum <#enumeration name#>: <#adopted protocols#> {
 }
 ```
 
-
 Enumerations declared in this form are sometimes called *discriminated unions*
 in other programming languages.
 
@@ -1583,7 +1541,6 @@ let f = Number.integer
 // Apply f to create an array of Number instances with integer values
 let evenInts: [Number] = [0, 2, 4, 6].map(f)
 ```
-
 
 <!--
   - test: `enum-case-as-function`
@@ -1638,7 +1595,6 @@ enum Tree<T> {
     indirect case node(value: T, left: Tree, right: Tree)
 }
 ```
-
 
 <!--
   - test: `indirect-enum`
@@ -1706,7 +1662,6 @@ enum <#enumeration name#>: <#raw-value type#>, <#adopted protocols#> {
 }
 ```
 
-
 In this form, each case block consists of the `case` keyword,
 followed by one or more enumeration cases, separated by commas.
 Unlike the cases in the first form, each case has an underlying
@@ -1740,7 +1695,6 @@ enum ExampleEnum: Int {
 }
 ```
 
-
 <!--
   - test: `raw-value-enum`
   
@@ -1765,7 +1719,6 @@ enum GamePlayMode: String {
     case cooperative, individual, competitive
 }
 ```
-
 
 <!--
   - test: `raw-value-enum-implicit-string-values`
@@ -1855,7 +1808,6 @@ raw-value-assignment --> ``=`` raw-value-literal
 raw-value-literal --> numeric-literal | static-string-literal | boolean-literal
 ```
 
-
 <!--
   NOTE: The two types of enums are sufficiently different enough to warrant separating
   the grammar accordingly. ([Contributor 6004] pointed this out in his email.)
@@ -1895,7 +1847,6 @@ struct <#structure name#>: <#adopted protocols#> {
    <#declarations#>
 }
 ```
-
 
 The body of a structure contains zero or more *declarations*.
 These *declarations* can include both stored and computed properties,
@@ -1946,7 +1897,6 @@ struct-members --> struct-member struct-members-OPT
 struct-member --> declaration | compiler-control-statement
 ```
 
-
 ## Class Declaration
 
 A *class declaration* introduces a named class type into your program.
@@ -1957,7 +1907,6 @@ class <#class name#>: <#superclass#>, <#adopted protocols#> {
    <#declarations#>
 }
 ```
-
 
 The body of a class contains zero or more *declarations*.
 These *declarations* can include both stored and computed properties,
@@ -2041,7 +1990,6 @@ class-members --> class-member class-members-OPT
 class-member --> declaration | compiler-control-statement
 ```
 
-
 ## Actor Declaration
 
 An *actor declaration* introduces a named actor type into your program.
@@ -2052,7 +2000,6 @@ actor <#actor name#>: <#adopted protocols#> {
     <#declarations#>
 }
 ```
-
 
 The body of an actor contains zero or more *declarations*.
 These *declarations* can include both stored and computed properties,
@@ -2132,7 +2079,6 @@ actor-members --> actor-member actor-members-OPT
 actor-member --> declaration | compiler-control-statement
 ```
 
-
 ## Protocol Declaration
 
 A *protocol declaration* introduces a named protocol type into your program.
@@ -2144,7 +2090,6 @@ protocol <#protocol name#>: <#inherited protocols#> {
    <#protocol member declarations#>
 }
 ```
-
 
 The body of a protocol contains zero or more *protocol member declarations*,
 which describe the conformance requirements that any type adopting the protocol must fulfill.
@@ -2220,7 +2165,6 @@ enum MyEnum: SomeProtocol {
 }
 ```
 
-
 <!--
   - test: `enum-case-satisfy-protocol-requirement`
   
@@ -2246,7 +2190,6 @@ protocol SomeProtocol: AnyObject {
     /* Protocol members go here */
 }
 ```
-
 
 <!--
   - test: `protocol-declaration`
@@ -2293,7 +2236,6 @@ protocol-member-declaration --> protocol-associated-type-declaration
 protocol-member-declaration --> typealias-declaration
 ```
 
-
 ### Protocol Property Declaration
 
 Protocols declare that conforming types must implement a property
@@ -2305,7 +2247,6 @@ declaration:
 ```swift
 var <#property name#>: <#type#> { get set }
 ```
-
 
 As with other protocol member declarations, these property declarations
 declare only the getter and setter requirements for types
@@ -2376,7 +2317,6 @@ Grammar of a protocol property declaration
 protocol-property-declaration --> variable-declaration-head variable-name type-annotation getter-setter-keyword-block
 ```
 
-
 ### Protocol Method Declaration
 
 Protocols declare that conforming types must implement a method
@@ -2410,7 +2350,6 @@ Grammar of a protocol method declaration
 protocol-method-declaration --> function-head function-name generic-parameter-clause-OPT function-signature generic-where-clause-OPT
 ```
 
-
 ### Protocol Initializer Declaration
 
 Protocols declare that conforming types must implement an initializer
@@ -2436,7 +2375,6 @@ protocol-initializer-declaration --> initializer-head generic-parameter-clause-O
 protocol-initializer-declaration --> initializer-head generic-parameter-clause-OPT parameter-clause ``rethrows`` generic-where-clause-OPT
 ```
 
-
 ### Protocol Subscript Declaration
 
 Protocols declare that conforming types must implement a subscript
@@ -2446,7 +2384,6 @@ Protocol subscript declarations have a special form of a subscript declaration:
 ```swift
 subscript (<#parameters#>) -> <#return type#> { get set }
 ```
-
 
 Subscript declarations only declare the minimum getter and setter implementation
 requirements for types that conform to the protocol.
@@ -2474,7 +2411,6 @@ Grammar of a protocol subscript declaration
 
 protocol-subscript-declaration --> subscript-head subscript-result generic-where-clause-OPT getter-setter-keyword-block
 ```
-
 
 ### Protocol Associated Type Declaration
 
@@ -2505,7 +2441,6 @@ protocol SubProtocolA: SomeProtocol {
 // This syntax is preferred.
 protocol SubProtocolB: SomeProtocol where SomeType: Equatable { }
 ```
-
 
 <!--
   - test: `protocol-associatedtype`
@@ -2609,7 +2544,6 @@ Grammar of a protocol associated type declaration
 protocol-associated-type-declaration --> attributes-OPT access-level-modifier-OPT ``associatedtype`` typealias-name type-inheritance-clause-OPT typealias-assignment-OPT generic-where-clause-OPT
 ```
 
-
 ## Initializer Declaration
 
 An *initializer declaration* introduces an initializer for a class,
@@ -2631,7 +2565,6 @@ init(<#parameters#>) {
    <#statements#>
 }
 ```
-
 
 A designated initializer of a class initializes
 all of the class's properties directly. It can't call any other initializers
@@ -2655,7 +2588,6 @@ convenience init(<#parameters#>) {
    <#statements#>
 }
 ```
-
 
 Convenience initializers can delegate the initialization process to another
 convenience initializer or to one of the class's designated initializers.
@@ -2719,7 +2651,6 @@ struct SomeStruct {
 }
 ```
 
-
 <!--
   - test: `failable`
   
@@ -2748,7 +2679,6 @@ if let actualInstance = SomeStruct(input: "Hello") {
     // initialization of 'SomeStruct' failed and the initializer returned 'nil'
 }
 ```
-
 
 <!--
   - test: `failable`
@@ -2800,7 +2730,6 @@ initializer-head --> attributes-OPT declaration-modifiers-OPT ``init`` ``!``
 initializer-body --> code-block
 ```
 
-
 ## Deinitializer Declaration
 
 A *deinitializer declaration* declares a deinitializer for a class type.
@@ -2811,7 +2740,6 @@ deinit {
    <#statements#>
 }
 ```
-
 
 A deinitializer is called automatically when there are no longer any references
 to a class object, just before the class object is deallocated.
@@ -2835,7 +2763,6 @@ Grammar of a deinitializer declaration
 deinitializer-declaration --> attributes-OPT ``deinit`` code-block
 ```
 
-
 ## Extension Declaration
 
 An *extension declaration* allows you to extend
@@ -2848,7 +2775,6 @@ extension <#type name#> where <#requirements#> {
    <#declarations#>
 }
 ```
-
 
 The body of an extension declaration contains zero or more *declarations*.
 These *declarations* can include computed properties, computed type properties,
@@ -2889,7 +2815,6 @@ extension <#type name#>: <#adopted protocols#> where <#requirements#> {
    <#declarations#>
 }
 ```
-
 
 Extension declarations can't add class inheritance to an existing class,
 and therefore you can specify only a list of protocols after the *type name* and colon.
@@ -2960,7 +2885,6 @@ extension String: TitledLoggable {
 }
 ```
 
-
 <!--
   - test: `conditional-conformance`
   
@@ -3021,7 +2945,6 @@ oneAndTwo.log()
 // Prints "Pair of 'String': (one, two)"
 ```
 
-
 <!--
   - test: `conditional-conformance`
   
@@ -3047,7 +2970,6 @@ func doSomething<T: Loggable>(with x: T) {
 doSomething(with: oneAndTwo)
 // Prints "(one, two)"
 ```
-
 
 <!--
   - test: `conditional-conformance`
@@ -3106,7 +3028,6 @@ extension Array: Serializable where Element == String {
 // Error: redundant conformance of 'Array<Element>' to protocol 'Serializable'
 ```
 
-
 <!--
   - test: `multiple-conformances`
   
@@ -3152,7 +3073,6 @@ extension Array: Serializable where Element: SerializableInArray {
     }
 }
 ```
-
 
 <!--
   - test: `multiple-conformances-success`
@@ -3210,7 +3130,6 @@ extension Array: TitledLoggable where Element: TitledLoggable {
 extension Array: MarkedLoggable where Element: MarkedLoggable { }
 ```
 
-
 <!--
   - test: `conditional-conformance`
   
@@ -3246,7 +3165,6 @@ extension Array: Loggable where Element: TitledLoggable { }
 extension Array: Loggable where Element: MarkedLoggable { }
 // Error: redundant conformance of 'Array<Element>' to protocol 'Loggable'
 ```
-
 
 <!--
   - test: `conditional-conformance-implicit-overlap`
@@ -3339,7 +3257,6 @@ extension-members --> extension-member extension-members-OPT
 extension-member --> declaration | compiler-control-statement
 ```
 
-
 ## Subscript Declaration
 
 A *subscript* declaration allows you to add subscripting support for objects
@@ -3358,7 +3275,6 @@ subscript (<#parameters#>) -> <#return type#> {
    }
 }
 ```
-
 
 Subscript declarations can appear only in the context of a class, structure,
 enumeration, extension, or protocol declaration.
@@ -3440,7 +3356,6 @@ subscript-head --> attributes-OPT declaration-modifiers-OPT ``subscript`` generi
 subscript-result --> ``->`` attributes-OPT type
 ```
 
-
 ## Operator Declaration
 
 An *operator declaration* introduces a new infix, prefix,
@@ -3465,7 +3380,6 @@ The following form declares a new infix operator:
 infix operator <#operator name#>: <#precedence group#>
 ```
 
-
 An *infix operator* is a binary operator that's written between its two operands,
 such as the familiar addition operator (`+`) in the expression `1 + 2`.
 
@@ -3481,7 +3395,6 @@ The following form declares a new prefix operator:
 prefix operator <#operator name#>
 ```
 
-
 A *prefix operator* is a unary operator that's written immediately before its operand,
 such as the prefix logical NOT operator (`!`) in the expression `!a`.
 
@@ -3493,7 +3406,6 @@ The following form declares a new postfix operator:
 ```swift
 postfix operator <#operator name#>
 ```
-
 
 A *postfix operator* is a unary operator that's written immediately after its operand,
 such as the postfix forced-unwrap operator (`!`) in the expression `a!`.
@@ -3525,7 +3437,6 @@ infix-operator-declaration --> ``infix`` ``operator`` operator infix-operator-gr
 infix-operator-group --> ``:`` precedence-group-name
 ```
 
-
 ## Precedence Group Declaration
 
 A *precedence group declaration* introduces
@@ -3543,7 +3454,6 @@ precedencegroup <#precedence group name#> {
     assignment: <#assignment#>
 }
 ```
-
 
 The *lower group names* and *higher group names* lists specify
 the new precedence group's relation to existing precedence groups.
@@ -3623,7 +3533,6 @@ precedence-group-associativity --> ``associativity`` ``:`` ``none``
 precedence-group-names --> precedence-group-name | precedence-group-name ``,`` precedence-group-names
 precedence-group-name --> identifier
 ```
-
 
 ## Declaration Modifiers
 
@@ -3782,8 +3691,6 @@ mutation-modifier --> ``mutating`` | ``nonmutating``
 
 actor-isolation-modifier --> ``nonisolated``
 ```
-
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Expressions.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Expressions.md
@@ -1,5 +1,3 @@
-
-
 # Expressions
 
 Access, modify, and assign values.
@@ -27,7 +25,6 @@ expression --> try-operator-OPT await-operator-OPT prefix-expression infix-expre
 expression-list --> expression | expression ``,`` expression-list
 ```
 
-
 ## Prefix Expressions
 
 *Prefix expressions* combine
@@ -48,7 +45,6 @@ prefix-expression --> prefix-operator-OPT postfix-expression
 prefix-expression --> in-out-expression
 ```
 
-
 ### In-Out Expression
 
 An *in-out expression* marks a variable
@@ -58,7 +54,6 @@ as an in-out argument to a function call expression.
 ```swift
 &<#expression#>
 ```
-
 
 For more information about in-out parameters and to see an example,
 see <doc:Functions#In-Out-Parameters>.
@@ -74,7 +69,6 @@ Grammar of an in-out expression
 in-out-expression --> ``&`` identifier
 ```
 
-
 ### Try Operator
 
 A *try expression* consists of the `try` operator
@@ -85,7 +79,6 @@ It has the following form:
 try <#expression#>
 ```
 
-
 The value of a `try` expression is the value of the *expression*.
 
 An *optional-try expression* consists of the `try?` operator
@@ -95,7 +88,6 @@ It has the following form:
 ```swift
 try? <#expression#>
 ```
-
 
 If the *expression* doesn't throw an error,
 the value of the optional-try expression
@@ -109,7 +101,6 @@ It has the following form:
 ```swift
 try! <#expression#>
 ```
-
 
 The value of a forced-try expression is the value of the *expression*.
 If the *expression* throws an error,
@@ -130,7 +121,6 @@ sum = try (someThrowingFunction() + anotherThrowingFunction())
 // Error: try applies only to the first function call
 sum = (try someThrowingFunction()) + anotherThrowingFunction()
 ```
-
 
 <!--
   - test: `placement-of-try`
@@ -200,7 +190,6 @@ Grammar of a try expression
 try-operator --> ``try`` | ``try`` ``?`` | ``try`` ``!``
 ```
 
-
 ### Await Operator
 
 An *await expression* consists of the `await` operator
@@ -210,7 +199,6 @@ It has the following form:
 ```swift
 await <#expression#>
 ```
-
 
 The value of an `await` expression is the value of the *expression*.
 
@@ -245,7 +233,6 @@ sum = await (someAsyncFunction() + anotherAsyncFunction())
 // Error: await applies only to the first function call
 sum = (await someAsyncFunction()) + anotherAsyncFunction()
 ```
-
 
 <!--
   - test: `placement-of-await`
@@ -310,7 +297,6 @@ Grammar of an await expression
 await-operator --> ``await``
 ```
 
-
 ## Infix Expressions
 
 *Infix expressions* combine
@@ -321,7 +307,6 @@ It has the following form:
 ```swift
 <#left-hand argument#> <#operator#> <#right-hand argument#>
 ```
-
 
 For information about the behavior of these operators,
 see <doc:BasicOperators> and <doc:AdvancedOperators>.
@@ -359,7 +344,6 @@ infix-expression --> type-casting-operator
 infix-expressions --> infix-expression infix-expressions-OPT
 ```
 
-
 ### Assignment Operator
 
 The *assignment operator* sets a new value
@@ -369,7 +353,6 @@ It has the following form:
 ```swift
 <#expression#> = <#value#>
 ```
-
 
 The value of the *expression*
 is set to the value obtained by evaluating the *value*.
@@ -385,7 +368,6 @@ For example:
 (a, _, (b, c)) = ("test", 9.45, (12, 3))
 // a is "test", b is 12, c is 3, and 9.45 is ignored
 ```
-
 
 <!--
   - test: `assignmentOperator`
@@ -406,7 +388,6 @@ Grammar of an assignment operator
 assignment-operator --> ``=``
 ```
 
-
 ### Ternary Conditional Operator
 
 The *ternary conditional operator* evaluates to one of two given values
@@ -416,7 +397,6 @@ It has the following form:
 ```swift
 <#condition#> ? <#expression used if true#> : <#expression used if false#>
 ```
-
 
 If the *condition* evaluates to `true`,
 the conditional operator evaluates the first expression
@@ -434,7 +414,6 @@ Grammar of a conditional operator
 conditional-operator --> ``?`` expression ``:``
 ```
 
-
 ### Type-Casting Operators
 
 There are four type-casting operators:
@@ -451,7 +430,6 @@ They have the following form:
 <#expression#> as? <#type#>
 <#expression#> as! <#type#>
 ```
-
 
 The `is` operator checks at runtime whether the *expression*
 can be cast to the specified *type*.
@@ -512,7 +490,6 @@ f(x as Any)
 // Prints "Function for Any"
 ```
 
-
 <!--
   - test: `explicit-type-with-as-operator`
   
@@ -568,7 +545,6 @@ type-casting-operator --> ``as`` ``?`` type
 type-casting-operator --> ``as`` ``!`` type
 ```
 
-
 ## Primary Expressions
 
 *Primary expressions*
@@ -594,7 +570,6 @@ primary-expression --> selector-expression
 primary-expression --> key-path-string-expression
 ```
 
-
 <!--
   NOTE: One reason for breaking primary expressions out of postfix
   expressions is for exposition -- it makes it easier to organize the
@@ -615,7 +590,6 @@ either an ordinary literal (such as a string or a number),
 an array or dictionary literal,
 a playground literal,
 or one of the following special literals:
-
 
 | Literal | Type | Value |
 | ------- | ---- | ----- |
@@ -692,7 +666,6 @@ func myFunction() {
 }
 ```
 
-
 <!--
   - test: `special-literal-evaluated-at-call-site`
   
@@ -725,7 +698,6 @@ It has the following form:
 [<#value 1#>, <#value 2#>, <#...#>]
 ```
 
-
 The last expression in the array can be followed by an optional comma.
 The value of an array literal has type `[T]`,
 where `T` is the type of the expressions inside it.
@@ -737,7 +709,6 @@ pair of square brackets and can be used to create an empty array of a specified 
 ```swift
 var emptyArray: [Double] = []
 ```
-
 
 <!--
   - test: `array-literal-brackets`
@@ -755,7 +726,6 @@ It has the following form:
 [<#key 1#>: <#value 1#>, <#key 2#>: <#value 2#>, <#...#>]
 ```
 
-
 The last expression in the dictionary can be followed by an optional comma.
 The value of a dictionary literal has type `[Key: Value]`,
 where `Key` is the type of its key expressions
@@ -772,7 +742,6 @@ of specified key and value types.
 ```swift
 var emptyDictionary: [String: Double] = [:]
 ```
-
 
 <!--
   - test: `dictionary-literal-brackets`
@@ -813,7 +782,6 @@ playground-literal --> ``#fileLiteral`` ``(`` ``resourceName`` ``:`` expression 
 playground-literal --> ``#imageLiteral`` ``(`` ``resourceName`` ``:`` expression ``)``
 ```
 
-
 ### Self Expression
 
 The `self` expression is an explicit reference to the current type
@@ -827,7 +795,6 @@ self[<#subscript index#>]
 self(<#initializer arguments#>)
 self.init(<#initializer arguments#>)
 ```
-
 
 <!--
   TODO: Come back and explain the second to last form (i.e., self(arg: value)).
@@ -851,7 +818,6 @@ class SomeClass {
     }
 }
 ```
-
 
 <!--
   - test: `self-expression`
@@ -878,7 +844,6 @@ struct Point {
     }
 }
 ```
-
 
 <!--
   - test: `self-expression`
@@ -911,7 +876,6 @@ self-subscript-expression --> ``self`` ``[`` function-call-argument-list ``]``
 self-initializer-expression --> ``self`` ``.`` ``init``
 ```
 
-
 ### Superclass Expression
 
 A *superclass expression* lets a class
@@ -923,7 +887,6 @@ super.<#member name#>
 super[<#subscript index#>]
 super.init(<#initializer arguments#>)
 ```
-
 
 The first form is used to access a member of the superclass.
 The second form is used to access the superclass's subscript implementation.
@@ -943,7 +906,6 @@ superclass-subscript-expression --> ``super`` ``[`` function-call-argument-list 
 superclass-initializer-expression --> ``super`` ``.`` ``init``
 ```
 
-
 ### Closure Expression
 
 A *closure expression* creates a closure,
@@ -960,7 +922,6 @@ It has the following form:
 }
 ```
 
-
 The *parameters* have the same form
 as the parameters in a function declaration,
 as described in <doc:Declarations#Function-Declaration>.
@@ -973,7 +934,6 @@ explicitly marks a closure as throwing or asynchronous.
    <#statements#>
 }
 ```
-
 
 If the body of a closure includes a try expression,
 the closure is understood to be throwing.
@@ -1017,7 +977,6 @@ myFunction { return $0 + $1 }
 
 myFunction { $0 + $1 }
 ```
-
 
 <!--
   - test: `closure-expression-forms`
@@ -1093,7 +1052,6 @@ closure()
 // Prints "0 10"
 ```
 
-
 <!--
   - test: `capture-list-value-semantics`
   
@@ -1160,7 +1118,6 @@ closure()
 // Prints "10 10"
 ```
 
-
 <!--
   - test: `capture-list-reference-semantics`
   
@@ -1226,7 +1183,6 @@ myFunction { [weak self] in print(self!.title) }    // weak capture
 myFunction { [unowned self] in print(self.title) }  // unowned capture
 ```
 
-
 <!--
   - test: `closure-expression-weak`
   
@@ -1258,7 +1214,6 @@ For example:
 // Weak capture of "self.parent" as "parent"
 myFunction { [weak parent = self.parent] in print(parent!.title) }
 ```
-
 
 <!--
   - test: `closure-expression-capture`
@@ -1323,7 +1278,6 @@ capture-list-item --> capture-specifier-OPT self-expression
 capture-specifier --> ``weak`` | ``unowned`` | ``unowned(safe)`` | ``unowned(unsafe)``
 ```
 
-
 ### Implicit Member Expression
 
 An *implicit member expression*
@@ -1337,14 +1291,12 @@ It has the following form:
 .<#member name#>
 ```
 
-
 For example:
 
 ```swift
 var x = MyEnumeration.someValue
 x = .anotherValue
 ```
-
 
 <!--
   - test: `implicitMemberEnum`
@@ -1363,7 +1315,6 @@ in an implicit member expression.
 ```swift
 var someOptional: MyEnumeration? = .someValue
 ```
-
 
 <!--
   - test: `implicitMemberEnum`
@@ -1404,7 +1355,6 @@ let y: SomeClass? = .shared
 let z: SomeClass = .sharedSubclass
 ```
 
-
 <!--
   - test: `implicit-member-chain`
   
@@ -1436,7 +1386,6 @@ Grammar of a implicit member expression
 implicit-member-expression --> ``.`` identifier
 implicit-member-expression --> ``.`` identifier ``.`` postfix-expression
 ```
-
 
 <!--
   The grammar above allows the additional pieces tested below,
@@ -1496,7 +1445,6 @@ Grammar of a parenthesized expression
 parenthesized-expression --> ``(`` expression ``)``
 ```
 
-
 ### Tuple Expression
 
 A *tuple expression* consists of
@@ -1508,7 +1456,6 @@ It has the following form:
 ```swift
 (<#identifier 1#>: <#expression 1#>, <#identifier 2#>: <#expression 2#>, <#...#>)
 ```
-
 
 Each identifier in a tuple expression must be unique
 within the scope of the tuple expression.
@@ -1552,7 +1499,6 @@ tuple-element-list --> tuple-element | tuple-element ``,`` tuple-element-list
 tuple-element --> expression | identifier ``:`` expression
 ```
 
-
 ### Wildcard Expression
 
 A *wildcard expression*
@@ -1564,7 +1510,6 @@ For example, in the following assignment
 (x, _) = (10, 20)
 // x is 10, and 20 is ignored
 ```
-
 
 <!--
   - test: `wildcardTuple`
@@ -1582,7 +1527,6 @@ Grammar of a wildcard expression
 wildcard-expression --> ``_``
 ```
 
-
 ### Key-Path Expression
 
 A *key-path expression*
@@ -1595,7 +1539,6 @@ They have the following form:
 ```swift
 \<#type name#>.<#path#>
 ```
-
 
 The *type name* is the name of a concrete type,
 including any generic parameters,
@@ -1636,7 +1579,6 @@ let value = s[keyPath: pathToProperty]
 // value is 12
 ```
 
-
 <!--
   - test: `keypath-expression`
   
@@ -1673,7 +1615,6 @@ c.observe(\.someProperty) { object, change in
     // ...
 }
 ```
-
 
 <!--
   - test: `keypath-expression-implicit-type-name`
@@ -1712,7 +1653,6 @@ var compoundValue = (a: 1, b: 2)
 compoundValue[keyPath: \.self] = (a: 10, b: 20)
 ```
 
-
 <!--
   - test: `keypath-expression-self-keypath`
   
@@ -1746,7 +1686,6 @@ let nestedValue = nested[keyPath: nestedKeyPath]
 // nestedValue is 24
 ```
 
-
 <!--
   - test: `keypath-expression`
   
@@ -1777,7 +1716,6 @@ let greetings = ["hello", "hola", "bonjour", "안녕"]
 let myGreeting = greetings[keyPath: \[String].[1]]
 // myGreeting is 'hola'
 ```
-
 
 <!--
   - test: `keypath-expression`
@@ -1826,7 +1764,6 @@ print(fn(greetings))
 // Prints "안녕"
 ```
 
-
 <!--
   - test: `keypath-expression`
   
@@ -1865,7 +1802,6 @@ let count = greetings[keyPath: \[String].first?.count]
 print(count as Any)
 // Prints "Optional(5)"
 ```
-
 
 <!--
   - test: `keypath-expression`
@@ -1908,7 +1844,6 @@ print(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count.bitWidth
 // Prints "64"
 ```
 
-
 <!--
   - test: `keypath-expression`
   
@@ -1950,7 +1885,6 @@ var toDoList = [
 let descriptions = toDoList.filter(\.completed).map(\.description)
 let descriptions2 = toDoList.filter { $0.completed }.map { $0.description }
 ```
-
 
 <!--
   - test: `keypath-expression`
@@ -1999,7 +1933,6 @@ let taskKeyPath = \[Task][makeIndex()]
 let someTask = toDoList[keyPath: taskKeyPath]
 ```
 
-
 <!--
   - test: `keypath-expression`
   
@@ -2037,7 +1970,6 @@ key-path-postfixes --> key-path-postfix key-path-postfixes-OPT
 key-path-postfix --> ``?`` | ``!`` | ``self`` | ``[`` function-call-argument-list ``]``
 ```
 
-
 ### Selector Expression
 
 A selector expression lets you access the selector
@@ -2050,7 +1982,6 @@ It has the following form:
 #selector(getter: <#property name#>)
 #selector(setter: <#property name#>)
 ```
-
 
 The *method name* and *property name* must be a reference to a method or a property
 that's available in the Objective-C runtime.
@@ -2071,7 +2002,6 @@ class SomeClass: NSObject {
 let selectorForMethod = #selector(SomeClass.doSomething(_:))
 let selectorForPropertyGetter = #selector(getter: SomeClass.property)
 ```
-
 
 <!--
   - test: `selector-expression`
@@ -2110,7 +2040,6 @@ extension SomeClass {
 }
 let anotherSelector = #selector(SomeClass.doSomething(_:) as (SomeClass) -> (String) -> Void)
 ```
-
 
 <!--
   - test: `selector-expression-with-as`
@@ -2152,7 +2081,6 @@ selector-expression --> ``#selector`` ``(`` ``getter:`` expression  ``)``
 selector-expression --> ``#selector`` ``(`` ``setter:`` expression  ``)``
 ```
 
-
 <!--
   Note: The parser does allow an arbitrary expression inside #selector(), not
   just a member name.  For example, see changes in Swift commit ef60d7289d in
@@ -2170,7 +2098,6 @@ It has the following form:
 ```swift
 #keyPath(<#property name#>)
 ```
-
 
 The *property name* must be a reference to a property
 that's available in the Objective-C runtime.
@@ -2193,7 +2120,6 @@ if let value = c.value(forKey: keyPath) {
 }
 // Prints "12"
 ```
-
 
 <!--
   - test: `keypath-string-expression`
@@ -2231,7 +2157,6 @@ print(keyPath == c.getSomeKeyPath())
 // Prints "true"
 ```
 
-
 <!--
   - test: `keypath-string-expression`
   
@@ -2265,7 +2190,6 @@ Grammar of a key-path string expression
 key-path-string-expression --> ``#keyPath`` ``(`` expression  ``)``
 ```
 
-
 ## Postfix Expressions
 
 *Postfix expressions* are formed
@@ -2293,7 +2217,6 @@ postfix-expression --> forced-value-expression
 postfix-expression --> optional-chaining-expression
 ```
 
-
 ### Function Call Expression
 
 <!--
@@ -2309,7 +2232,6 @@ Function call expressions have the following form:
 <#function name#>(<#argument value 1#>, <#argument value 2#>)
 ```
 
-
 The *function name* can be any expression whose value is of a function type.
 
 If the function definition includes names for its parameters,
@@ -2320,7 +2242,6 @@ This kind of function call expression has the following form:
 ```swift
 <#function name#>(<#argument name 1#>: <#argument value 1#>, <#argument name 2#>: <#argument value 2#>)
 ```
-
 
 A function call expression can include trailing closures
 in the form of closure expressions immediately after the closing parenthesis.
@@ -2340,7 +2261,6 @@ someFunction(x: x) { $0 == 13 }
 anotherFunction(x: x, f: { $0 == 13 }, g: { print(99) })
 anotherFunction(x: x) { $0 == 13 } g: { print(99) }
 ```
-
 
 <!--
   - test: `trailing-closure`
@@ -2387,7 +2307,6 @@ myData.someMethod() { $0 == 13 }
 myData.someMethod { $0 == 13 }
 ```
 
-
 <!--
   - test: `no-paren-trailing-closure`
   
@@ -2416,7 +2335,6 @@ myData.someMethod { $0 == 13 }
 
 To include the trailing closures in the arguments,
 the compiler examines the function's parameters from left to right as follows:
-
 
 | Trailing Closure | Parameter | Action |
 | ---------------- | --------- | ------ |
@@ -2503,7 +2421,6 @@ someFunction { return $0 + 100 }  // Ambiguous
 someFunction { return $0 } secondClosure: { return $0 }  // Prints "10 20"
 ```
 
-
 <!--
   - test: `trailing-closure-scanning-direction`
   
@@ -2572,7 +2489,6 @@ var myNumber = 1234
 unsafeFunction(pointer: &myNumber)
 withUnsafePointer(to: myNumber) { unsafeFunction(pointer: $0) }
 ```
-
 
 <!--
   - test: `inout-unsafe-pointer`
@@ -2673,7 +2589,6 @@ labeled-trailing-closures --> labeled-trailing-closure labeled-trailing-closures
 labeled-trailing-closure --> identifier ``:`` closure-expression
 ```
 
-
 ### Initializer Expression
 
 An *initializer expression* provides access
@@ -2683,7 +2598,6 @@ It has the following form:
 ```swift
 <#expression#>.init(<#initializer arguments#>)
 ```
-
 
 You use the initializer expression in a function call expression
 to initialize a new instance of a type.
@@ -2698,7 +2612,6 @@ class SomeSubClass: SomeSuperClass {
     }
 }
 ```
-
 
 <!--
   - test: `init-call-superclass`
@@ -2725,7 +2638,6 @@ print(oneTwoThree)
 // Prints "123"
 ```
 
-
 <!--
   - test: `init-as-value`
   
@@ -2749,7 +2661,6 @@ let s2 = SomeType(data: 1)       // Also valid
 let s3 = type(of: someValue).init(data: 7)  // Valid
 let s4 = type(of: someValue)(data: 5)       // Error
 ```
-
 
 <!--
   - test: `explicit-implicit-init`
@@ -2778,7 +2689,6 @@ initializer-expression --> postfix-expression ``.`` ``init``
 initializer-expression --> postfix-expression ``.`` ``init`` ``(`` argument-names ``)``
 ```
 
-
 ### Explicit Member Expression
 
 An *explicit member expression* allows access
@@ -2789,7 +2699,6 @@ and the identifier of its member.
 ```swift
 <#expression#>.<#member name#>
 ```
-
 
 The members of a named type are named
 as part of the type's declaration or extension.
@@ -2802,7 +2711,6 @@ class SomeClass {
 let c = SomeClass()
 let y = c.someProperty  // Member access
 ```
-
 
 <!--
   - test: `explicitMemberExpression`
@@ -2826,7 +2734,6 @@ var t = (10, 20, 30)
 t.0 = t.1
 // Now t is (20, 20, 30)
 ```
-
 
 <!--
   - test: `explicit-member-expression`
@@ -2870,7 +2777,6 @@ let d = instance.overloadedMethod        // Ambiguous
 let d = instance.overloadedMethod(x:y:)  // Still ambiguous
 let d: (Int, Bool) -> Void  = instance.overloadedMethod(x:y:)  // Unambiguous
 ```
-
 
 <!--
   - test: `function-with-argument-names`
@@ -2933,7 +2839,6 @@ let x = [10, 3, 20, 15, 4]
     .map { $0 * 100 }
 ```
 
-
 <!--
   - test: `period-at-start-of-line`
   
@@ -2961,7 +2866,6 @@ let numbers = [10, 20, 33, 43, 50]
     .filter { $0 > 25 }
 #endif
 ```
-
 
 <!--
   - test: `pound-if-inside-postfix-expression`
@@ -3061,7 +2965,6 @@ argument-names --> argument-name argument-names-OPT
 argument-name --> identifier ``:``
 ```
 
-
 <!--
   The grammar for method-name doesn't include the following:
       method-name -> identifier argument-names-OPT
@@ -3082,7 +2985,6 @@ immediately followed by `.self`. It has the following forms:
 <#type#>.self
 ```
 
-
 The first form evaluates to the value of the *expression*.
 For example, `x.self` evaluates to `x`.
 
@@ -3097,7 +2999,6 @@ Grammar of a postfix self expression
 postfix-self-expression --> postfix-expression ``.`` ``self``
 ```
 
-
 ### Subscript Expression
 
 A *subscript expression* provides subscript access
@@ -3108,7 +3009,6 @@ It has the following form:
 ```swift
 <#expression#>[<#index expressions#>]
 ```
-
 
 To evaluate the value of a subscript expression,
 the subscript getter for the *expression*'s type is called
@@ -3139,7 +3039,6 @@ Grammar of a subscript expression
 subscript-expression --> postfix-expression ``[`` function-call-argument-list ``]``
 ```
 
-
 <!--
   - test: `subscripts-can-take-operators`
   
@@ -3166,7 +3065,6 @@ It has the following form:
 <#expression#>!
 ```
 
-
 If the value of the *expression* isn't `nil`,
 the optional value is unwrapped
 and returned with the corresponding non-optional type.
@@ -3186,7 +3084,6 @@ var someDictionary = ["a": [1, 2, 3], "b": [10, 20]]
 someDictionary["a"]![0] = 100
 // someDictionary is now ["a": [100, 2, 3], "b": [10, 20]]
 ```
-
 
 <!--
   - test: `optional-as-lvalue`
@@ -3210,7 +3107,6 @@ Grammar of a forced-value expression
 forced-value-expression --> postfix-expression ``!``
 ```
 
-
 ### Optional-Chaining Expression
 
 An *optional-chaining expression* provides a simplified syntax
@@ -3220,7 +3116,6 @@ It has the following form:
 ```swift
 <#expression#>?
 ```
-
 
 The postfix `?` operator makes an optional-chaining expression
 from an expression without changing the expression's value.
@@ -3251,7 +3146,6 @@ var c: SomeClass?
 var result: Bool? = c?.property.performAction()
 ```
 
-
 <!--
   - test: `optional-chaining`
   
@@ -3274,7 +3168,6 @@ if let unwrappedC = c {
     result = unwrappedC.property.performAction()
 }
 ```
-
 
 <!--
   - test: `optional-chaining-alt`
@@ -3313,7 +3206,6 @@ someDictionary["a"]?[0] = someFunctionWithSideEffects()
 // someDictionary is now ["a": [42, 2, 3], "b": [10, 20]]
 ```
 
-
 <!--
   - test: `optional-chaining-as-lvalue`
   
@@ -3341,8 +3233,6 @@ Grammar of an optional-chaining expression
 
 optional-chaining-expression --> postfix-expression ``?``
 ```
-
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/GenericParametersAndArguments.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/GenericParametersAndArguments.md
@@ -1,5 +1,3 @@
-
-
 # Generic Parameters and Arguments
 
 Generalize declarations to abstract away concrete types.
@@ -29,14 +27,12 @@ and has the following form:
 <<#generic parameter list#>>
 ```
 
-
 The *generic parameter list* is a comma-separated list of generic parameters,
 each of which has the following form:
 
 ```swift
 <#type parameter#>: <#constraint#>
 ```
-
 
 A generic parameter consists of a *type parameter* followed by
 an optional *constraint*. A *type parameter* is simply the name
@@ -61,7 +57,6 @@ func simpleMax<T: Comparable>(_ x: T, _ y: T) -> T {
 }
 ```
 
-
 <!--
   - test: `generic-params`
   
@@ -85,7 +80,6 @@ to the function or initializer.
 simpleMax(17, 42) // T is inferred to be Int
 simpleMax(3.14159, 2.71828) // T is inferred to be Double
 ```
-
 
 <!--
   - test: `generic-params`
@@ -116,7 +110,6 @@ followed by a comma-separated list of one or more *requirements*.
 ```swift
 where <#requirements#>
 ```
-
 
 The *requirements* in a generic `where` clause specify that a type parameter inherits from
 a class or conforms to a protocol or protocol composition.
@@ -163,7 +156,6 @@ extension Collection where Element: SomeProtocol {
     }
 }
 ```
-
 
 <!--
   - test: `contextual-where-clauses-combine`
@@ -230,7 +222,6 @@ conformance-requirement --> type-identifier ``:`` protocol-composition-type
 same-type-requirement --> type-identifier ``==`` type
 ```
 
-
 <!--
   NOTE: A conformance requirement can only have one type after the colon,
   otherwise, you'd have a syntactic ambiguity
@@ -248,7 +239,6 @@ and has the following form:
 <<#generic argument list#>>
 ```
 
-
 The *generic argument list* is a comma-separated list of type arguments.
 A *type argument* is the name of an actual concrete type that replaces
 a corresponding type parameter in the generic parameter clause of a generic type.
@@ -261,7 +251,6 @@ struct Dictionary<Key: Hashable, Value>: Collection, ExpressibleByDictionaryLite
     /* ... */
 }
 ```
-
 
 <!--
   TODO: How are we supposed to wrap code lines like the above?
@@ -285,7 +274,6 @@ to form an array whose elements are themselves arrays of integers.
 let arrayOfArrays: Array<Array<Int>> = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 ```
 
-
 <!--
   - test: `array-of-arrays`
   
@@ -305,8 +293,6 @@ generic-argument-clause --> ``<`` generic-argument-list ``>``
 generic-argument-list --> generic-argument | generic-argument ``,`` generic-argument-list
 generic-argument --> type
 ```
-
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/LexicalStructure.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/LexicalStructure.md
@@ -1,5 +1,3 @@
-
-
 # Lexical Structure
 
 Use the lowest-level components of the syntax.
@@ -75,7 +73,6 @@ multiline-comment-text-item --> multiline-comment
 multiline-comment-text-item --> comment-text-item
 multiline-comment-text-item --> Any Unicode scalar value except ``/*`` or ``*/``
 ```
-
 
 ## Identifiers
 
@@ -159,7 +156,6 @@ identifier-characters --> identifier-character identifier-characters-OPT
 implicit-parameter-name --> ``$`` decimal-digits
 property-wrapper-projection --> ``$`` identifier-characters
 ```
-
 
 ## Keywords and Punctuation
 
@@ -404,7 +400,6 @@ The following are examples of literals:
 true             // Boolean literal
 ```
 
-
 <!--
   - test: `basic-literals`
   
@@ -447,7 +442,6 @@ the annotation's type must be a type that can be instantiated from that literal 
 That is, the type must conform to the Swift standard library protocols
 listed in the table below.
 
-
 | Literal | Default type | Protocol |
 | ------- | ------------ | -------- |
 | Integer | `Int` | `ExpressibleByIntegerLiteral` |
@@ -478,7 +472,6 @@ numeric-literal --> ``-``-OPT integer-literal | ``-``-OPT floating-point-literal
 boolean-literal --> ``true`` | ``false``
 nil-literal --> ``nil``
 ```
-
 
 ### Integer Literals
 
@@ -556,7 +549,6 @@ hexadecimal-literal-character --> hexadecimal-digit | ``_``
 hexadecimal-literal-characters --> hexadecimal-literal-character hexadecimal-literal-characters-OPT
 ```
 
-
 ### Floating-Point Literals
 
 *Floating-point literals* represent floating-point values of unspecified precision.
@@ -620,7 +612,6 @@ floating-point-p --> ``p`` | ``P``
 sign --> ``+`` | ``-``
 ```
 
-
 ### String Literals
 
 A string literal is a sequence of characters surrounded by quotation marks.
@@ -630,7 +621,6 @@ and has the following form:
 ```swift
 "<#characters#>"
 ```
-
 
 String literals can't contain
 an unescaped double quotation mark (`"`),
@@ -645,7 +635,6 @@ and has the following form:
 <#characters#>
 """
 ```
-
 
 Unlike a single-line string literal,
 a multiline string literal can contain
@@ -727,7 +716,6 @@ For example, all of the following string literals have the same value:
 let x = 3; "1 2 \(x)"
 ```
 
-
 <!--
   - test: `string-literals`
   
@@ -768,7 +756,6 @@ A string delimited by extended delimiters has the following forms:
 """#
 ```
 
-
 Special characters in a string delimited by extended delimiters
 appear in the resulting string as normal characters
 rather than as special characters.
@@ -790,7 +777,6 @@ print(string)
 print(string == escaped)
 // Prints "true"
 ```
-
 
 <!--
   - test: `extended-string-delimiters`
@@ -823,7 +809,6 @@ don't place whitespace in between the number signs:
 print(###"Line 1\###nLine 2"###) // OK
 print(# # #"Line 1\# # #nLine 2"# # #) // Error
 ```
-
 
 <!--
   - test: `extended-string-delimiters-err`
@@ -858,7 +843,6 @@ no runtime concatenation is performed.
 let textA = "Hello " + "world"
 let textB = "Hello world"
 ```
-
 
 <!--
   - test: `concatenated-strings`
@@ -910,7 +894,6 @@ unicode-scalar-digits --> Between one and eight hexadecimal digits
 escaped-newline -->  escape-sequence inline-spaces-OPT line-break
 ```
 
-
 <!--
   Quoted text resolves to a sequence of escaped characters by way of
   the quoted-text rule which allows repetition; no need to allow
@@ -936,7 +919,6 @@ surrounded by slashes (`/`) with the following form:
 ```swift
 /<#regular expression#>/
 ```
-
 
 Regular expression literals
 must not begin with an unescaped tab or space,
@@ -993,7 +975,6 @@ delimited by extended delimiters has the following forms:
 /#
 ```
 
-
 A regular expression literal that uses extended delimiters
 can begin with an unescaped space or tab,
 contain unescaped slashes (`/`),
@@ -1020,7 +1001,6 @@ let regex1 = ##/abc/##       // OK
 let regex2 = # #/abc/# #     // Error
 ```
 
-
 <!--
   - test: `extended-regex-delimiters-err`
   
@@ -1044,7 +1024,6 @@ regular-expression-literal-closing-delimiter --> ``/`` extended-regular-expressi
 
 extended-regular-expression-literal-delimiter --> ``#`` extended-regular-expression-literal-delimiter-OPT
 ```
-
 
 ## Operators
 
@@ -1251,8 +1230,6 @@ infix-operator --> operator
 prefix-operator --> operator
 postfix-operator --> operator
 ```
-
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Patterns.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Patterns.md
@@ -1,5 +1,3 @@
-
-
 # Patterns
 
 Match and destructure values.
@@ -46,7 +44,6 @@ pattern --> type-casting-pattern
 pattern --> expression-pattern
 ```
 
-
 ## Wildcard Pattern
 
 A *wildcard pattern* matches and ignores any value and consists of an underscore
@@ -59,7 +56,6 @@ for _ in 1...3 {
     // Do something three times.
 }
 ```
-
 
 <!--
   - test: `wildcard-pattern`
@@ -77,7 +73,6 @@ Grammar of a wildcard pattern
 wildcard-pattern --> ``_``
 ```
 
-
 ## Identifier Pattern
 
 An *identifier pattern* matches any value and binds the matched value to a
@@ -88,7 +83,6 @@ that matches the value `42` of type `Int`:
 ```swift
 let someValue = 42
 ```
-
 
 <!--
   - test: `identifier-pattern`
@@ -111,7 +105,6 @@ Grammar of an identifier pattern
 identifier-pattern --> identifier
 ```
 
-
 ## Value-Binding Pattern
 
 A *value-binding pattern* binds matched values to variable or constant names.
@@ -133,7 +126,6 @@ case let (x, y):
 }
 // Prints "The point is at (3, 2)."
 ```
-
 
 <!--
   - test: `value-binding-pattern`
@@ -158,7 +150,6 @@ Grammar of a value-binding pattern
 
 value-binding-pattern --> ``var`` pattern | ``let`` pattern
 ```
-
 
 <!--
   NOTE: We chose to call this "value-binding pattern"
@@ -194,7 +185,6 @@ for (x, 0) in points {
 }
 ```
 
-
 <!--
   - test: `tuple-pattern`
   
@@ -227,7 +217,6 @@ let (a) = 2      // a: Int = 2
 let (a): Int = 2 // a: Int = 2
 ```
 
-
 <!--
   - test: `single-element-tuple-pattern`
   
@@ -257,7 +246,6 @@ tuple-pattern --> ``(`` tuple-pattern-element-list-OPT ``)``
 tuple-pattern-element-list --> tuple-pattern-element | tuple-pattern-element ``,`` tuple-pattern-element-list
 tuple-pattern-element --> pattern | identifier ``:`` pattern
 ```
-
 
 ## Enumeration Case Pattern
 
@@ -294,7 +282,6 @@ case nil:
 // Prints "Turn left"
 ```
 
-
 <!--
   - test: `enum-pattern-matching-optional`
   
@@ -319,7 +306,6 @@ Grammar of an enumeration case pattern
 enum-case-pattern --> type-identifier-OPT ``.`` enum-case-name tuple-pattern-OPT
 ```
 
-
 ## Optional Pattern
 
 An *optional pattern* matches values wrapped in a `some(Wrapped)` case
@@ -343,7 +329,6 @@ if case let x? = someOptional {
     print(x)
 }
 ```
-
 
 <!--
   - test: `optional-pattern`
@@ -379,7 +364,6 @@ for case let number? in arrayOfOptionalInts {
 // Found a 5
 ```
 
-
 <!--
   - test: `optional-pattern-for-in`
   
@@ -401,7 +385,6 @@ Grammar of an optional pattern
 optional-pattern --> identifier-pattern ``?``
 ```
 
-
 ## Type-Casting Patterns
 
 There are two type-casting patterns, the `is` pattern and the `as` pattern.
@@ -412,7 +395,6 @@ case labels. The `is` and `as` patterns have the following form:
 is <#type#>
 <#pattern#> as <#type#>
 ```
-
 
 The `is` pattern matches a value if the type of that value at runtime is the same as
 the type specified in the right-hand side of the `is` pattern---or a subclass of that type.
@@ -436,7 +418,6 @@ type-casting-pattern --> is-pattern | as-pattern
 is-pattern --> ``is`` type
 as-pattern --> pattern ``as`` type
 ```
-
 
 ## Expression Pattern
 
@@ -466,7 +447,6 @@ default:
 }
 // Prints "(1, 2) is near the origin."
 ```
-
 
 <!--
   - test: `expression-pattern`
@@ -503,7 +483,6 @@ default:
 // Prints "The point is at (1, 2)."
 ```
 
-
 <!--
   - test: `expression-pattern`
   
@@ -527,8 +506,6 @@ Grammar of an expression pattern
 
 expression-pattern --> expression
 ```
-
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Statements.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Statements.md
@@ -1,5 +1,3 @@
-
-
 # Statements
 
 Structure groups of expressions and control their behavior.
@@ -39,7 +37,6 @@ statement --> compiler-control-statement
 statements --> statement statements-OPT
 ```
 
-
 <!--
   NOTE: Removed semicolon-statement as syntactic category,
   because, according to Doug, they're not really statements.
@@ -72,7 +69,6 @@ loop-statement --> while-statement
 loop-statement --> repeat-while-statement
 ```
 
-
 ### For-In Statement
 
 A `for`-`in` statement allows a block of code to be executed
@@ -87,7 +83,6 @@ for <#item#> in <#collection#> {
    <#statements#>
 }
 ```
-
 
 The `makeIterator()` method is called on the *collection* expression
 to obtain a value of an iterator type---that is,
@@ -108,7 +103,6 @@ Grammar of a for-in statement
 for-in-statement --> ``for`` ``case``-OPT pattern ``in`` expression where-clause-OPT code-block
 ```
 
-
 ### While Statement
 
 A `while` statement allows a block of code to be executed repeatedly,
@@ -121,7 +115,6 @@ while <#condition#> {
    <#statements#>
 }
 ```
-
 
 A `while` statement is executed as follows:
 
@@ -149,7 +142,6 @@ case-condition --> ``case`` pattern initializer
 optional-binding-condition --> ``let`` pattern initializer-OPT | ``var`` pattern initializer-OPT
 ```
 
-
 ### Repeat-While Statement
 
 A `repeat`-`while` statement allows a block of code to be executed one or more times,
@@ -162,7 +154,6 @@ repeat {
    <#statements#>
 } while <#condition#>
 ```
-
 
 A `repeat`-`while` statement is executed as follows:
 
@@ -182,7 +173,6 @@ Grammar of a repeat-while statement
 
 repeat-while-statement --> ``repeat`` code-block ``while`` expression
 ```
-
 
 ## Branch Statements
 
@@ -204,7 +194,6 @@ branch-statement --> guard-statement
 branch-statement --> switch-statement
 ```
 
-
 ### If Statement
 
 An `if` statement is used for executing code
@@ -222,7 +211,6 @@ if <#condition#> {
 }
 ```
 
-
 The second form of an `if` statement provides an additional *else clause*
 (introduced by the `else` keyword)
 and is used for executing one part of code when the condition is true
@@ -236,7 +224,6 @@ if <#condition#> {
    <#statements to execute if condition is false#>
 }
 ```
-
 
 The else clause of an `if` statement can contain another `if` statement
 to test more than one condition.
@@ -252,7 +239,6 @@ if <#condition 1#> {
 }
 ```
 
-
 The value of any condition in an `if` statement
 must be of type `Bool` or a type bridged to `Bool`.
 The condition can also be an optional binding declaration,
@@ -264,7 +250,6 @@ Grammar of an if statement
 if-statement --> ``if`` condition-list code-block else-clause-OPT
 else-clause --> ``else`` code-block | ``else`` if-statement
 ```
-
 
 ### Guard Statement
 
@@ -278,7 +263,6 @@ guard <#condition#> else {
    <#statements#>
 }
 ```
-
 
 The value of any condition in a `guard` statement
 must be of type `Bool` or a type bridged to `Bool`.
@@ -309,7 +293,6 @@ Grammar of a guard statement
 guard-statement --> ``guard`` condition-list ``else`` code-block
 ```
 
-
 ### Switch Statement
 
 A `switch` statement allows certain blocks of code to be executed
@@ -330,7 +313,6 @@ default:
     <#statements#>
 }
 ```
-
 
 The *control expression* of the `switch` statement is evaluated
 and then compared with the patterns specified in each case.
@@ -363,7 +345,6 @@ only if it's a tuple that contains two elements of the same value, such as `(1, 
 ```swift
 case let (x, y) where x == y:
 ```
-
 
 <!--
   - test: `switch-case-statement`
@@ -495,7 +476,6 @@ case .suppressed:
 // Prints "Generate a default mirror for all ancestor classes."
 ```
 
-
 <!--
   - test: `unknown-case`
   
@@ -550,7 +530,6 @@ switch-elseif-directive-clause --> elseif-directive compilation-condition switch
 switch-else-directive-clause --> else-directive switch-cases-OPT
 ```
 
-
 <!--
   The grammar above uses attributes-OPT to match what's used
   in all other places where attributes are allowed,
@@ -602,7 +581,6 @@ statement-label --> label-name ``:``
 label-name --> identifier
 ```
 
-
 ## Control Transfer Statements
 
 Control transfer statements can change the order in which code in your program is executed
@@ -620,7 +598,6 @@ control-transfer-statement --> return-statement
 control-transfer-statement --> throw-statement
 ```
 
-
 ### Break Statement
 
 A `break` statement ends program execution of a loop,
@@ -633,7 +610,6 @@ as shown below.
 break
 break <#label name#>
 ```
-
 
 When a `break` statement is followed by the name of a statement label,
 it ends program execution of the loop,
@@ -657,7 +633,6 @@ Grammar of a break statement
 break-statement --> ``break`` label-name-OPT
 ```
 
-
 ### Continue Statement
 
 A `continue` statement ends program execution of the current iteration of a loop
@@ -670,7 +645,6 @@ as shown below.
 continue
 continue <#label name#>
 ```
-
 
 When a `continue` statement is followed by the name of a statement label,
 it ends program execution of the current iteration
@@ -696,7 +670,6 @@ Grammar of a continue statement
 
 continue-statement --> ``continue`` label-name-OPT
 ```
-
 
 ### Fallthrough Statement
 
@@ -724,7 +697,6 @@ Grammar of a fallthrough statement
 fallthrough-statement --> ``fallthrough``
 ```
 
-
 ### Return Statement
 
 A `return` statement occurs in the body of a function or method definition
@@ -738,7 +710,6 @@ or it can consist of the `return` keyword followed by an expression, as shown be
 return
 return <#expression#>
 ```
-
 
 When a `return` statement is followed by an expression,
 the value of the expression is returned to the calling function or method.
@@ -765,7 +736,6 @@ Grammar of a return statement
 return-statement --> ``return`` expression-OPT
 ```
 
-
 ### Throw Statement
 
 A `throw` statement occurs in the body of a throwing function or method,
@@ -783,7 +753,6 @@ followed by an expression, as shown below.
 throw <#expression#>
 ```
 
-
 The value of the *expression* must have a type that conforms to
 the `Error` protocol.
 
@@ -796,7 +765,6 @@ Grammar of a throw statement
 
 throw-statement --> ``throw`` expression
 ```
-
 
 ## Defer Statement
 
@@ -811,7 +779,6 @@ defer {
     <#statements#>
 }
 ```
-
 
 The statements within the `defer` statement are executed
 no matter how program control is transferred.
@@ -839,7 +806,6 @@ f(x: 5)
 // Prints "End of function"
 // Prints "First defer"
 ```
-
 
 <!--
   ```swifttest
@@ -885,7 +851,6 @@ f()
 // Prints "First defer"
 ```
 
-
 <!--
   ```swifttest
   -> func f() {
@@ -908,7 +873,6 @@ Grammar of a defer statement
 
 defer-statement --> ``defer`` code-block
 ```
-
 
 ## Do Statement
 
@@ -938,7 +902,6 @@ do {
     <#statements#>
 }
 ```
-
 
 If any statement in the `do` code block throws an error,
 program control is transferred
@@ -989,7 +952,6 @@ catch-pattern-list --> catch-pattern | catch-pattern ``,`` catch-pattern-list
 catch-pattern --> pattern where-clause-OPT
 ```
 
-
 ## Compiler Control Statements
 
 Compiler control statements allow the program to change aspects of the compiler's behavior.
@@ -1006,7 +968,6 @@ compiler-control-statement --> line-control-statement
 compiler-control-statement --> diagnostic-statement
 ```
 
-
 ### Conditional Compilation Block
 
 A conditional compilation block allows code to be conditionally compiled
@@ -1022,7 +983,6 @@ A simple conditional compilation block has the following form:
 #endif
 ```
 
-
 Unlike the condition of an `if` statement,
 the *compilation condition* is evaluated at compile time.
 As a result,
@@ -1032,7 +992,6 @@ evaluates to `true` at compile time.
 The *compilation condition* can include the `true` and `false` Boolean literals,
 an identifier used with the `-D` command line flag, or any of the platform
 conditions listed in the table below.
-
 
 | Platform condition | Valid arguments |
 | ------------------ | --------------- |
@@ -1089,7 +1048,6 @@ print("Compiled with the Swift 5 compiler or later in a Swift mode earlier than 
 // Prints "Compiled in Swift 4.2 mode or later"
 // Prints "Compiled with the Swift 5 compiler or later in a Swift mode earlier than 5"
 ```
-
 
 <!--
   ```swifttest
@@ -1244,7 +1202,6 @@ have the following form:
 #endif
 ```
 
-
 > Note: Each statement in the body of a conditional compilation block is parsed
 > even if it's not compiled.
 > However, there's an exception
@@ -1295,7 +1252,6 @@ swift-version-continuation --> ``.`` decimal-digits swift-version-continuation-O
 environment --> ``simulator`` | ``macCatalyst``
 ```
 
-
 <!--
   Testing notes:
   
@@ -1324,7 +1280,6 @@ A line control statement has the following forms:
 #sourceLocation()
 ```
 
-
 The first form of a line control statement changes the values
 of the `#line`, `#file`, `#fileID`, and `#filePath`
 literal expressions, beginning with the line of code following the line control statement.
@@ -1349,7 +1304,6 @@ line-number --> A decimal integer greater than zero
 file-path --> static-string-literal
 ```
 
-
 ### Compile-Time Diagnostic Statement
 
 A compile-time diagnostic statement causes the compiler
@@ -1360,7 +1314,6 @@ A compile-time diagnostic statement has the following forms:
 #error("<#error message#>")
 #warning("<#warning message#>")
 ```
-
 
 The first form emits the *error message* as a fatal error
 and terminates the compilation process.
@@ -1379,7 +1332,6 @@ diagnostic-statement --> ``#warning`` ``(`` diagnostic-message ``)``
 
 diagnostic-message --> static-string-literal
 ```
-
 
 <!--
   - test: `good-diagnostic-statement-messages`
@@ -1439,7 +1391,6 @@ if #available(<#platform name#> <#version#>, <#...#>, *) {
 }
 ```
 
-
 You use an availability condition to execute a block of code,
 depending on whether the APIs you want to use are available at runtime.
 The compiler uses the information from the availability condition
@@ -1465,7 +1416,6 @@ if #unavailable(<#platform name#> <#version#>, <#...#>) {
 }
 ```
 
-
 The `#unavailable` form is syntactic sugar that negates the condition.
 In an unavailability condition,
 the `*` argument is implicit and must not be included.
@@ -1489,7 +1439,6 @@ platform-version --> decimal-digits
 platform-version --> decimal-digits ``.`` decimal-digits
 platform-version --> decimal-digits ``.`` decimal-digits ``.`` decimal-digits
 ```
-
 
 <!--
   If you need to add a new platform to this list,
@@ -1548,7 +1497,6 @@ platform-version --> decimal-digits ``.`` decimal-digits ``.`` decimal-digits
   !$                ^
   ```
 -->
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Types.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Types.md
@@ -1,5 +1,3 @@
-
-
 # Types
 
 Use built-in nominal and structural types.
@@ -54,7 +52,6 @@ type --> self-type
 type --> ``(`` type ``)``
 ```
 
-
 ## Type Annotation
 
 A *type annotation* explicitly specifies the type of a variable or expression.
@@ -65,7 +62,6 @@ as the following examples show:
 let someTuple: (Double, Double) = (3.14159, 2.71828)
 func someFunction(a: Int) { /* ... */ }
 ```
-
 
 <!--
   - test: `type-annotation`
@@ -89,7 +85,6 @@ Grammar of a type annotation
 type-annotation --> ``:`` attributes-OPT ``inout``-OPT type
 ```
 
-
 ## Type Identifier
 
 A *type identifier* refers to either a named type
@@ -111,7 +106,6 @@ typealias Point = (Int, Int)
 let origin: Point = (0, 0)
 ```
 
-
 <!--
   - test: `type-identifier`
   
@@ -130,7 +124,6 @@ that's declared in the `ExampleModule` module.
 var someValue: ExampleModule.MyType
 ```
 
-
 <!--
   - test: `type-identifier-dot`
   
@@ -148,7 +141,6 @@ Grammar of a type identifier
 type-identifier --> type-name generic-argument-clause-OPT | type-name generic-argument-clause-OPT ``.`` type-identifier
 type-name --> identifier
 ```
-
 
 ## Tuple Type
 
@@ -170,7 +162,6 @@ someTuple = (top: 4, bottom: 42) // OK: names match
 someTuple = (9, 99)              // OK: names are inferred
 someTuple = (left: 5, right: 5)  // Error: names don't match
 ```
-
 
 <!--
   - test: `tuple-type-names`
@@ -198,7 +189,6 @@ tuple-type-element --> element-name type-annotation | type
 element-name --> identifier
 ```
 
-
 ## Function Type
 
 A *function type* represents the type of a function, method, or closure
@@ -207,7 +197,6 @@ and consists of a parameter and return type separated by an arrow (`->`):
 ```swift
 (<#parameter type#>) -> <#return type#>
 ```
-
 
 The *parameter type* is comma-separated list of types.
 Because the *return type* can be a tuple type,
@@ -292,7 +281,6 @@ func functionWithDifferentNumberOfArguments(left: Int, right: Int, top: Int) {}
 f = functionWithDifferentNumberOfArguments // Error
 ```
 
-
 <!--
   - test: `argument-names-err`
   
@@ -327,7 +315,6 @@ var operation: (lhs: Int, rhs: Int) -> Int     // Error
 var operation: (_ lhs: Int, _ rhs: Int) -> Int // OK
 var operation: (Int, Int) -> Int               // OK
 ```
-
 
 <!--
   - test: `omit-argument-names-in-function-type`
@@ -443,7 +430,6 @@ func takesTwoFunctions(first: (() -> Void) -> Void, second: (() -> Void) -> Void
 }
 ```
 
-
 <!--
   - test: `memory-nonescaping-functions`
   
@@ -508,7 +494,6 @@ function-type-argument --> attributes-OPT ``inout``-OPT type | argument-label ty
 argument-label --> identifier
 ```
 
-
 <!--
   NOTE: Functions are first-class citizens in Swift,
   except for generic functions, i.e., parametric polymorphic functions.
@@ -534,14 +519,12 @@ The Swift language provides the following syntactic sugar for the Swift standard
 [<#type#>]
 ```
 
-
 In other words, the following two declarations are equivalent:
 
 ```swift
 let someArray: Array<String> = ["Alex", "Brian", "Dave"]
 let someArray: [String] = ["Alex", "Brian", "Dave"]
 ```
-
 
 <!--
   - test: `array-literal`
@@ -568,7 +551,6 @@ a three-dimensional array of integers using three sets of square brackets:
 var array3D: [[[Int]]] = [[[1, 2], [3, 4]], [[5, 6], [7, 8]]]
 ```
 
-
 <!--
   - test: `array-3d`
   
@@ -593,7 +575,6 @@ Grammar of an array type
 array-type --> ``[`` type ``]``
 ```
 
-
 ## Dictionary Type
 
 The Swift language provides the following syntactic sugar for the Swift standard library
@@ -603,14 +584,12 @@ The Swift language provides the following syntactic sugar for the Swift standard
 [<#key type#>: <#value type#>]
 ```
 
-
 In other words, the following two declarations are equivalent:
 
 ```swift
 let someDictionary: [String: Int] = ["Alex": 31, "Paul": 39]
 let someDictionary: Dictionary<String, Int> = ["Alex": 31, "Paul": 39]
 ```
-
 
 <!--
   - test: `dictionary-literal`
@@ -649,7 +628,6 @@ Grammar of a dictionary type
 dictionary-type --> ``[`` type ``:`` type ``]``
 ```
 
-
 ## Optional Type
 
 The Swift language defines the postfix `?` as syntactic sugar for
@@ -660,7 +638,6 @@ In other words, the following two declarations are equivalent:
 var optionalInteger: Int?
 var optionalInteger: Optional<Int>
 ```
-
 
 <!--
   - test: `optional-literal`
@@ -700,7 +677,6 @@ optionalInteger = 42
 optionalInteger! // 42
 ```
 
-
 <!--
   - test: `optional-type`
   
@@ -734,7 +710,6 @@ Grammar of an optional type
 optional-type --> type ``?``
 ```
 
-
 ## Implicitly Unwrapped Optional Type
 
 The Swift language defines the postfix `!` as syntactic sugar for
@@ -750,7 +725,6 @@ the following two declarations are equivalent:
 var implicitlyUnwrappedString: String!
 var explicitlyUnwrappedString: Optional<String>
 ```
-
 
 Note that no whitespace may appear between the type and the `!`.
 
@@ -768,7 +742,6 @@ let implicitlyUnwrappedTuple: (Int, Int)!             // OK
 let arrayOfImplicitlyUnwrappedElements: [Int!]        // Error
 let implicitlyUnwrappedArray: [Int]!                  // OK
 ```
-
 
 Because implicitly unwrapped optionals
 have the same `Optional<Wrapped>` type as optional values,
@@ -796,7 +769,6 @@ Grammar of an implicitly unwrapped optional type
 implicitly-unwrapped-optional-type --> type ``!``
 ```
 
-
 ## Protocol Composition Type
 
 A *protocol composition type* defines a type that conforms to each protocol
@@ -818,7 +790,6 @@ Protocol composition types have the following form:
 ```swift
 <#Protocol 1#> & <#Protocol 2#>
 ```
-
 
 A protocol composition type allows you to specify a value whose type conforms to the requirements
 of multiple protocols without explicitly defining a new, named protocol
@@ -852,7 +823,6 @@ typealias PQ = P & Q
 typealias PQR = PQ & Q & R
 ```
 
-
 <!--
   - test: `protocol-composition-can-have-repeats`
   
@@ -872,7 +842,6 @@ protocol-composition-type --> type-identifier ``&`` protocol-composition-continu
 protocol-composition-continuation --> type-identifier | protocol-composition-type
 ```
 
-
 ## Opaque Type
 
 An *opaque type* defines a type
@@ -889,7 +858,6 @@ Opaque types have the following form:
 ```swift
 some <#constraint#>
 ```
-
 
 The *constraint* is a class type,
 protocol type,
@@ -924,7 +892,6 @@ Grammar of an opaque type
 
 opaque-type --> ``some`` type
 ```
-
 
 ## Metatype Type
 
@@ -965,7 +932,6 @@ let someInstance: SomeBaseClass = SomeSubClass()
 type(of: someInstance).printClassName()
 // Prints "SomeSubClass"
 ```
-
 
 <!--
   - test: `metatype-type`
@@ -1013,7 +979,6 @@ let metatype: AnotherSubClass.Type = AnotherSubClass.self
 let anotherInstance = metatype.init(string: "some string")
 ```
 
-
 <!--
   - test: `metatype-type`
   
@@ -1038,7 +1003,6 @@ Grammar of a metatype type
 metatype-type --> type ``.`` ``Type`` | type ``.`` ``Protocol``
 ```
 
-
 ## Any Type
 
 The `Any` type can contain values from all other types.
@@ -1053,7 +1017,6 @@ for an instance of any of the following types:
 ```swift
 let mixed: [Any] = ["one", 2, true, (4, 5.3), { () -> Int in return 6 }]
 ```
-
 
 <!--
   - test: `any-type`
@@ -1080,7 +1043,6 @@ if let first = mixed.first as? String {
 }
 // Prints "The first item, 'one', is a string."
 ```
-
 
 <!--
   - test: `any-type`
@@ -1109,7 +1071,6 @@ Grammar of an Any type
 
 any-type --> ``Any``
 ```
-
 
 ## Self Type
 
@@ -1186,7 +1147,6 @@ print(type(of: z.f()))
 // Prints "Subclass"
 ```
 
-
 <!--
   - test: `self-gives-dynamic-type`
   
@@ -1236,7 +1196,6 @@ Grammar of a Self type
 self-type --> ``Self``
 ```
 
-
 ## Type Inheritance Clause
 
 A *type inheritance clause* is used to specify which class a named type inherits from
@@ -1272,7 +1231,6 @@ type-inheritance-clause --> ``:`` type-inheritance-list
 type-inheritance-list --> attributes-OPT type-identifier | attributes-OPT type-identifier ``,`` type-inheritance-list
 ```
 
-
 ## Type Inference
 
 Swift uses *type inference* extensively,
@@ -1301,7 +1259,6 @@ let e = 2.71828 // The type of e is inferred to be Double.
 let eFloat: Float = 2.71828 // The type of eFloat is Float.
 ```
 
-
 <!--
   - test: `type-inference`
   
@@ -1320,7 +1277,6 @@ the expression or one of its subexpressions.
   TODO: Email Doug for a list of rules or situations describing when type-inference
   is allowed and when types must be fully typed.
 -->
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/RevisionHistory/RevisionHistory.md
+++ b/Sources/TSPL/TSPL.docc/RevisionHistory/RevisionHistory.md
@@ -1,5 +1,3 @@
-
-
 # Document Revision History
 
 Review the recent changes to this book.
@@ -786,7 +784,6 @@ Review the recent changes to this book.
 - Updated to `..<` rather than `..`
   for the <doc:BasicOperators#Half-Open-Range-Operator>.
 - Added an example of <doc:Generics#Extending-a-Generic-Type>.
-
 
 <!--
 This source file is part of the Swift.org open source project

--- a/Sources/TSPL/TSPL.docc/TSPL.md
+++ b/Sources/TSPL/TSPL.docc/TSPL.md
@@ -64,7 +64,6 @@
 
 - <doc:RevisionHistory>
 
-
 <!--
 This source file is part of the Swift.org open source project
 


### PR DESCRIPTION
Most of these runs of blank lines were added as a byproduct of the RST-to-markdown export.  In a few places, these were an intentional part of authoring — for example, most of the reference has two blank lines before a section heading — which we could put back if desired.  I think there is an argument to be made for the consistency of single blank lines, from an authoring perspective.  I don't remember the full rationale from 2014 when Brian and I used the double blanks in the reference.

Verified changes are only in blank lines with `git diff --ignore-blank-lines`, which has no output.  Also confirmed that there are no changes in the HTML output from DocC.