### PR TITLE
Update name in screenshot markers

### DIFF
--- a/Sources/TSPL/TSPL.docc/GuidedTour/GuidedTour.md
+++ b/Sources/TSPL/TSPL.docc/GuidedTour/GuidedTour.md
@@ -263,9 +263,7 @@ occupations["Jayne"] = "Public Relations"
   ```
 -->
 
-<!--
-  Apple Books screenshot begins here.
--->
+<!-- Apple Books screenshot begins here. -->
 
 Arrays automatically grow as you add elements.
 
@@ -390,9 +388,7 @@ or contains `nil` to indicate that a value is missing.
 Write a question mark (`?`) after the type of a value
 to mark the value as optional.
 
-<!--
-  Apple Books screenshot ends here.
--->
+<!-- Apple Books screenshot ends here. -->
 
 <!--
   REFERENCE

--- a/Sources/TSPL/TSPL.docc/GuidedTour/GuidedTour.md
+++ b/Sources/TSPL/TSPL.docc/GuidedTour/GuidedTour.md
@@ -264,7 +264,7 @@ occupations["Jayne"] = "Public Relations"
 -->
 
 <!--
-  iBooks Store screenshot begins here.
+  Apple Books screenshot begins here.
 -->
 
 Arrays automatically grow as you add elements.
@@ -391,7 +391,7 @@ Write a question mark (`?`) after the type of a value
 to mark the value as optional.
 
 <!--
-  iBooks Store screenshot ends here.
+  Apple Books screenshot ends here.
 -->
 
 <!--

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/AdvancedOperators.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/AdvancedOperators.md
@@ -73,7 +73,7 @@ and its second four bits set to `1`.
 This is equivalent to a decimal value of `15`.
 
 <!--
-  iBooks Store screenshot begins here.
+  Apple Books screenshot begins here.
 -->
 
 The bitwise NOT operator is then used to create a new constant called `invertedBits`,
@@ -123,7 +123,7 @@ if the bits are equal to `1` in *either* input number:
 ![](bitwiseOR)
 
 <!--
-  iBooks Store screenshot ends here.
+  Apple Books screenshot ends here.
 -->
 
 In the example below,

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/AdvancedOperators.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/AdvancedOperators.md
@@ -72,9 +72,7 @@ which has its first four bits set to `0`,
 and its second four bits set to `1`.
 This is equivalent to a decimal value of `15`.
 
-<!--
-  Apple Books screenshot begins here.
--->
+<!-- Apple Books screenshot begins here. -->
 
 The bitwise NOT operator is then used to create a new constant called `invertedBits`,
 which is equal to `initialBits`,
@@ -122,9 +120,7 @@ if the bits are equal to `1` in *either* input number:
 
 ![](bitwiseOR)
 
-<!--
-  Apple Books screenshot ends here.
--->
+<!-- Apple Books screenshot ends here. -->
 
 In the example below,
 the values of `someBits` and `moreBits` have different bits set to `1`.

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/ControlFlow.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/ControlFlow.md
@@ -309,7 +309,7 @@ This example plays a simple game of *Snakes and Ladders*
 (also known as *Chutes and Ladders*):
 
 <!--
-  iBooks Store screenshot begins here.
+  Apple Books screenshot begins here.
 -->
 
 ![](snakesAndLadders)
@@ -365,7 +365,7 @@ board[14] = -10; board[19] = -11; board[22] = -02; board[24] = -08
 -->
 
 <!--
-  iBooks Store screenshot ends here.
+  Apple Books screenshot ends here.
 -->
 
 Square 3 contains the bottom of a ladder that moves you up to square 11.

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/ControlFlow.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/ControlFlow.md
@@ -308,9 +308,7 @@ while <#condition#> {
 This example plays a simple game of *Snakes and Ladders*
 (also known as *Chutes and Ladders*):
 
-<!--
-  Apple Books screenshot begins here.
--->
+<!-- Apple Books screenshot begins here. -->
 
 ![](snakesAndLadders)
 
@@ -364,9 +362,7 @@ board[14] = -10; board[19] = -11; board[22] = -02; board[24] = -08
   ```
 -->
 
-<!--
-  Apple Books screenshot ends here.
--->
+<!-- Apple Books screenshot ends here. -->
 
 Square 3 contains the bottom of a ladder that moves you up to square 11.
 To represent this, `board[03]` is equal to `+08`,

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Properties.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Properties.md
@@ -431,9 +431,7 @@ Setting the `center` property calls the setter for `center`,
 which modifies the `x` and `y` values of the stored `origin` property,
 and moves the square to its new position.
 
-<!--
-  Apple Books screenshot begins here.
--->
+<!-- Apple Books screenshot begins here. -->
 
 ![](computedProperties)
 
@@ -484,9 +482,7 @@ struct AlternativeRect {
   ```
 -->
 
-<!--
-  Apple Books screenshot ends here.
--->
+<!-- Apple Books screenshot ends here. -->
 
 ### Shorthand Getter Declaration
 

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Properties.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Properties.md
@@ -432,7 +432,7 @@ which modifies the `x` and `y` values of the stored `origin` property,
 and moves the square to its new position.
 
 <!--
-  iBooks Store screenshot begins here.
+  Apple Books screenshot begins here.
 -->
 
 ![](computedProperties)
@@ -485,7 +485,7 @@ struct AlternativeRect {
 -->
 
 <!--
-  iBooks Store screenshot ends here.
+  Apple Books screenshot ends here.
 -->
 
 ### Shorthand Getter Declaration

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Expressions.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Expressions.md
@@ -876,7 +876,7 @@ struct Point {
 -->
 
 <!--
-  iBooks Store screenshot begins here.
+  Apple Books screenshot begins here.
 -->
 
 > Grammar of a self expression:
@@ -961,7 +961,7 @@ There are several special forms
 that allow closures to be written more concisely:
 
 <!--
-  iBooks Store screenshot ends here.
+  Apple Books screenshot ends here.
 -->
 
 - A closure can omit the types

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Expressions.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Expressions.md
@@ -875,9 +875,7 @@ struct Point {
   ```
 -->
 
-<!--
-  Apple Books screenshot begins here.
--->
+<!-- Apple Books screenshot begins here. -->
 
 > Grammar of a self expression:
 >
@@ -960,9 +958,7 @@ it's understood to be asynchronous.
 There are several special forms
 that allow closures to be written more concisely:
 
-<!--
-  Apple Books screenshot ends here.
--->
+<!-- Apple Books screenshot ends here. -->
 
 - A closure can omit the types
   of its parameters, its return type, or both.

--- a/bin/find_screenshot_changes
+++ b/bin/find_screenshot_changes
@@ -1,0 +1,41 @@
+#! /usr/bin/env zsh
+
+setopt ERR_EXIT NO_UNSET PIPE_FAIL
+
+# This script helps identify changes that show up in screenshots.
+#
+# Set $COMMIT to the oldest commit this script should consider:
+# ideally, that's the commit when the current screenshots were taken.
+#
+# Lines in the output that start with whitespace are unchanged since $COMMIT.
+# Lines that start with a commit ID were changed in that commit, after $COMMIT.
+#
+# To check whether we need to re-shoot the screenshots,
+# run this script and check whether any lines start with commit IDs.
+# For example:
+#
+#     ./bin/find_screenshot_changes.zsh | grep -v '^ '
+#
+# To show those commits that made scheenshot changes:
+#
+#     ./bin/find_screenshot_changes.zsh |
+#     cut -d ' ' -f 1 |
+#     sort -u |
+#     xargs -L1 git --no-pager log -1
+
+BEGIN='<!-- Apple Books screenshot begins here -->'
+END='<!-- Apple Books screenshot ends here -->'
+
+# The commit when these comment markers were originally added.
+# COMMIT=64627a260ed600015dbad1a853d8b85f611b61d4
+
+# The commit when the content was converted from RST to markdown.
+COMMIT=96f0925407c6bd9eadd9d58d253bad3e1ef7a9f2
+
+cd Sources/TSPL/TSPL.docc
+git grep --files-with-matches $BEGIN | while IFS= read -r FILE
+do
+    git --no-pager blame -bs $COMMIT.. -L /$BEGIN/,/$END/ $FILE
+    echo
+    echo
+done


### PR DESCRIPTION
The iBooks Store was renamed several years ago — the comment markers should follow the current name.

When we're able to publish an ePUB version again (https://github.com/apple/swift-book/issues/2), we probably want to retake all of the screenshots.  We can update the value of `COMMIT` in the script at that time, to help us after that so we can find and retake only things that change.

Fixes rdar://101972172