### PR TITLE
Remove trailing whitespace

### DIFF
--- a/Sources/TSPL/TSPL.docc/GuidedTour/Compatibility.md
+++ b/Sources/TSPL/TSPL.docc/GuidedTour/Compatibility.md
@@ -9,7 +9,7 @@ that are written in either Swift 5.7, Swift 4.2, or Swift 4.
 
 <!--
   - test: `swift-version`
-  
+
   ```swifttest
   >> #if swift(>=5.7.1)
   >>     print("Too new")

--- a/Sources/TSPL/TSPL.docc/GuidedTour/GuidedTour.md
+++ b/Sources/TSPL/TSPL.docc/GuidedTour/GuidedTour.md
@@ -18,7 +18,7 @@ print("Hello, world!")
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> print("Hello, world!")
   <- Hello, world!
@@ -60,7 +60,7 @@ let myConstant = 42
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> var myVariable = 42
   -> myVariable = 50
@@ -90,7 +90,7 @@ let explicitDouble: Double = 70
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> let implicitInteger = 70
   -> let implicitDouble = 70.0
@@ -113,7 +113,7 @@ let widthLabel = label + String(width)
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> let label = "The width is "
   -> let width = 94
@@ -146,7 +146,7 @@ let fruitSummary = "I have \(apples + oranges) pieces of fruit."
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> let apples = 3
   -> let oranges = 5
@@ -178,7 +178,7 @@ And then I said "I have \(apples + oranges) pieces of fruit."
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> let quotation = """
      I said "I have \(apples) apples."
@@ -202,13 +202,13 @@ A comma is allowed after the last element.
   The list of fruits comes from the colors that the original iMac came in,
   following the initial launch of the iMac in Bondi Blue, ordered by SKU --
   which also lines up with the order they appeared in ads:
-  
+
        M7389LL/A (266 MHz Strawberry)
        M7392LL/A (266 MHz Lime)
        M7391LL/A (266 MHz Tangerine)
        M7390LL/A (266 MHz Grape)
        M7345LL/A (266 MHz Blueberry)
-  
+
        M7441LL/A (333 MHz Strawberry)
        M7444LL/A (333 MHz Lime)
        M7443LL/A (333 MHz Tangerine)
@@ -220,12 +220,12 @@ A comma is allowed after the last element.
   REFERENCE
   Occupations is a reference to Firefly,
   specifically to Mal's joke about Jayne's job on the ship.
-  
-  
-  
+
+
+
   Can't find the specific episode,
   but it shows up in several lists of Firefly "best of" quotes:
-  
+
   Mal: Jayne, you will keep a civil tongue in that mouth, or I will sew it shut.
        Is there an understanding between us?
   Jayne: You don't pay me to talk pretty. [...]
@@ -250,7 +250,7 @@ occupations["Jayne"] = "Public Relations"
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> var fruits = ["strawberries", "limes", "tangerines"]
   -> fruits[1] = "grapes"
@@ -272,7 +272,7 @@ print(fruits)
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> fruits.append("blueberries")
   -> print(fruits)
@@ -290,7 +290,7 @@ let emptyDictionary: [String: Float] = [:]
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> let emptyArray: [String] = []
   -> let emptyDictionary: [String: Float] = [:]
@@ -314,7 +314,7 @@ occupations = [:]
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> fruits = []
   -> occupations = [:]
@@ -345,7 +345,7 @@ print(teamScore)
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> let individualScores = [75, 43, 103, 87, 12]
   -> var teamScore = 0
@@ -412,7 +412,7 @@ if let name = optionalName {
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> var optionalString: String? = "Hello"
   -> print(optionalString == nil)
@@ -453,7 +453,7 @@ let informalGreeting = "Hi \(nickname ?? fullName)"
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> let nickname: String? = nil
   -> let fullName: String = "John Appleseed"
@@ -474,7 +474,7 @@ if let nickname {
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> if let nickname {
          print("Hey, \(nickname)")
@@ -512,7 +512,7 @@ default:
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> let vegetable = "red pepper"
   -> switch vegetable {
@@ -582,7 +582,7 @@ print(largest)
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> let interestingNumbers = [
          "Prime": [2, 3, 5, 7, 11, 13],
@@ -634,7 +634,7 @@ print(m)
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> var n = 2
   -> while n < 100 {
@@ -666,7 +666,7 @@ print(total)
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> var total = 0
   -> for i in 0..<4 {
@@ -705,7 +705,7 @@ greet(person: "Bob", day: "Tuesday")
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> func greet(person: String, day: String) -> String {
          return "Hello \(person), today is \(day)."
@@ -735,7 +735,7 @@ greet("John", on: "Wednesday")
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> func greet(_ person: String, on day: String) -> String {
          return "Hello \(person), today is \(day)."
@@ -786,13 +786,13 @@ print(statistics.2)
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> func calculateStatistics(scores: [Int]) -> (min: Int, max: Int, sum: Int) {
          var min = scores[0]
          var max = scores[0]
          var sum = 0
-  
+
          for score in scores {
              if score > max {
                  max = score
@@ -801,7 +801,7 @@ print(statistics.2)
              }
              sum += score
          }
-  
+
          return (min, max, sum)
      }
   -> let statistics = calculateStatistics(scores: [5, 3, 100, 3, 9])
@@ -835,7 +835,7 @@ returnFifteen()
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> func returnFifteen() -> Int {
          var y = 10
@@ -868,7 +868,7 @@ increment(7)
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> func makeIncrementer() -> ((Int) -> Int) {
          func addOne(number: Int) -> Int {
@@ -904,7 +904,7 @@ hasAnyMatches(list: numbers, condition: lessThanTen)
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> func hasAnyMatches(list: [Int], condition: (Int) -> Bool) -> Bool {
          for item in list {
@@ -944,7 +944,7 @@ numbers.map({ (number: Int) -> Int in
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   >> let numbersMap =
   -> numbers.map({ (number: Int) -> Int in
@@ -974,7 +974,7 @@ print(mappedNumbers)
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> let mappedNumbers = numbers.map({ number in 3 * number })
   -> print(mappedNumbers)
@@ -997,7 +997,7 @@ print(sortedNumbers)
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> let sortedNumbers = numbers.sorted { $0 > $1 }
   -> print(sortedNumbers)
@@ -1046,7 +1046,7 @@ class Shape {
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> class Shape {
          var numberOfSides = 0
@@ -1075,7 +1075,7 @@ var shapeDescription = shape.simpleDescription()
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> var shape = Shape()
   -> shape.numberOfSides = 7
@@ -1106,7 +1106,7 @@ class NamedShape {
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> class NamedShape {
          var numberOfSides: Int = 0
@@ -1177,7 +1177,7 @@ test.simpleDescription()
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> class Square: NamedShape {
          var sideLength: Double
@@ -1251,7 +1251,7 @@ print(triangle.sideLength)
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> class EquilateralTriangle: NamedShape {
          var sideLength: Double = 0.0
@@ -1341,7 +1341,7 @@ print(triangleAndSquare.triangle.sideLength)
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> class TriangleAndSquare {
          var triangle: EquilateralTriangle {
@@ -1394,7 +1394,7 @@ let sideLength = optionalSquare?.sideLength
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> let optionalSquare: Square? = Square(sideLength: 2.5, name: "optional square")
   -> let sideLength = optionalSquare?.sideLength
@@ -1444,7 +1444,7 @@ let aceRawValue = ace.rawValue
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> enum Rank: Int {
          case ace = 1
@@ -1498,7 +1498,7 @@ if let convertedRank = Rank(rawValue: 3) {
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> if let convertedRank = Rank(rawValue: 3) {
          let threeDescription = convertedRank.simpleDescription()
@@ -1537,7 +1537,7 @@ let heartsDescription = hearts.simpleDescription()
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> enum Suit {
          case spades, hearts, diamonds, clubs
@@ -1602,21 +1602,21 @@ or it responds with a description of what went wrong.
   REFERENCE
   The server response is a simple way to essentially re-implement Optional
   while sidestepping the fact that I'm doing so.
-  
+
   "Out of cheese" is a reference to a Terry Pratchet book,
   which features a computer named Hex.
   Hex's other error messages include:
-  
+
        - Out of Cheese Error. Redo From Start.
        - Mr. Jelly! Mr. Jelly! Error at Address Number 6, Treacle Mine Road.
        - Melon melon melon
        - +++ Wahhhhhhh! Mine! +++
        - +++ Divide By Cucumber Error. Please Reinstall Universe And Reboot +++
        - +++Whoops! Here comes the cheese! +++
-  
+
   These messages themselves are references to BASIC interpreters
   (REDO FROM START) and old Hayes-compatible modems (+++).
-  
+
   The "out of cheese error" may be a reference to a military computer
   although I can't find the source of this story anymore.
   As the story goes, during the course of a rather wild party,
@@ -1652,7 +1652,7 @@ case let .failure(message):
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> enum ServerResponse {
          case result(String, String)
@@ -1700,7 +1700,7 @@ let threeOfSpadesDescription = threeOfSpades.simpleDescription()
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> struct Card {
          var rank: Rank
@@ -1735,7 +1735,7 @@ func fetchUserID(from server: String) async -> Int {
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> func fetchUserID(from server: String) async -> Int {
          if server == "primary" {
@@ -1760,7 +1760,7 @@ func fetchUsername(from server: String) async -> String {
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> func fetchUsername(from server: String) async -> String {
          let userID = await fetchUserID(from: server)
@@ -1787,7 +1787,7 @@ func connectUser(to server: String) async {
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> func connectUser(to server: String) async {
          async let userID = fetchUserID(from: server)
@@ -1810,7 +1810,7 @@ Task {
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> Task {
          await connectUser(to: "primary")
@@ -1833,7 +1833,7 @@ protocol ExampleProtocol {
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> protocol ExampleProtocol {
           var simpleDescription: String { get }
@@ -1877,7 +1877,7 @@ let bDescription = b.simpleDescription
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> class SimpleClass: ExampleProtocol {
           var simpleDescription: String = "A very simple class."
@@ -1939,7 +1939,7 @@ print(7.simpleDescription)
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> extension Int: ExampleProtocol {
          var simpleDescription: String {
@@ -1973,7 +1973,7 @@ print(protocolValue.simpleDescription)
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> let protocolValue: ExampleProtocol = a
   -> print(protocolValue.simpleDescription)
@@ -1999,7 +1999,7 @@ You represent errors using any type that adopts the `Error` protocol.
   fire" error message, used when the kernel can't identify the specific error.
   The names of printers used in the examples in this section are names of
   people who were important in the development of printing.
-  
+
   Bi Sheng is credited with inventing the first movable type out of porcelain
   in China in the 1040s.  It was a mixed success, in large part because of the
   vast number of characters needed to write Chinese, and failed to replace
@@ -2022,7 +2022,7 @@ enum PrinterError: Error {
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> enum PrinterError: Error {
          case outOfPaper
@@ -2049,7 +2049,7 @@ func send(job: Int, toPrinter printerName: String) throws -> String {
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> func send(job: Int, toPrinter printerName: String) throws -> String {
          if printerName == "Never Has Toner" {
@@ -2080,7 +2080,7 @@ do {
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> do {
          let printerResponse = try send(job: 1040, toPrinter: "Bi Sheng")
@@ -2101,7 +2101,7 @@ do {
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   >> do {
          let printerResponse = try send(job: 500, toPrinter: "Never Has Toner")
@@ -2139,7 +2139,7 @@ do {
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> do {
          let printerResponse = try send(job: 1440, toPrinter: "Gutenberg")
@@ -2174,7 +2174,7 @@ let printerFailure = try? send(job: 1885, toPrinter: "Never Has Toner")
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> let printerSuccess = try? send(job: 1884, toPrinter: "Mergenthaler")
   >> print(printerSuccess as Any)
@@ -2212,7 +2212,7 @@ print(fridgeIsOpen)
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> var fridgeIsOpen = false
   -> let fridgeContent = ["milk", "eggs", "leftovers"]
@@ -2260,7 +2260,7 @@ makeArray(repeating: "knock", numberOfTimes: 4)
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> func makeArray<Item>(repeating item: Item, numberOfTimes: Int) -> [Item] {
          var result: [Item] = []
@@ -2291,7 +2291,7 @@ possibleInteger = .some(100)
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   // Reimplement the Swift standard library's optional type
   -> enum OptionalValue<Wrapped> {
@@ -2328,7 +2328,7 @@ anyCommonElements([1, 2, 3], [3])
 
 <!--
   - test: `guided-tour`
-  
+
   ```swifttest
   -> func anyCommonElements<T: Sequence, U: Sequence>(_ lhs: T, _ rhs: U) -> Bool
          where T.Element: Equatable, T.Element == U.Element

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/AccessControl.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/AccessControl.md
@@ -166,7 +166,7 @@ private func somePrivateFunction() {}
 
 <!--
   - test: `accessControlSyntax`
-  
+
   ```swifttest
   -> public class SomePublicClass {}
   -> internal class SomeInternalClass {}
@@ -193,7 +193,7 @@ let someInternalConstant = 0            // implicitly internal
 
 <!--
   - test: `accessControlDefaulted`
-  
+
   ```swifttest
   -> class SomeInternalClass {}              // implicitly internal
   -> let someInternalConstant = 0            // implicitly internal
@@ -252,7 +252,7 @@ private class SomePrivateClass {                // explicitly private class
 
 <!--
   - test: `accessControl, accessControlWrong`
-  
+
   ```swifttest
   -> public class SomePublicClass {                  // explicitly public class
         public var somePublicProperty = 0            // explicitly public class member
@@ -288,7 +288,7 @@ the access level for that compound tuple type will be private.
 
 <!--
   - test: `tupleTypes_Module1, tupleTypes_Module1_PublicAndInternal, tupleTypes_Module1_Private`
-  
+
   ```swifttest
   -> public struct PublicStruct {}
   -> internal struct InternalStruct {}
@@ -307,7 +307,7 @@ the access level for that compound tuple type will be private.
 
 <!--
   - test: `tupleTypes_Module1_PublicAndInternal`
-  
+
   ```swifttest
   // tuples with (at least) internal members can be accessed within their own module
   -> let publicTuple = returnPublicTuple()
@@ -317,7 +317,7 @@ the access level for that compound tuple type will be private.
 
 <!--
   - test: `tupleTypes_Module1_Private`
-  
+
   ```swifttest
   // a tuple with one or more private members can't be accessed from outside of its source file
   -> let privateTuple = returnFilePrivateTuple()
@@ -329,7 +329,7 @@ the access level for that compound tuple type will be private.
 
 <!--
   - test: `tupleTypes_Module2_Public`
-  
+
   ```swifttest
   // a public tuple with all-public members can be used in another module
   -> import tupleTypes_Module1
@@ -339,7 +339,7 @@ the access level for that compound tuple type will be private.
 
 <!--
   - test: `tupleTypes_Module2_InternalAndPrivate`
-  
+
   ```swifttest
   // tuples with internal or private members can't be used outside of their own module
   -> import tupleTypes_Module1
@@ -381,7 +381,7 @@ func someFunction() -> (SomeInternalClass, SomePrivateClass) {
 
 <!--
   - test: `accessControlWrong`
-  
+
   ```swifttest
   -> func someFunction() -> (SomeInternalClass, SomePrivateClass) {
         // function implementation goes here
@@ -412,7 +412,7 @@ private func someFunction() -> (SomeInternalClass, SomePrivateClass) {
 
 <!--
   - test: `accessControl`
-  
+
   ```swifttest
   -> private func someFunction() -> (SomeInternalClass, SomePrivateClass) {
         // function implementation goes here
@@ -449,7 +449,7 @@ public enum CompassPoint {
 
 <!--
   - test: `enumerationCases`
-  
+
   ```swifttest
   -> public enum CompassPoint {
         case north
@@ -462,7 +462,7 @@ public enum CompassPoint {
 
 <!--
   - test: `enumerationCases_Module1`
-  
+
   ```swifttest
   -> public enum CompassPoint {
         case north
@@ -475,7 +475,7 @@ public enum CompassPoint {
 
 <!--
   - test: `enumerationCases_Module2`
-  
+
   ```swifttest
   -> import enumerationCases_Module1
   -> let north = CompassPoint.north
@@ -501,7 +501,7 @@ you must explicitly declare the nested type as public.
 
 <!--
   - test: `nestedTypes_Module1, nestedTypes_Module1_PublicAndInternal, nestedTypes_Module1_Private`
-  
+
   ```swifttest
   -> public struct PublicStruct {
         public enum PublicEnumInsidePublicStruct { case a, b }
@@ -527,7 +527,7 @@ you must explicitly declare the nested type as public.
 
 <!--
   - test: `nestedTypes_Module1_PublicAndInternal`
-  
+
   ```swifttest
   // these are all expected to succeed within the same module
   -> let publicNestedInsidePublic = PublicStruct.PublicEnumInsidePublicStruct.a
@@ -541,7 +541,7 @@ you must explicitly declare the nested type as public.
 
 <!--
   - test: `nestedTypes_Module1_Private`
-  
+
   ```swifttest
   // these are all expected to fail, because they're private to the other file
   -> let privateNestedInsidePublic = PublicStruct.PrivateEnumInsidePublicStruct.a
@@ -574,7 +574,7 @@ you must explicitly declare the nested type as public.
 
 <!--
   - test: `nestedTypes_Module2_Public`
-  
+
   ```swifttest
   // this is the only expected to succeed within the second module
   -> import nestedTypes_Module1
@@ -584,7 +584,7 @@ you must explicitly declare the nested type as public.
 
 <!--
   - test: `nestedTypes_Module2_InternalAndPrivate`
-  
+
   ```swifttest
   // these are all expected to fail, because they're private or internal to the other module
   -> import nestedTypes_Module1
@@ -672,7 +672,7 @@ internal class B: A {
 
 <!--
   - test: `subclassingNoCall`
-  
+
   ```swifttest
   -> public class A {
         fileprivate func someMethod() {}
@@ -705,7 +705,7 @@ internal class B: A {
 
 <!--
   - test: `subclassingWithCall`
-  
+
   ```swifttest
   -> public class A {
         fileprivate func someMethod() {}
@@ -738,7 +738,7 @@ private var privateInstance = SomePrivateClass()
 
 <!--
   - test: `accessControl`
-  
+
   ```swifttest
   -> private var privateInstance = SomePrivateClass()
   ```
@@ -746,7 +746,7 @@ private var privateInstance = SomePrivateClass()
 
 <!--
   - test: `useOfPrivateTypeRequiresPrivateModifier`
-  
+
   ```swifttest
   -> class Scope {  // Need to be in a scope to meaningfully use private (vs fileprivate)
   -> private class SomePrivateClass {}
@@ -813,7 +813,7 @@ struct TrackedString {
 
 <!--
   - test: `reducedSetterScope, reducedSetterScope_error`
-  
+
   ```swifttest
   -> struct TrackedString {
         private(set) var numberOfEdits = 0
@@ -849,7 +849,7 @@ when it's used outside the structure's definition.
 
 <!--
   - test: `reducedSetterScope_error`
-  
+
   ```swifttest
   -> extension TrackedString {
          mutating func f() { numberOfEdits += 1 }
@@ -882,7 +882,7 @@ print("The number of edits is \(stringToEdit.numberOfEdits)")
 
 <!--
   - test: `reducedSetterScope`
-  
+
   ```swifttest
   -> var stringToEdit = TrackedString()
   -> stringToEdit.value = "This string will be tracked."
@@ -924,7 +924,7 @@ public struct TrackedString {
 
 <!--
   - test: `reducedSetterScopePublic`
-  
+
   ```swifttest
   -> public struct TrackedString {
         public private(set) var numberOfEdits = 0
@@ -940,7 +940,7 @@ public struct TrackedString {
 
 <!--
   - test: `reducedSetterScopePublic_Module1_Allowed, reducedSetterScopePublic_Module1_NotAllowed`
-  
+
   ```swifttest
   -> public struct TrackedString {
         public private(set) var numberOfEdits = 0
@@ -956,7 +956,7 @@ public struct TrackedString {
 
 <!--
   - test: `reducedSetterScopePublic_Module1_Allowed`
-  
+
   ```swifttest
   // check that we can retrieve its value with the public getter from another file in the same module
   -> var stringToEdit_Module1B = TrackedString()
@@ -966,7 +966,7 @@ public struct TrackedString {
 
 <!--
   - test: `reducedSetterScopePublic_Module1_NotAllowed`
-  
+
   ```swifttest
   // check that we can't set its value from another file in the same module
   -> var stringToEdit_Module1C = TrackedString()
@@ -979,7 +979,7 @@ public struct TrackedString {
 
 <!--
   - test: `reducedSetterScopePublic_Module2`
-  
+
   ```swifttest
   // check that we can retrieve its value with the public getter from a different module
   -> import reducedSetterScopePublic_Module1_Allowed
@@ -1051,7 +1051,7 @@ on any type that adopts the protocol.
 
 <!--
   - test: `protocolRequirementsCannotBeDifferentThanTheProtocol`
-  
+
   ```swifttest
   -> public protocol PublicProtocol {
         public var publicProperty: Int { get }
@@ -1099,7 +1099,7 @@ on any type that adopts the protocol.
 
 <!--
   - test: `protocols_Module1, protocols_Module1_PublicAndInternal, protocols_Module1_Private`
-  
+
   ```swifttest
   -> public protocol PublicProtocol {
         var publicProperty: Int { get }
@@ -1122,7 +1122,7 @@ on any type that adopts the protocol.
 
 <!--
   - test: `protocols_Module1_PublicAndInternal`
-  
+
   ```swifttest
   // these should all be allowed without problem
   -> public class PublicClassConformingToPublicProtocol: PublicProtocol {
@@ -1155,7 +1155,7 @@ on any type that adopts the protocol.
 
 <!--
   - test: `protocols_Module1_Private`
-  
+
   ```swifttest
   // these will fail, because FilePrivateProtocol isn't visible outside of its file
   -> public class PublicClassConformingToFilePrivateProtocol: FilePrivateProtocol {
@@ -1179,7 +1179,7 @@ on any type that adopts the protocol.
 
 <!--
   - test: `protocols_Module2_Public`
-  
+
   ```swifttest
   // these should all be allowed without problem
   -> import protocols_Module1
@@ -1200,7 +1200,7 @@ on any type that adopts the protocol.
 
 <!--
   - test: `protocols_Module2_InternalAndPrivate`
-  
+
   ```swifttest
   // these will all fail, because InternalProtocol, FilePrivateProtocol, and PrivateProtocol
   // aren't visible to other modules
@@ -1284,7 +1284,7 @@ the default access level for each protocol requirement implementation within the
 
 <!--
   - test: `extensions_Module1, extensions_Module1_PublicAndInternal, extensions_Module1_Private`
-  
+
   ```swifttest
   -> public struct PublicStruct {
         public init() {}
@@ -1305,7 +1305,7 @@ the default access level for each protocol requirement implementation within the
 
 <!--
   - test: `extensions_Module1_PublicAndInternal`
-  
+
   ```swifttest
   -> var publicStructInDifferentFile = PublicStruct()
   -> let differentFileA = publicStructInDifferentFile.implicitlyInternalMethodFromStruct()
@@ -1315,7 +1315,7 @@ the default access level for each protocol requirement implementation within the
 
 <!--
   - test: `extensions_Module1_Private`
-  
+
   ```swifttest
   -> var publicStructInDifferentFile = PublicStruct()
   -> let differentFileC = publicStructInDifferentFile.filePrivateMethod()
@@ -1330,7 +1330,7 @@ the default access level for each protocol requirement implementation within the
 
 <!--
   - test: `extensions_Module2`
-  
+
   ```swifttest
   -> import extensions_Module1
   -> var publicStructInDifferentModule = PublicStruct()
@@ -1386,7 +1386,7 @@ protocol SomeProtocol {
 
 <!--
   - test: `extensions_privatemembers`
-  
+
   ```swifttest
   -> protocol SomeProtocol {
          func doSomething()
@@ -1410,7 +1410,7 @@ extension SomeStruct: SomeProtocol {
 
 <!--
   - test: `extensions_privatemembers`
-  
+
   ```swifttest
   -> struct SomeStruct {
          private var privateVariable = 12
@@ -1444,7 +1444,7 @@ but a public type alias can't alias an internal, file-private, or private type.
 
 <!--
   - test: `typeAliases`
-  
+
   ```swifttest
   -> public struct PublicStruct {}
   -> internal struct InternalStruct {}

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/AdvancedOperators.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/AdvancedOperators.md
@@ -56,7 +56,7 @@ let invertedBits = ~initialBits  // equals 11110000
 
 <!--
   - test: `bitwiseOperators`
-  
+
   ```swifttest
   -> let initialBits: UInt8 = 0b00001111
   >> assert(initialBits == 15)
@@ -105,7 +105,7 @@ let middleFourBits = firstSixBits & lastSixBits  // equals 00111100
 
 <!--
   - test: `bitwiseOperators`
-  
+
   ```swifttest
   -> let firstSixBits: UInt8 = 0b11111100
   -> let lastSixBits: UInt8  = 0b00111111
@@ -139,7 +139,7 @@ let combinedbits = someBits | moreBits  // equals 11111110
 
 <!--
   - test: `bitwiseOperators`
-  
+
   ```swifttest
   -> let someBits: UInt8 = 0b10110010
   -> let moreBits: UInt8 = 0b01011110
@@ -173,7 +173,7 @@ let outputBits = firstBits ^ otherBits  // equals 00010001
 
 <!--
   - test: `bitwiseOperators`
-  
+
   ```swifttest
   -> let firstBits: UInt8 = 0b00010100
   -> let otherBits: UInt8 = 0b00000101
@@ -232,7 +232,7 @@ shiftBits >> 2             // 00000001
 
 <!--
   - test: `bitwiseShiftOperators`
-  
+
   ```swifttest
   -> let shiftBits: UInt8 = 4   // 00000100 in binary
   >> let r0 =
@@ -269,7 +269,7 @@ let blueComponent = pink & 0x0000FF           // blueComponent is 0x99, or 153
 
 <!--
   - test: `bitwiseShiftOperators`
-  
+
   ```swifttest
   -> let pink: UInt32 = 0xCC6699
   -> let redComponent = (pink & 0xFF0000) >> 16    // redComponent is 0xCC, or 204
@@ -401,7 +401,7 @@ potentialOverflow += 1
 
 <!--
   - test: `overflowOperatorsWillFailToOverflow`
-  
+
   ```swifttest
   -> var potentialOverflow = Int16.max
   /> potentialOverflow equals \(potentialOverflow), which is the maximum value an Int16 can hold
@@ -443,7 +443,7 @@ unsignedOverflow = unsignedOverflow &+ 1
 
 <!--
   - test: `overflowOperatorsWillOverflowInPositiveDirection`
-  
+
   ```swifttest
   -> var unsignedOverflow = UInt8.max
   /> unsignedOverflow equals \(unsignedOverflow), which is the maximum value a UInt8 can hold
@@ -478,7 +478,7 @@ unsignedOverflow = unsignedOverflow &- 1
 
 <!--
   - test: `overflowOperatorsWillOverflowInNegativeDirection`
-  
+
   ```swifttest
   -> var unsignedOverflow = UInt8.min
   /> unsignedOverflow equals \(unsignedOverflow), which is the minimum value a UInt8 can hold
@@ -511,7 +511,7 @@ signedOverflow = signedOverflow &- 1
 
 <!--
   - test: `overflowOperatorsWillOverflowSigned`
-  
+
   ```swifttest
   -> var signedOverflow = Int8.min
   /> signedOverflow equals \(signedOverflow), which is the minimum value an Int8 can hold
@@ -561,7 +561,7 @@ operator precedence explains why the following expression equals `17`.
 
 <!--
   - test: `evaluationOrder`
-  
+
   ```swifttest
   >> let r0 =
   -> 2 + 3 % 4 * 5
@@ -603,7 +603,7 @@ starting from their left:
 
 <!--
   - test: `evaluationOrder`
-  
+
   ```swifttest
   >> let r1 =
   -> 2 + ((3 % 4) * 5)
@@ -624,7 +624,7 @@ starting from their left:
 
 <!--
   - test: `evaluationOrder`
-  
+
   ```swifttest
   >> let r2 =
   -> 2 + (3 * 5)
@@ -645,7 +645,7 @@ starting from their left:
 
 <!--
   - test: `evaluationOrder`
-  
+
   ```swifttest
   >> let r3 =
   -> 2 + 15
@@ -700,7 +700,7 @@ extension Vector2D {
 
 <!--
   - test: `customOperators`
-  
+
   ```swifttest
   -> struct Vector2D {
         var x = 0.0, y = 0.0
@@ -743,7 +743,7 @@ let combinedVector = vector + anotherVector
 
 <!--
   - test: `customOperators`
-  
+
   ```swifttest
   -> let vector = Vector2D(x: 3.0, y: 1.0)
   -> let anotherVector = Vector2D(x: 2.0, y: 4.0)
@@ -781,7 +781,7 @@ extension Vector2D {
 
 <!--
   - test: `customOperators`
-  
+
   ```swifttest
   -> extension Vector2D {
          static prefix func - (vector: Vector2D) -> Vector2D {
@@ -811,7 +811,7 @@ let alsoPositive = -negative
 
 <!--
   - test: `customOperators`
-  
+
   ```swifttest
   -> let positive = Vector2D(x: 3.0, y: 4.0)
   -> let negative = -positive
@@ -844,7 +844,7 @@ extension Vector2D {
 
 <!--
   - test: `customOperators`
-  
+
   ```swifttest
   -> extension Vector2D {
          static func += (left: inout Vector2D, right: Vector2D) {
@@ -869,7 +869,7 @@ original += vectorToAdd
 
 <!--
   - test: `customOperators`
-  
+
   ```swifttest
   -> var original = Vector2D(x: 1.0, y: 2.0)
   -> let vectorToAdd = Vector2D(x: 3.0, y: 4.0)
@@ -887,7 +887,7 @@ original += vectorToAdd
 
 <!--
   - test: `cant-overload-assignment`
-  
+
   ```swifttest
   >> struct Vector2D {
   >>    var x = 0.0, y = 0.0
@@ -931,7 +931,7 @@ extension Vector2D: Equatable {
 
 <!--
   - test: `customOperators`
-  
+
   ```swifttest
   -> extension Vector2D: Equatable {
          static func == (left: Vector2D, right: Vector2D) -> Bool {
@@ -961,7 +961,7 @@ if twoThree == anotherTwoThree {
 
 <!--
   - test: `customOperators`
-  
+
   ```swifttest
   -> let twoThree = Vector2D(x: 2.0, y: 3.0)
   -> let anotherTwoThree = Vector2D(x: 2.0, y: 3.0)
@@ -992,7 +992,7 @@ prefix operator +++
 
 <!--
   - test: `customOperators`
-  
+
   ```swifttest
   -> prefix operator +++
   ```
@@ -1024,7 +1024,7 @@ let afterDoubling = +++toBeDoubled
 
 <!--
   - test: `customOperators`
-  
+
   ```swifttest
   -> extension Vector2D {
         static prefix func +++ (vector: inout Vector2D) -> Vector2D {
@@ -1073,7 +1073,7 @@ let plusMinusVector = firstVector +- secondVector
 
 <!--
   - test: `customOperators`
-  
+
   ```swifttest
   -> infix operator +-: AdditionPrecedence
   -> extension Vector2D {
@@ -1107,7 +1107,7 @@ see <doc:Declarations#Operator-Declaration>.
 
 <!--
   - test: `postfixOperatorsAreAppliedBeforePrefixOperators`
-  
+
   ```swifttest
   -> prefix operator +++
   -> postfix operator ---
@@ -1173,7 +1173,7 @@ struct AllCaps: Drawable {
 
 <!--
   - test: `result-builder`
-  
+
   ```swifttest
   -> protocol Drawable {
          func draw() -> String
@@ -1233,7 +1233,7 @@ print(manualDrawing.draw())
 
 <!--
   - test: `result-builder`
-  
+
   ```swifttest
   -> let name: String? = "Ravi Patel"
   -> let manualDrawing = Line(elements: [
@@ -1280,7 +1280,7 @@ struct DrawingBuilder {
 
 <!--
   - test: `result-builder`
-  
+
   ```swifttest
   -> @resultBuilder
   -> struct DrawingBuilder {
@@ -1345,7 +1345,7 @@ print(personalGreeting.draw())
 
 <!--
   - test: `result-builder`
-  
+
   ```swifttest
   -> func draw(@DrawingBuilder content: () -> Drawable) -> Drawable {
          return content()
@@ -1410,7 +1410,7 @@ let capsDrawing = caps {
 
 <!--
   - test: `result-builder`
-  
+
   ```swifttest
   -> let capsDrawing = caps {
          let partialDrawing: Drawable
@@ -1455,7 +1455,7 @@ let manyStars = draw {
 
 <!--
   - test: `result-builder`
-  
+
   ```swifttest
   -> extension DrawingBuilder {
          static func buildArray(_ components: [Drawable]) -> Drawable {
@@ -1483,10 +1483,10 @@ see <doc:Attributes#resultBuilder>.
 
 <!--
   The following needs more work...
-  
+
    Protocol Operator Requirements
    ------------------------------
-  
+
    You can include operators in the requirements of a protocol.
    A type conforms to the protocol
    only if there's an implementation of the operator for that type.
@@ -1494,19 +1494,19 @@ see <doc:Attributes#resultBuilder>.
    just like you do in other protocol requirements.
    For example, the standard library defines the ``Equatable`` protocol
    which requires the ``==`` operator:
-  
+
    .. testcode:: protocolOperator
-  
+
       -> protocol Equatable {
              static func == (lhs: Self, rhs: Self) -> Bool
          }
-  
+
    To make a type conform to the protocol,
    you need to implement the ``==`` operator for that type.
    For example:
-  
+
    .. testcode:: protocolOperator
-  
+
   -> struct Vector3D {
         var x = 0.0, y = 0.0, z = 0.0
      }
@@ -1523,7 +1523,7 @@ see <doc:Attributes#resultBuilder>.
 <!--
   FIXME: This doesn't work
   <rdar://problem/27536066> SE-0091 -- can't have protocol conformance & operator implementation in different types
-  
+
    For operators that take values of two different types,
    the operator's implementation doesn't have to be
    a member of the type that conforms to the protocol ---
@@ -1535,9 +1535,9 @@ see <doc:Attributes#resultBuilder>.
    because there's an implementation of the operator
    that takes a ``Vector2D`` as its second argument,
    even though that implementation is a member of ``Double``.
-  
+
    .. testcode:: customOperators
-  
+
   -> infix operator *** {}
   -> protocol AnotherProtocol {
          // static func * (scale: Double, vector: Self) -> Self

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/AutomaticReferenceCounting.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/AutomaticReferenceCounting.md
@@ -74,7 +74,7 @@ class Person {
 
 <!--
   - test: `howARCWorks`
-  
+
   ```swifttest
   -> class Person {
         let name: String
@@ -109,7 +109,7 @@ var reference3: Person?
 
 <!--
   - test: `howARCWorks`
-  
+
   ```swifttest
   -> var reference1: Person?
   -> var reference2: Person?
@@ -127,7 +127,7 @@ reference1 = Person(name: "John Appleseed")
 
 <!--
   - test: `howARCWorks`
-  
+
   ```swifttest
   -> reference1 = Person(name: "John Appleseed")
   <- John Appleseed is being initialized
@@ -153,7 +153,7 @@ reference3 = reference1
 
 <!--
   - test: `howARCWorks`
-  
+
   ```swifttest
   -> reference2 = reference1
   -> reference3 = reference1
@@ -174,7 +174,7 @@ reference2 = nil
 
 <!--
   - test: `howARCWorks`
-  
+
   ```swifttest
   -> reference1 = nil
   -> reference2 = nil
@@ -192,7 +192,7 @@ reference3 = nil
 
 <!--
   - test: `howARCWorks`
-  
+
   ```swifttest
   -> reference3 = nil
   <- John Appleseed is being deinitialized
@@ -241,7 +241,7 @@ class Apartment {
 
 <!--
   - test: `referenceCycles`
-  
+
   ```swifttest
   -> class Person {
         let name: String
@@ -284,7 +284,7 @@ var unit4A: Apartment?
 
 <!--
   - test: `referenceCycles`
-  
+
   ```swifttest
   -> var john: Person?
   -> var unit4A: Apartment?
@@ -301,7 +301,7 @@ unit4A = Apartment(unit: "4A")
 
 <!--
   - test: `referenceCycles`
-  
+
   ```swifttest
   -> john = Person(name: "John Appleseed")
   -> unit4A = Apartment(unit: "4A")
@@ -327,7 +327,7 @@ unit4A!.tenant = john
 
 <!--
   - test: `referenceCycles`
-  
+
   ```swifttest
   -> john!.apartment = unit4A
   -> unit4A!.tenant = john
@@ -354,7 +354,7 @@ unit4A = nil
 
 <!--
   - test: `referenceCycles`
-  
+
   ```swifttest
   -> john = nil
   -> unit4A = nil
@@ -427,7 +427,7 @@ a reference to an invalid instance that no longer exists.
 
 <!--
   - test: `weak-reference-doesnt-trigger-didset`
-  
+
   ```swifttest
   -> class C {
          weak var w: C? { didSet { print("did set") } }
@@ -467,7 +467,7 @@ class Apartment {
 
 <!--
   - test: `weakReferences`
-  
+
   ```swifttest
   -> class Person {
         let name: String
@@ -501,7 +501,7 @@ unit4A!.tenant = john
 
 <!--
   - test: `weakReferences`
-  
+
   ```swifttest
   -> var john: Person?
   -> var unit4A: Apartment?
@@ -531,7 +531,7 @@ john = nil
 
 <!--
   - test: `weakReferences`
-  
+
   ```swifttest
   -> john = nil
   <- John Appleseed is being deinitialized
@@ -556,7 +556,7 @@ unit4A = nil
 
 <!--
   - test: `weakReferences`
-  
+
   ```swifttest
   -> unit4A = nil
   <- Apartment 4A is being deinitialized
@@ -661,7 +661,7 @@ class CreditCard {
 
 <!--
   - test: `unownedReferences`
-  
+
   ```swifttest
   -> class Customer {
         let name: String
@@ -699,7 +699,7 @@ var john: Customer?
 
 <!--
   - test: `unownedReferences`
-  
+
   ```swifttest
   -> var john: Customer?
   ```
@@ -716,7 +716,7 @@ john!.card = CreditCard(number: 1234_5678_9012_3456, customer: john!)
 
 <!--
   - test: `unownedReferences`
-  
+
   ```swifttest
   -> john = Customer(name: "John Appleseed")
   -> john!.card = CreditCard(number: 1234_5678_9012_3456, customer: john!)
@@ -750,7 +750,7 @@ john = nil
 
 <!--
   - test: `unownedReferences`
-  
+
   ```swifttest
   -> john = nil
   <- John Appleseed is being deinitialized
@@ -817,7 +817,7 @@ class Course {
 
 <!--
   - test: `unowned-optional-references`
-  
+
   ```swifttest
   -> class Department {
          var name: String
@@ -870,7 +870,7 @@ department.courses = [intro, intermediate, advanced]
 
 <!--
   - test: `unowned-optional-references`
-  
+
   ```swifttest
   -> let department = Department(name: "Horticulture")
   ---
@@ -915,7 +915,7 @@ that other courses might have.
 
 <!--
   - test: `unowned-can-be-optional`
-  
+
   ```swifttest
   >> class C { var x = 100 }
   >> class D {
@@ -998,7 +998,7 @@ class City {
 
 <!--
   - test: `implicitlyUnwrappedOptionals`
-  
+
   ```swifttest
   -> class Country {
         let name: String
@@ -1060,7 +1060,7 @@ print("\(country.name)'s capital city is called \(country.capitalCity.name)")
 
 <!--
   - test: `implicitlyUnwrappedOptionals`
-  
+
   ```swifttest
   -> var country = Country(name: "Canada", capitalName: "Ottawa")
   -> print("\(country.name)'s capital city is called \(country.capitalCity.name)")
@@ -1136,7 +1136,7 @@ class HTMLElement {
 
 <!--
   - test: `strongReferenceCyclesForClosures`
-  
+
   ```swifttest
   -> class HTMLElement {
   ---
@@ -1208,7 +1208,7 @@ print(heading.asHTML())
 
 <!--
   - test: `strongReferenceCyclesForClosures`
-  
+
   ```swifttest
   -> let heading = HTMLElement(name: "h1")
   -> let defaultText = "some default text"
@@ -1244,7 +1244,7 @@ print(paragraph!.asHTML())
 
 <!--
   - test: `strongReferenceCyclesForClosures`
-  
+
   ```swifttest
   -> var paragraph: HTMLElement? = HTMLElement(name: "p", text: "hello, world")
   -> print(paragraph!.asHTML())
@@ -1286,7 +1286,7 @@ paragraph = nil
 
 <!--
   - test: `strongReferenceCyclesForClosures`
-  
+
   ```swifttest
   -> paragraph = nil
   ```
@@ -1332,7 +1332,7 @@ lazy var someClosure = {
 
 <!--
   - test: `strongReferenceCyclesForClosures`
-  
+
   ```swifttest
   >> class SomeClass {
   >> var delegate: AnyObject?
@@ -1360,7 +1360,7 @@ lazy var someClosure = {
 
 <!--
   - test: `strongReferenceCyclesForClosures`
-  
+
   ```swifttest
   >> class AnotherClass {
   >> var delegate: AnyObject?
@@ -1427,7 +1427,7 @@ class HTMLElement {
 
 <!--
   - test: `unownedReferencesForClosures`
-  
+
   ```swifttest
   -> class HTMLElement {
   ---
@@ -1471,7 +1471,7 @@ print(paragraph!.asHTML())
 
 <!--
   - test: `unownedReferencesForClosures`
-  
+
   ```swifttest
   -> var paragraph: HTMLElement? = HTMLElement(name: "p", text: "hello, world")
   -> print(paragraph!.asHTML())
@@ -1496,7 +1496,7 @@ paragraph = nil
 
 <!--
   - test: `unownedReferencesForClosures`
-  
+
   ```swifttest
   -> paragraph = nil
   <- p is being deinitialized

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/BasicOperators.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/BasicOperators.md
@@ -62,7 +62,7 @@ a = b
 
 <!--
   - test: `assignmentOperator`
-  
+
   ```swifttest
   -> let b = 10
   -> var a = 5
@@ -82,7 +82,7 @@ let (x, y) = (1, 2)
 
 <!--
   - test: `assignmentOperator`
-  
+
   ```swifttest
   -> let (x, y) = (1, 2)
   /> x is equal to \(x), and y is equal to \(y)
@@ -92,7 +92,7 @@ let (x, y) = (1, 2)
 
 <!--
   - test: `tuple-unwrapping-with-var`
-  
+
   ```swifttest
   >> var (x, y) = (1, 2)
   ```
@@ -119,7 +119,7 @@ if x = y {
 
 <!--
   - test: `assignmentOperatorInvalid`
-  
+
   ```swifttest
   -> if x = y {
         // This isn't valid, because x = y doesn't return a value.
@@ -161,7 +161,7 @@ Swift supports the four standard *arithmetic operators* for all number types:
 
 <!--
   - test: `arithmeticOperators`
-  
+
   ```swifttest
   >> let r0 =
   -> 1 + 2       // equals 3
@@ -191,7 +191,7 @@ The addition operator is also supported for `String` concatenation:
 
 <!--
   - test: `arithmeticOperators`
-  
+
   ```swifttest
   >> let r4 =
   -> "hello, " + "world"  // equals "hello, world"
@@ -213,7 +213,7 @@ and returns the value that's left over
 
 <!--
   - test: `percentOperatorIsRemainderNotModulo`
-  
+
   ```swifttest
   -> for i in -5...0 {
         print(i % 4)
@@ -242,7 +242,7 @@ In Swift, this would be written as:
 
 <!--
   - test: `arithmeticOperators`
-  
+
   ```swifttest
   >> let r5 =
   -> 9 % 4    // equals 1
@@ -271,7 +271,7 @@ The same method is applied when calculating the remainder for a negative value o
 
 <!--
   - test: `arithmeticOperators`
-  
+
   ```swifttest
   >> let r6 =
   -> -9 % 4   // equals -1
@@ -301,7 +301,7 @@ let plusThree = -minusThree   // plusThree equals 3, or "minus minus three"
 
 <!--
   - test: `arithmeticOperators`
-  
+
   ```swifttest
   -> let three = 3
   -> let minusThree = -three       // minusThree equals -3
@@ -324,7 +324,7 @@ let alsoMinusSix = +minusSix  // alsoMinusSix equals -6
 
 <!--
   - test: `arithmeticOperators`
-  
+
   ```swifttest
   -> let minusSix = -6
   -> let alsoMinusSix = +minusSix  // alsoMinusSix equals -6
@@ -349,7 +349,7 @@ a += 2
 
 <!--
   - test: `compoundAssignment`
-  
+
   ```swifttest
   -> var a = 1
   -> a += 2
@@ -396,7 +396,7 @@ Each of the comparison operators returns a `Bool` value to indicate whether or n
 
 <!--
   - test: `comparisonOperators`
-  
+
   ```swifttest
   >> assert(
   -> 1 == 1   // true because 1 is equal to 1
@@ -434,7 +434,7 @@ if name == "world" {
 
 <!--
   - test: `comparisonOperators`
-  
+
   ```swifttest
   -> let name = "world"
   -> if name == "world" {
@@ -470,7 +470,7 @@ For example:
 
 <!--
   - test: `tuple-comparison-operators`
-  
+
   ```swifttest
   >> let a =
   -> (1, "zebra") < (2, "apple")   // true because 1 is less than 2; "zebra" and "apple" aren't compared
@@ -512,7 +512,7 @@ with the `<` operator because the `<` operator can't be applied to
 
 <!--
   - test: `tuple-comparison-operators-err`
-  
+
   ```swifttest
   >> _ =
   -> ("blue", -1) < ("purple", 1)        // OK, evaluates to true
@@ -532,7 +532,7 @@ with the `<` operator because the `<` operator can't be applied to
 
 <!--
   - test: `tuple-comparison-operators-ok`
-  
+
   ```swifttest
   >> let x = ("blue", -1) < ("purple", 1)        // OK, evaluates to true
   >> print(x)
@@ -572,7 +572,7 @@ if question {
 
 <!--
   - test: `ternaryConditionalOperatorOutline`
-  
+
   ```swifttest
   >> let question = true
   >> let answer1 = true
@@ -609,7 +609,7 @@ let rowHeight = contentHeight + (hasHeader ? 50 : 20)
 
 <!--
   - test: `ternaryConditionalOperatorPart1`
-  
+
   ```swifttest
   -> let contentHeight = 40
   -> let hasHeader = true
@@ -635,7 +635,7 @@ if hasHeader {
 
 <!--
   - test: `ternaryConditionalOperatorPart2`
-  
+
   ```swifttest
   -> let contentHeight = 40
   -> let hasHeader = true
@@ -676,7 +676,7 @@ a != nil ? a! : b
 
 <!--
   - test: `nilCoalescingOperatorOutline`
-  
+
   ```swifttest
   >> var a: Int?
   >> let b = 42
@@ -710,7 +710,7 @@ var colorNameToUse = userDefinedColorName ?? defaultColorName
 
 <!--
   - test: `nilCoalescingOperator`
-  
+
   ```swifttest
   -> let defaultColorName = "red"
   -> var userDefinedColorName: String?   // defaults to nil
@@ -743,7 +743,7 @@ colorNameToUse = userDefinedColorName ?? defaultColorName
 
 <!--
   - test: `nilCoalescingOperator`
-  
+
   ```swifttest
   -> userDefinedColorName = "green"
   -> colorNameToUse = userDefinedColorName ?? defaultColorName
@@ -766,7 +766,7 @@ The value of `a` must not be greater than `b`.
 
 <!--
   - test: `closedRangeStartCanBeLessThanEnd`
-  
+
   ```swifttest
   -> let range = 1...2
   >> print(type(of: range))
@@ -776,7 +776,7 @@ The value of `a` must not be greater than `b`.
 
 <!--
   - test: `closedRangeStartCanBeTheSameAsEnd`
-  
+
   ```swifttest
   -> let range = 1...1
   ```
@@ -784,7 +784,7 @@ The value of `a` must not be greater than `b`.
 
 <!--
   - test: `closedRangeStartCannotBeGreaterThanEnd`
-  
+
   ```swifttest
   -> let range = 1...0
   xx assertion
@@ -808,7 +808,7 @@ for index in 1...5 {
 
 <!--
   - test: `rangeOperators`
-  
+
   ```swifttest
   -> for index in 1...5 {
         print("\(index) times 5 is \(index * 5)")
@@ -837,7 +837,7 @@ then the resulting range will be empty.
 
 <!--
   - test: `halfOpenRangeStartCanBeLessThanEnd`
-  
+
   ```swifttest
   -> let range = 1..<2
   >> print(type(of: range))
@@ -847,7 +847,7 @@ then the resulting range will be empty.
 
 <!--
   - test: `halfOpenRangeStartCanBeTheSameAsEnd`
-  
+
   ```swifttest
   -> let range = 1..<1
   ```
@@ -855,7 +855,7 @@ then the resulting range will be empty.
 
 <!--
   - test: `halfOpenRangeStartCannotBeGreaterThanEnd`
-  
+
   ```swifttest
   -> let range = 1..<0
   xx assertion
@@ -880,7 +880,7 @@ for i in 0..<count {
 
 <!--
   - test: `rangeOperators`
-  
+
   ```swifttest
   -> let names = ["Anna", "Alex", "Brian", "Jack"]
   -> let count = names.count
@@ -932,7 +932,7 @@ for name in names[...2] {
 
 <!--
   - test: `rangeOperators`
-  
+
   ```swifttest
   -> for name in names[2...] {
          print(name)
@@ -966,7 +966,7 @@ for name in names[..<2] {
 
 <!--
   - test: `rangeOperators`
-  
+
   ```swifttest
   -> for name in names[..<2] {
          print(name)
@@ -996,7 +996,7 @@ range.contains(-1)  // true
 
 <!--
   - test: `rangeOperators`
-  
+
   ```swifttest
   -> let range = ...5
   >> print(type(of: range))
@@ -1042,7 +1042,7 @@ if !allowedEntry {
 
 <!--
   - test: `logicalOperators`
-  
+
   ```swifttest
   -> let allowedEntry = false
   -> if !allowedEntry {
@@ -1089,7 +1089,7 @@ if enteredDoorCode && passedRetinaScan {
 
 <!--
   - test: `logicalOperators`
-  
+
   ```swifttest
   -> let enteredDoorCode = true
   -> let passedRetinaScan = false
@@ -1136,7 +1136,7 @@ if hasDoorKey || knowsOverridePassword {
 
 <!--
   - test: `logicalOperators`
-  
+
   ```swifttest
   -> let hasDoorKey = false
   -> let knowsOverridePassword = true
@@ -1164,7 +1164,7 @@ if enteredDoorCode && passedRetinaScan || hasDoorKey || knowsOverridePassword {
 
 <!--
   - test: `logicalOperators`
-  
+
   ```swifttest
   -> if enteredDoorCode && passedRetinaScan || hasDoorKey || knowsOverridePassword {
         print("Welcome!")
@@ -1213,7 +1213,7 @@ if (enteredDoorCode && passedRetinaScan) || hasDoorKey || knowsOverridePassword 
 
 <!--
   - test: `logicalOperators`
-  
+
   ```swifttest
   -> if (enteredDoorCode && passedRetinaScan) || hasDoorKey || knowsOverridePassword {
         print("Welcome!")

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/ClassesAndStructures.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/ClassesAndStructures.md
@@ -79,7 +79,7 @@ class SomeClass {
 
 <!--
   - test: `ClassesAndStructures`
-  
+
   ```swifttest
   -> struct SomeStructure {
         // structure definition goes here
@@ -117,7 +117,7 @@ class VideoMode {
 
 <!--
   - test: `ClassesAndStructures`
-  
+
   ```swifttest
   -> struct Resolution {
         var width = 0
@@ -169,7 +169,7 @@ let someVideoMode = VideoMode()
 
 <!--
   - test: `ClassesAndStructures`
-  
+
   ```swifttest
   -> let someResolution = Resolution()
   -> let someVideoMode = VideoMode()
@@ -202,7 +202,7 @@ print("The width of someResolution is \(someResolution.width)")
 
 <!--
   - test: `ClassesAndStructures`
-  
+
   ```swifttest
   -> print("The width of someResolution is \(someResolution.width)")
   <- The width of someResolution is 0
@@ -223,7 +223,7 @@ print("The width of someVideoMode is \(someVideoMode.resolution.width)")
 
 <!--
   - test: `ClassesAndStructures`
-  
+
   ```swifttest
   -> print("The width of someVideoMode is \(someVideoMode.resolution.width)")
   <- The width of someVideoMode is 0
@@ -240,7 +240,7 @@ print("The width of someVideoMode is now \(someVideoMode.resolution.width)")
 
 <!--
   - test: `ClassesAndStructures`
-  
+
   ```swifttest
   -> someVideoMode.resolution.width = 1280
   -> print("The width of someVideoMode is now \(someVideoMode.resolution.width)")
@@ -261,7 +261,7 @@ let vga = Resolution(width: 640, height: 480)
 
 <!--
   - test: `ClassesAndStructures`
-  
+
   ```swifttest
   -> let vga = Resolution(width: 640, height: 480)
   ```
@@ -272,7 +272,7 @@ Initializers are described in more detail in <doc:Initialization>.
 
 <!--
   - test: `classesDontHaveADefaultMemberwiseInitializer`
-  
+
   ```swifttest
   -> class C { var x = 0, y = 0 }
   -> let c = C(x: 1, y: 1)
@@ -326,7 +326,7 @@ var cinema = hd
 
 <!--
   - test: `ClassesAndStructures`
-  
+
   ```swifttest
   -> let hd = Resolution(width: 1920, height: 1080)
   -> var cinema = hd
@@ -356,7 +356,7 @@ cinema.width = 2048
 
 <!--
   - test: `ClassesAndStructures`
-  
+
   ```swifttest
   -> cinema.width = 2048
   ```
@@ -372,7 +372,7 @@ print("cinema is now \(cinema.width) pixels wide")
 
 <!--
   - test: `ClassesAndStructures`
-  
+
   ```swifttest
   -> print("cinema is now \(cinema.width) pixels wide")
   <- cinema is now 2048 pixels wide
@@ -389,7 +389,7 @@ print("hd is still \(hd.width) pixels wide")
 
 <!--
   - test: `ClassesAndStructures`
-  
+
   ```swifttest
   -> print("hd is still \(hd.width) pixels wide")
   <- hd is still 1920 pixels wide
@@ -428,7 +428,7 @@ print("The remembered direction is \(rememberedDirection)")
 
 <!--
   - test: `ClassesAndStructures`
-  
+
   ```swifttest
   -> enum CompassPoint {
         case north, south, east, west
@@ -475,7 +475,7 @@ tenEighty.frameRate = 25.0
 
 <!--
   - test: `ClassesAndStructures`
-  
+
   ```swifttest
   -> let tenEighty = VideoMode()
   -> tenEighty.resolution = hd
@@ -502,7 +502,7 @@ alsoTenEighty.frameRate = 30.0
 
 <!--
   - test: `ClassesAndStructures`
-  
+
   ```swifttest
   -> let alsoTenEighty = tenEighty
   -> alsoTenEighty.frameRate = 30.0
@@ -527,7 +527,7 @@ print("The frameRate property of tenEighty is now \(tenEighty.frameRate)")
 
 <!--
   - test: `ClassesAndStructures`
-  
+
   ```swifttest
   -> print("The frameRate property of tenEighty is now \(tenEighty.frameRate)")
   <- The frameRate property of tenEighty is now 30.0
@@ -580,7 +580,7 @@ or passed to a function.)
 
 <!--
   - test: `structuresDontSupportTheIdentityOperators`
-  
+
   ```swifttest
   -> struct S { var x = 0, y = 0 }
   -> let s1 = S()
@@ -597,7 +597,7 @@ or passed to a function.)
 
 <!--
   - test: `enumerationsDontSupportTheIdentityOperators`
-  
+
   ```swifttest
   -> enum E { case a, b }
   -> let e1 = E.a
@@ -630,7 +630,7 @@ if tenEighty === alsoTenEighty {
 
 <!--
   - test: `ClassesAndStructures`
-  
+
   ```swifttest
   -> if tenEighty === alsoTenEighty {
         print("tenEighty and alsoTenEighty refer to the same VideoMode instance.")
@@ -654,7 +654,7 @@ is described in <doc:AdvancedOperators#Equivalence-Operators>.
 
 <!--
   - test: `classesDontGetEqualityByDefault`
-  
+
   ```swifttest
   -> class C { var x = 0, y = 0 }
   -> let c1 = C()
@@ -668,7 +668,7 @@ is described in <doc:AdvancedOperators#Equivalence-Operators>.
 
 <!--
   - test: `structuresDontGetEqualityByDefault`
-  
+
   ```swifttest
   -> struct S { var x = 0, y = 0 }
   -> let s1 = S()

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Closures.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Closures.md
@@ -72,7 +72,7 @@ let names = ["Chris", "Alex", "Ewa", "Barry", "Daniella"]
 
 <!--
   - test: `closureSyntax`
-  
+
   ```swifttest
   -> let names = ["Chris", "Alex", "Ewa", "Barry", "Daniella"]
   ```
@@ -102,7 +102,7 @@ var reversedNames = names.sorted(by: backward)
 
 <!--
   - test: `closureSyntax`
-  
+
   ```swifttest
   -> func backward(_ s1: String, _ s2: String) -> Bool {
         return s1 > s2
@@ -155,7 +155,7 @@ reversedNames = names.sorted(by: { (s1: String, s2: String) -> Bool in
 
 <!--
   - test: `closureSyntax`
-  
+
   ```swifttest
   -> reversedNames = names.sorted(by: { (s1: String, s2: String) -> Bool in
         return s1 > s2
@@ -185,7 +185,7 @@ reversedNames = names.sorted(by: { (s1: String, s2: String) -> Bool in return s1
 
 <!--
   - test: `closureSyntax`
-  
+
   ```swifttest
   -> reversedNames = names.sorted(by: { (s1: String, s2: String) -> Bool in return s1 > s2 } )
   >> assert(reversedNames == ["Ewa", "Daniella", "Chris", "Barry", "Alex"])
@@ -215,7 +215,7 @@ reversedNames = names.sorted(by: { s1, s2 in return s1 > s2 } )
 
 <!--
   - test: `closureSyntax`
-  
+
   ```swifttest
   -> reversedNames = names.sorted(by: { s1, s2 in return s1 > s2 } )
   >> assert(reversedNames == ["Ewa", "Daniella", "Chris", "Barry", "Alex"])
@@ -247,7 +247,7 @@ reversedNames = names.sorted(by: { s1, s2 in s1 > s2 } )
 
 <!--
   - test: `closureSyntax`
-  
+
   ```swifttest
   -> reversedNames = names.sorted(by: { s1, s2 in s1 > s2 } )
   >> assert(reversedNames == ["Ewa", "Daniella", "Chris", "Barry", "Alex"])
@@ -281,7 +281,7 @@ reversedNames = names.sorted(by: { $0 > $1 } )
 
 <!--
   - test: `closureSyntax`
-  
+
   ```swifttest
   -> reversedNames = names.sorted(by: { $0 > $1 } )
   >> assert(reversedNames == ["Ewa", "Daniella", "Chris", "Barry", "Alex"])
@@ -297,7 +297,7 @@ the shorthand arguments `$0` and `$1` are both of type `String`.
 
 <!--
   - test: `closure-syntax-arity-inference`
-  
+
   ```swifttest
   >> let a: [String: String] = [:]
   >> var b: [String: String] = [:]
@@ -326,7 +326,7 @@ reversedNames = names.sorted(by: >)
 
 <!--
   - test: `closureSyntax`
-  
+
   ```swifttest
   -> reversedNames = names.sorted(by: >)
   >> assert(reversedNames == ["Ewa", "Daniella", "Chris", "Barry", "Alex"])
@@ -368,7 +368,7 @@ someFunctionThatTakesAClosure() {
 
 <!--
   - test: `closureSyntax`
-  
+
   ```swifttest
   -> func someFunctionThatTakesAClosure(closure: () -> Void) {
         // function body goes here
@@ -397,7 +397,7 @@ reversedNames = names.sorted() { $0 > $1 }
 
 <!--
   - test: `closureSyntax`
-  
+
   ```swifttest
   -> reversedNames = names.sorted() { $0 > $1 }
   >> assert(reversedNames == ["Ewa", "Daniella", "Chris", "Barry", "Alex"])
@@ -415,7 +415,7 @@ reversedNames = names.sorted { $0 > $1 }
 
 <!--
   - test: `closureSyntax`
-  
+
   ```swifttest
   -> reversedNames = names.sorted { $0 > $1 }
   >> assert(reversedNames == ["Ewa", "Daniella", "Chris", "Barry", "Alex"])
@@ -451,7 +451,7 @@ let numbers = [16, 58, 510]
 
 <!--
   - test: `arrayMap`
-  
+
   ```swifttest
   -> let digitNames = [
         0: "Zero", 1: "One", 2: "Two",   3: "Three", 4: "Four",
@@ -484,7 +484,7 @@ let strings = numbers.map { (number) -> String in
 
 <!--
   - test: `arrayMap`
-  
+
   ```swifttest
   -> let strings = numbers.map { (number) -> String in
         var number = number
@@ -564,7 +564,7 @@ func loadPicture(from server: Server, completion: (Picture) -> Void, onFailure: 
 
 <!--
   - test: `multiple-trailing-closures`
-  
+
   ```swifttest
   >> struct Server { }
   >> struct Picture { }
@@ -598,7 +598,7 @@ loadPicture(from: someServer) { picture in
 
 <!--
   - test: `multiple-trailing-closures`
-  
+
   ```swifttest
   >> struct View {
   >>    var currentPicture = Picture() { didSet { print("Changed picture") } }
@@ -663,7 +663,7 @@ func makeIncrementer(forIncrement amount: Int) -> () -> Int {
 
 <!--
   - test: `closures`
-  
+
   ```swifttest
   -> func makeIncrementer(forIncrement amount: Int) -> () -> Int {
         var runningTotal = 0
@@ -708,7 +708,7 @@ func incrementer() -> Int {
 
 <!--
   - test: `closuresPullout`
-  
+
   ```swifttest
   -> func incrementer() -> Int {
   >>    var runningTotal = 0
@@ -742,7 +742,7 @@ let incrementByTen = makeIncrementer(forIncrement: 10)
 
 <!--
   - test: `closures`
-  
+
   ```swifttest
   -> let incrementByTen = makeIncrementer(forIncrement: 10)
   ```
@@ -764,7 +764,7 @@ incrementByTen()
 
 <!--
   - test: `closures`
-  
+
   ```swifttest
   >> let r0 =
   -> incrementByTen()
@@ -797,7 +797,7 @@ incrementBySeven()
 
 <!--
   - test: `closures`
-  
+
   ```swifttest
   -> let incrementBySeven = makeIncrementer(forIncrement: 7)
   >> let r3 =
@@ -818,7 +818,7 @@ incrementByTen()
 
 <!--
   - test: `closures`
-  
+
   ```swifttest
   >> let r4 =
   -> incrementByTen()
@@ -862,7 +862,7 @@ incrementByTen()
 
 <!--
   - test: `closures`
-  
+
   ```swifttest
   -> let alsoIncrementByTen = incrementByTen
   >> let r5 =
@@ -910,7 +910,7 @@ func someFunctionWithEscapingClosure(completionHandler: @escaping () -> Void) {
 
 <!--
   - test: `noescape-closure-as-argument, implicit-self-struct`
-  
+
   ```swifttest
   -> var completionHandlers: [() -> Void] = []
   -> func someFunctionWithEscapingClosure(completionHandler: @escaping () -> Void) {
@@ -970,7 +970,7 @@ print(instance.x)
 
 <!--
   - test: `noescape-closure-as-argument`
-  
+
   ```swifttest
   -> func someFunctionWithNonescapingClosure(closure: () -> Void) {
          closure()
@@ -1011,7 +1011,7 @@ class SomeOtherClass {
 
 <!--
   - test: `noescape-closure-as-argument`
-  
+
   ```swifttest
   -> class SomeOtherClass {
          var x = 10
@@ -1051,7 +1051,7 @@ struct SomeStruct {
 
 <!--
   - test: `struct-capture-mutable-self`
-  
+
   ```swifttest
   >> var completionHandlers: [() -> Void] = []
   >> func someFunctionWithEscapingClosure(completionHandler: @escaping () -> Void) {
@@ -1085,7 +1085,7 @@ a mutable reference to `self` for structures.
 
 <!--
   - test: `noescape-closure-as-argument`
-  
+
   ```swifttest
   // Test the non-error portion of struct-capture-mutable-self
   >> struct SomeStruct {
@@ -1105,7 +1105,7 @@ a mutable reference to `self` for structures.
 
 <!--
   - test: `noescape-closure-as-argument`
-  
+
   ```swifttest
   >> struct S {
   >>     var x = 10
@@ -1165,7 +1165,7 @@ print(customersInLine.count)
 
 <!--
   - test: `autoclosures`
-  
+
   ```swifttest
   -> var customersInLine = ["Chris", "Alex", "Ewa", "Barry", "Daniella"]
   -> print(customersInLine.count)
@@ -1220,7 +1220,7 @@ serve(customer: { customersInLine.remove(at: 0) } )
 
 <!--
   - test: `autoclosures-function`
-  
+
   ```swifttest
   >> var customersInLine = ["Alex", "Ewa", "Barry", "Daniella"]
   /> customersInLine is \(customersInLine)
@@ -1256,7 +1256,7 @@ serve(customer: customersInLine.remove(at: 0))
 
 <!--
   - test: `autoclosures-function-with-autoclosure`
-  
+
   ```swifttest
   >> var customersInLine = ["Ewa", "Barry", "Daniella"]
   /> customersInLine is \(customersInLine)
@@ -1297,7 +1297,7 @@ for customerProvider in customerProviders {
 
 <!--
   - test: `autoclosures-function-with-escape`
-  
+
   ```swifttest
   >> var customersInLine = ["Barry", "Daniella"]
   /> customersInLine is \(customersInLine)

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/CollectionTypes.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/CollectionTypes.md
@@ -79,7 +79,7 @@ print("someInts is of type [Int] with \(someInts.count) items.")
 
 <!--
   - test: `arraysEmpty`
-  
+
   ```swifttest
   -> var someInts: [Int] = []
   -> print("someInts is of type [Int] with \(someInts.count) items.")
@@ -105,7 +105,7 @@ someInts = []
 
 <!--
   - test: `arraysEmpty`
-  
+
   ```swifttest
   -> someInts.append(3)
   /> someInts now contains \(someInts.count) value of type Int
@@ -131,7 +131,7 @@ var threeDoubles = Array(repeating: 0.0, count: 3)
 
 <!--
   - test: `arraysEmpty`
-  
+
   ```swifttest
   -> var threeDoubles = Array(repeating: 0.0, count: 3)
   /> threeDoubles is of type [Double], and equals [\(threeDoubles[0]), \(threeDoubles[1]), \(threeDoubles[2])]
@@ -155,7 +155,7 @@ var sixDoubles = threeDoubles + anotherThreeDoubles
 
 <!--
   - test: `arraysEmpty`
-  
+
   ```swifttest
   -> var anotherThreeDoubles = Array(repeating: 2.5, count: 3)
   /> anotherThreeDoubles is of type [Double], and equals [\(anotherThreeDoubles[0]), \(anotherThreeDoubles[1]), \(anotherThreeDoubles[2])]
@@ -200,7 +200,7 @@ var shoppingList: [String] = ["Eggs", "Milk"]
 
 <!--
   - test: `arrays`
-  
+
   ```swifttest
   -> var shoppingList: [String] = ["Eggs", "Milk"]
   // shoppingList has been initialized with two initial items
@@ -235,7 +235,7 @@ var shoppingList = ["Eggs", "Milk"]
 
 <!--
   - test: `arraysInferred`
-  
+
   ```swifttest
   -> var shoppingList = ["Eggs", "Milk"]
   ```
@@ -259,7 +259,7 @@ print("The shopping list contains \(shoppingList.count) items.")
 
 <!--
   - test: `arraysInferred`
-  
+
   ```swifttest
   -> print("The shopping list contains \(shoppingList.count) items.")
   <- The shopping list contains 2 items.
@@ -280,7 +280,7 @@ if shoppingList.isEmpty {
 
 <!--
   - test: `arraysInferred`
-  
+
   ```swifttest
   -> if shoppingList.isEmpty {
         print("The shopping list is empty.")
@@ -300,7 +300,7 @@ shoppingList.append("Flour")
 
 <!--
   - test: `arraysInferred`
-  
+
   ```swifttest
   -> shoppingList.append("Flour")
   /> shoppingList now contains \(shoppingList.count) items, and someone is making pancakes
@@ -320,7 +320,7 @@ shoppingList += ["Chocolate Spread", "Cheese", "Butter"]
 
 <!--
   - test: `arraysInferred`
-  
+
   ```swifttest
   -> shoppingList += ["Baking Powder"]
   /> shoppingList now contains \(shoppingList.count) items
@@ -342,7 +342,7 @@ var firstItem = shoppingList[0]
 
 <!--
   - test: `arraysInferred`
-  
+
   ```swifttest
   -> var firstItem = shoppingList[0]
   /> firstItem is equal to \"\(firstItem)\"
@@ -362,7 +362,7 @@ shoppingList[0] = "Six eggs"
 
 <!--
   - test: `arraysInferred`
-  
+
   ```swifttest
   -> shoppingList[0] = "Six eggs"
   /> the first item in the list is now equal to \"\(shoppingList[0])\" rather than \"Eggs\"
@@ -394,7 +394,7 @@ shoppingList[4...6] = ["Bananas", "Apples"]
 
 <!--
   - test: `arraysInferred`
-  
+
   ```swifttest
   -> shoppingList[4...6] = ["Bananas", "Apples"]
   /> shoppingList now contains \(shoppingList.count) items
@@ -413,7 +413,7 @@ shoppingList.insert("Maple Syrup", at: 0)
 
 <!--
   - test: `arraysInferred`
-  
+
   ```swifttest
   -> shoppingList.insert("Maple Syrup", at: 0)
   /> shoppingList now contains \(shoppingList.count) items
@@ -440,7 +440,7 @@ let mapleSyrup = shoppingList.remove(at: 0)
 
 <!--
   - test: `arraysInferred`
-  
+
   ```swifttest
   -> let mapleSyrup = shoppingList.remove(at: 0)
   // the item that was at index 0 has just been removed
@@ -471,7 +471,7 @@ firstItem = shoppingList[0]
 
 <!--
   - test: `arraysInferred`
-  
+
   ```swifttest
   -> firstItem = shoppingList[0]
   /> firstItem is now equal to \"\(firstItem)\"
@@ -493,7 +493,7 @@ let apples = shoppingList.removeLast()
 
 <!--
   - test: `arraysInferred`
-  
+
   ```swifttest
   -> let apples = shoppingList.removeLast()
   // the last item in the array has just been removed
@@ -521,7 +521,7 @@ for item in shoppingList {
 
 <!--
   - test: `arraysInferred`
-  
+
   ```swifttest
   -> for item in shoppingList {
         print(item)
@@ -558,7 +558,7 @@ for (index, value) in shoppingList.enumerated() {
 
 <!--
   - test: `arraysInferred`
-  
+
   ```swifttest
   -> for (index, value) in shoppingList.enumerated() {
         print("Item \(index + 1): \(value)")
@@ -627,7 +627,7 @@ print("letters is of type Set<Character> with \(letters.count) items.")
 
 <!--
   - test: `setsEmpty`
-  
+
   ```swifttest
   -> var letters = Set<Character>()
   -> print("letters is of type Set<Character> with \(letters.count) items.")
@@ -651,7 +651,7 @@ letters = []
 
 <!--
   - test: `setsEmpty`
-  
+
   ```swifttest
   -> letters.insert("a")
   /> letters now contains \(letters.count) value of type Character
@@ -675,7 +675,7 @@ var favoriteGenres: Set<String> = ["Rock", "Classical", "Hip hop"]
 
 <!--
   - test: `sets`
-  
+
   ```swifttest
   -> var favoriteGenres: Set<String> = ["Rock", "Classical", "Hip hop"]
   // favoriteGenres has been initialized with three initial items
@@ -707,7 +707,7 @@ var favoriteGenres: Set = ["Rock", "Classical", "Hip hop"]
 
 <!--
   - test: `setsInferred`
-  
+
   ```swifttest
   -> var favoriteGenres: Set = ["Rock", "Classical", "Hip hop"]
   ```
@@ -731,7 +731,7 @@ print("I have \(favoriteGenres.count) favorite music genres.")
 
 <!--
   - test: `setUsage`
-  
+
   ```swifttest
   >> var favoriteGenres: Set = ["Rock", "Classical", "Hip hop"]
   -> print("I have \(favoriteGenres.count) favorite music genres.")
@@ -753,7 +753,7 @@ if favoriteGenres.isEmpty {
 
 <!--
   - test: `setUsage`
-  
+
   ```swifttest
   -> if favoriteGenres.isEmpty {
         print("As far as music goes, I'm not picky.")
@@ -773,7 +773,7 @@ favoriteGenres.insert("[Tool J]")
 
 <!--
   - test: `setUsage`
-  
+
   ```swifttest
   -> favoriteGenres.insert("[Tool J]")
   /> favoriteGenres now contains \(favoriteGenres.count) items
@@ -798,7 +798,7 @@ if let removedGenre = favoriteGenres.remove("Rock") {
 
 <!--
   - test: `setUsage`
-  
+
   ```swifttest
   -> if let removedGenre = favoriteGenres.remove("Rock") {
         print("\(removedGenre)? I'm over it.")
@@ -822,7 +822,7 @@ if favoriteGenres.contains("Funk") {
 
 <!--
   - test: `setUsage`
-  
+
   ```swifttest
   -> if favoriteGenres.contains("Funk") {
          print("I get up on the good foot.")
@@ -848,7 +848,7 @@ for genre in favoriteGenres {
 
 <!--
   - test: `setUsage`
-  
+
   ```swifttest
   -> for genre in favoriteGenres {
         print("\(genre)")
@@ -878,7 +878,7 @@ for genre in favoriteGenres.sorted() {
 
 <!--
   - test: `setUsage`
-  
+
   ```swifttest
   -> for genre in favoriteGenres.sorted() {
         print("\(genre)")
@@ -925,7 +925,7 @@ oddDigits.symmetricDifference(singleDigitPrimeNumbers).sorted()
 
 <!--
   - test: `setOperations`
-  
+
   ```swifttest
   -> let oddDigits: Set = [1, 3, 5, 7, 9]
   -> let evenDigits: Set = [0, 2, 4, 6, 8]
@@ -989,7 +989,7 @@ farmAnimals.isDisjoint(with: cityAnimals)
 
 <!--
   - test: `setOperations`
-  
+
   ```swifttest
   -> let houseAnimals: Set = ["🐶", "🐱"]
   -> let farmAnimals: Set = ["🐮", "🐔", "🐑", "🐶", "🐱"]
@@ -1056,7 +1056,7 @@ var namesOfIntegers: [Int: String] = [:]
 
 <!--
   - test: `dictionariesEmpty`
-  
+
   ```swifttest
   -> var namesOfIntegers: [Int: String] = [:]
   // namesOfIntegers is an empty [Int: String] dictionary
@@ -1081,7 +1081,7 @@ namesOfIntegers = [:]
 
 <!--
   - test: `dictionariesEmpty`
-  
+
   ```swifttest
   -> namesOfIntegers[16] = "sixteen"
   /> namesOfIntegers now contains \(namesOfIntegers.count) key-value pair
@@ -1118,7 +1118,7 @@ var airports: [String: String] = ["YYZ": "Toronto Pearson", "DUB": "Dublin"]
 
 <!--
   - test: `dictionaries`
-  
+
   ```swifttest
   -> var airports: [String: String] = ["YYZ": "Toronto Pearson", "DUB": "Dublin"]
   ```
@@ -1154,7 +1154,7 @@ var airports = ["YYZ": "Toronto Pearson", "DUB": "Dublin"]
 
 <!--
   - test: `dictionariesInferred`
-  
+
   ```swifttest
   -> var airports = ["YYZ": "Toronto Pearson", "DUB": "Dublin"]
   ```
@@ -1180,7 +1180,7 @@ print("The airports dictionary contains \(airports.count) items.")
 
 <!--
   - test: `dictionariesInferred`
-  
+
   ```swifttest
   -> print("The airports dictionary contains \(airports.count) items.")
   <- The airports dictionary contains 2 items.
@@ -1201,7 +1201,7 @@ if airports.isEmpty {
 
 <!--
   - test: `dictionariesInferred`
-  
+
   ```swifttest
   -> if airports.isEmpty {
         print("The airports dictionary is empty.")
@@ -1223,7 +1223,7 @@ airports["LHR"] = "London"
 
 <!--
   - test: `dictionariesInferred`
-  
+
   ```swifttest
   -> airports["LHR"] = "London"
   /> the airports dictionary now contains \(airports.count) items
@@ -1240,7 +1240,7 @@ airports["LHR"] = "London Heathrow"
 
 <!--
   - test: `dictionariesInferred`
-  
+
   ```swifttest
   -> airports["LHR"] = "London Heathrow"
   /> the value for \"LHR\" has been changed to \"\(airports["LHR"]!)\"
@@ -1275,7 +1275,7 @@ if let oldValue = airports.updateValue("Dublin Airport", forKey: "DUB") {
 
 <!--
   - test: `dictionariesInferred`
-  
+
   ```swifttest
   -> if let oldValue = airports.updateValue("Dublin Airport", forKey: "DUB") {
         print("The old value for DUB was \(oldValue).")
@@ -1302,7 +1302,7 @@ if let airportName = airports["DUB"] {
 
 <!--
   - test: `dictionariesInferred`
-  
+
   ```swifttest
   -> if let airportName = airports["DUB"] {
         print("The name of the airport is \(airportName).")
@@ -1325,7 +1325,7 @@ airports["APL"] = nil
 
 <!--
   - test: `dictionariesInferred`
-  
+
   ```swifttest
   -> airports["APL"] = "Apple International"
   // "Apple International" isn't the real airport for APL, so delete it
@@ -1358,7 +1358,7 @@ if let removedValue = airports.removeValue(forKey: "DUB") {
 
 <!--
   - test: `dictionariesInferred`
-  
+
   ```swifttest
   -> if let removedValue = airports.removeValue(forKey: "DUB") {
         print("The removed airport's name is \(removedValue).")
@@ -1386,7 +1386,7 @@ for (airportCode, airportName) in airports {
 
 <!--
   - test: `dictionariesInferred`
-  
+
   ```swifttest
   -> for (airportCode, airportName) in airports {
         print("\(airportCode): \(airportName)")
@@ -1417,7 +1417,7 @@ for airportName in airports.values {
 
 <!--
   - test: `dictionariesInferred`
-  
+
   ```swifttest
   -> for airportCode in airports.keys {
         print("Airport code: \(airportCode)")
@@ -1447,7 +1447,7 @@ let airportNames = [String](airports.values)
 
 <!--
   - test: `dictionariesInferred`
-  
+
   ```swifttest
   -> let airportCodes = [String](airports.keys)
   /> airportCodes is [\"\(airportCodes[0])\", \"\(airportCodes[1])\"]

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Concurrency.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Concurrency.md
@@ -66,7 +66,7 @@ listPhotos(inGallery: "Summer Vacation") { photoNames in
 
 <!--
   - test: `async-via-nested-completion-handlers`
-  
+
   ```swifttest
   >> struct Data {}  // Instead of actually importing Foundation
   >> func listPhotos(inGallery name: String, completionHandler: ([String]) -> Void ) {
@@ -121,7 +121,7 @@ func listPhotos(inGallery name: String) async -> [String] {
 
 <!--
   - test: `async-function-shape`
-  
+
   ```swifttest
   -> func listPhotos(inGallery name: String) async -> [String] {
          let result = // ... some asynchronous networking code ...
@@ -136,7 +136,7 @@ you write `async` before `throws`.
 
 <!--
   - test: `async-comes-before-throws`
-  
+
   ```swifttest
   >> func right() async throws -> Int { return 12 }
   >> func wrong() throws async -> Int { return 12 }
@@ -172,7 +172,7 @@ show(photo)
 
 <!--
   - test: `defining-async-function`
-  
+
   ```swifttest
   >> struct Data {}  // Instead of actually importing Foundation
   >> func downloadPhoto(named name: String) async -> Data { return Data() }
@@ -244,7 +244,7 @@ only certain places in your program can call asynchronous functions or methods:
   SE-0296 specifically calls out that top-level code is *not* an async context,
   contrary to what you might expect.
   If that gets changed, add this bullet to the list above:
-  
+
   - Code at the top level that forms an implicit main function.
 -->
 
@@ -304,7 +304,7 @@ you'll get compile-time error instead of introducing a bug.
 > but waits at least the given number of nanoseconds before it returns.
 > Here's a version of the `listPhotos(inGallery:)` function
 > that uses `sleep(until:tolerance:clock:)` to simulate waiting for a network operation:
-> 
+>
 > ```swift
 > func listPhotos(inGallery name: String) async throws -> [String] {
 >     try await Task.sleep(until: .now + .seconds(2), clock: .continuous)
@@ -333,11 +333,11 @@ you'll get compile-time error instead of introducing a bug.
 
 <!--
   TODO closures can be async too -- outline
-  
+
   like how you can have an async function, a closure con be async
   if a closure contains 'await' that implicitly makes it async
   you can mark it explicitly with "async -> in"
-  
+
   (discussion of @MainActor closures can probably go here too)
 -->
 
@@ -362,7 +362,7 @@ for try await line in handle.bytes.lines {
 
 <!--
   - test: `async-sequence`
-  
+
   ```swifttest
   -> import Foundation
   ---
@@ -396,21 +396,21 @@ by adding conformance to the
 <!--
   TODO what happened to ``Series`` which was supposed to be a currency type?
   Is that coming from Combine instead of the stdlib maybe?
-  
+
   Also... need a real API that produces a async sequence.
   I'd prefer not to go through the whole process of making one here,
   since the protocol reference has enough detail to show you how to do that.
   There's nothing in the stdlib except for the AsyncFooSequence types.
   Maybe one of the other conforming types from an Apple framework --
   how about FileHandle.AsyncBytes (myFilehandle.bytes.lines) from Foundation?
-  
+
   https://developer.apple.com/documentation/swift/asyncsequence
   https://developer.apple.com/documentation/foundation/filehandle
-  
+
   if we get a stdlib-provided async sequence type at some point,
   rewrite the above to fit the same narrative flow
   using something like the following
-  
+
   let names = await listPhotos(inGallery: "Winter Vacation")
   for await photo in Photos(names: names) {
       show(photo)
@@ -451,7 +451,7 @@ show(photos)
 
 <!--
   - test: `defining-async-function`
-  
+
   ```swifttest
   >> func show(_ images: [Data]) { }
   >> func ff() async {
@@ -490,7 +490,7 @@ show(photos)
 
 <!--
   - test: `calling-with-async-let`
-  
+
   ```swifttest
   >> struct Data {}  // Instead of actually importing Foundation
   >> func show(_ images: [Data]) { }
@@ -575,31 +575,31 @@ see [TaskGroup](https://developer.apple.com/documentation/swift/taskgroup).
 
 <!--
   OUTLINE
-  
+
   - A task itself doesn't have any concurrency; it does one thing at a time
-  
+
   - other reasons to use the API include setting:
-  
+
   + cancellation (``Task.isCancelled``)
   + priority (``Task.currentPriority``)
-  
+
   .. not for WWDC, but keep for future:
   task have deadlines, not timeouts --- like "now + 20 ms" ---
   a deadline is usually what you want anyhow when you think of a timeout
-  
+
   - this chapter introduces the core ways you use tasks;
   for the full list what you can do,
   including the unsafe escape hatches
   and ``Task.current()`` for advanced use cases,
   see the Task API reference [link to stdlib]
-  
+
   - task cancellation isn't part of the state diagram below;
   it's an independent property that can happen in any state
-  
+
   [PLACEHOLDER ART]
-  
+
   Task state diagram
-  
+
      |
      v
   Suspended <-+
@@ -609,11 +609,11 @@ see [TaskGroup](https://developer.apple.com/documentation/swift/taskgroup).
      |
      v
   Completed
-  
+
   [PLACEHOLDER ART]
-  
+
   Task state diagram, including "substates"
-  
+
      |
      v
   Suspended <-----+
@@ -628,31 +628,31 @@ see [TaskGroup](https://developer.apple.com/documentation/swift/taskgroup).
      |
      v
   Completed
-  
+
   .. _Concurrency_ChildTasks:
-  
+
   Adding Child Tasks to a Task Group
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  
+
   - Creating a group with ``withTaskGroup`` and ``withThrowingTaskGroup``
-  
+
   - awaiting ``withGroup`` means waiting for all child tasks to complete
-  
+
   - a child task can't outlive its parent,
   like how ``async``-``let`` can't outlive the (implicit) parent
   which is the function scope
-  
+
   - Adding a child with ``TaskGroup.addTask(priority:operation:)``
-  
+
   - awaiting ``addTask(priority:operation:)``
   means waiting for that child task to be added,
   not waiting for that child task to finish
-  
+
   - ?? maybe cover ``TaskGroup.next``
   probably nicer to use the ``for await result in someGroup`` syntax
-  
+
   quote from the SE proposal --- I want to include this fact here too
-  
+
   > There's no way for reference to the child task to
   > escape the scope in which the child task is created.
   > This ensures that the structure of structured concurrency is maintained.
@@ -663,26 +663,26 @@ see [TaskGroup](https://developer.apple.com/documentation/swift/taskgroup).
 
 <!--
   OUTLINE
-  
+
   .. _Concurrency_TaskPriority:
-  
+
   Setting Task Priority
   ~~~~~~~~~~~~~~~~~~~~~
-  
+
   - priority values defined by ``Task.Priority`` enum
-  
+
   - type property ``Task.currentPriority``
-  
+
   - The exact result of setting a task's priority depends on the executor
-  
+
   - TR: What's the built-in stdlib executor do?
-  
+
   - Child tasks inherit the priority of their parents
-  
+
   - If a high-priority task is waiting for a low-priority one,
   the low-priority one gets scheduled at high priority
   (this is known as :newTerm:`priority escalation`)
-  
+
   - In addition, or instead of, setting a low priority,
   you can use ``Task.yield()`` to explicitly pass execution to the next scheduled task.
   This is a sort of cooperative multitasking for long-running work.
@@ -751,13 +751,13 @@ call [Task.cancel()](https://developer.apple.com/documentation/swift/task/385121
 
 <!--
   OUTLINE
-  
+
   - task
-  
+
   - cancellation propagates (Konrad's example below)
-  
+
   ::
-  
+
       let handle = spawnDetached {
       await withTaskGroup(of: Bool.self) { group in
           var done = false
@@ -767,10 +767,10 @@ call [Task.cancel()](https://developer.apple.com/documentation/swift/task/385121
           }
       print("done!") // <1>
       }
-  
+
       handle.cancel()
       // done!           <1>
-  
+
   - Use ``withCancellationHandler()`` to specify a closure to run
   if the task is canceled
   along with a closure that defines the task's work
@@ -811,13 +811,13 @@ actor TemperatureLogger {
 
 <!--
   - test: `actors, actors-implicitly-sendable`
-  
+
   ```swifttest
   -> actor TemperatureLogger {
          let label: String
          var measurements: [Int]
          private(set) var max: Int
-  
+
          init(label: String, measurement: Int) {
              self.label = label
              self.measurements = [measurement]
@@ -918,44 +918,44 @@ This guarantee is known as *actor isolation*.
 
 <!--
   OUTLINE -- design patterns for actors
-  
+
   - do your mutation in a sync function
 -->
 
 <!--
   OUTLINE
-  
+
   Add this post-WWDC when we have a more solid story to tell around Sendable
-  
+
    .. _Concurrency_ActorIsolation:
-  
+
    Actor Isolation
    ~~~~~~~~~~~~~~~
-  
+
    TODO outline impact from SE-0313 Control Over Actor Isolation
    about the 'isolated' and 'nonisolated' keywords
-  
+
    - actors protect their mutable state using :newTerm:`actor isolation`
    to prevent data races
    (one actor reading data that's in an inconsistent state
    while another actor is updating/writing to that data)
-  
+
    - within an actor's implementation,
    you can read and write to properties of ``self`` synchronously,
    likewise for calling methods of ``self`` or ``super``
-  
+
    - method calls from outside the actor are always async,
    as is reading the value of an actor's property
-  
+
    - you can't write to a property directly from outside the actor
-  
+
    TODO: Either define "data race" or use a different term;
    the chapter on exclusive ownership talks about "conflicting access",
    which is related, but different.
    Konrad defines "data race" as concurrent access to shared state,
    noting that our current design doesn't prevent all race conditions
    because suspension points allow for interleaving.
-  
+
    - The same actor method can be called multiple times, overlapping itself.
    This is sometimes referred to as *reentrant code*.
    The behavior is defined and safe... but might have unexpected results.
@@ -963,23 +963,23 @@ This guarantee is known as *actor isolation*.
    that these overlapping calls behave correctly (that they're *idempotent*).
    Encapsulate state changes in a synchronous function
    or write them so they don't contain an ``await`` in the middle.
-  
+
    - If a closure is ``@Sendable`` or ``@escaping``
    then it behaves like code outside of the actor
    because it could execute concurrently with other code that's part of the actor
-  
-  
+
+
    exercise the log actor, using its client API to mutate state
-  
+
    ::
-  
+
        let logger = TemperatureSensor(lines: [
            "Outdoor air temperature",
            "25 C",
            "24 C",
        ])
        print(await logger.getMax())
-  
+
        await logger.update(with: "27 C")
        print(await logger.getMax())
 -->
@@ -1065,7 +1065,7 @@ await logger.addReading(from: reading)
 
 <!--
   - test: `actors`
-  
+
   ```swifttest
   -> struct TemperatureReading: Sendable {
          var measurement: Int
@@ -1097,7 +1097,7 @@ struct TemperatureReading {
 
 <!--
   - test: `actors-implicitly-sendable`
-  
+
   ```swifttest
   -> struct TemperatureReading {
          var measurement: Int
@@ -1108,22 +1108,22 @@ struct TemperatureReading {
 <!--
   OUTLINE
   .. _Concurrency_MainActor:
-  
+
   The Main Actor
   ~~~~~~~~~~~~~~
-  
-  
+
+
   - the main actor is kinda-sorta like the main thread
-  
+
   - use it when you have shared mutable state,
   but that state isn't neatly wrapped up in a single type
-  
+
   - you can put it on a function,
   which makes calls to the function always run on the main actor
-  
+
   - you can put it on a type,
   which makes calls to all of the type's methods run on the main actor
-  
+
   - some property wrappers like ``@EnvironmentObject`` from SwiftUI
   imply ``@MainActor`` on a type.
   Check for a ``wrappedValue`` that's marked ``@MainActor``.
@@ -1134,35 +1134,35 @@ struct TemperatureReading {
 
 <!--
   LEFTOVER OUTLINE BITS
-  
+
   - like classes, actors can inherit from other actors
-  
+
   - actors can also inherit from ``NSObject``,
   which lets you mark them ``@objc`` and do interop stuff with them
-  
+
   - every actor implicitly conforms to the ``Actor`` protocol,
   which has no requirements
-  
+
   - you can use the ``Actor`` protocol to write code that's generic across actors
-  
+
   - In the future, when we get distributed actors,
     the TemperatureSensor example
     might be a good example to expand when explaining them.
-  
-  
+
+
   ::
-  
+
       while let result = try await group.next() { }
       for try await result in group { }
-  
+
   how much should you have to understand threads to understand this?
   Ideally you don't have to know anything about them.
-  
+
   How do you meld async-await-Task-Actor with an event driven model?
   Can you feed your user events through an async sequence or Combine
   and then use for-await-in to spin an event loop?
   I think so --- but how do you get the events *into* the async sequence?
-  
+
   Probably don't cover unsafe continuations (SE-0300) in TSPL,
   but maybe link to them?
 -->

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/ControlFlow.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/ControlFlow.md
@@ -40,7 +40,7 @@ for name in names {
 
 <!--
   - test: `forLoops`
-  
+
   ```swifttest
   -> let names = ["Anna", "Alex", "Brian", "Jack"]
   -> for name in names {
@@ -73,7 +73,7 @@ for (animalName, legCount) in numberOfLegs {
 
 <!--
   - test: `forLoops`
-  
+
   ```swifttest
   -> let numberOfLegs = ["spider": 8, "ant": 6, "cat": 4]
   -> for (animalName, legCount) in numberOfLegs {
@@ -114,7 +114,7 @@ for index in 1...5 {
 
 <!--
   - test: `forLoops`
-  
+
   ```swifttest
   -> for index in 1...5 {
         print("\(index) times 5 is \(index * 5)")
@@ -161,7 +161,7 @@ print("\(base) to the power of \(power) is \(answer)")
 
 <!--
   - test: `forLoops`
-  
+
   ```swifttest
   -> let base = 3
   -> let power = 10
@@ -204,7 +204,7 @@ for tickMark in 0..<minutes {
 
 <!--
   - test: `forLoops`
-  
+
   ```swifttest
   -> let minutes = 60
   >> var result: [Int] = []
@@ -230,7 +230,7 @@ for tickMark in stride(from: 0, to: minutes, by: minuteInterval) {
 
 <!--
   - test: `forLoops`
-  
+
   ```swifttest
   -> let minuteInterval = 5
   >> result = []
@@ -255,7 +255,7 @@ for tickMark in stride(from: 3, through: hours, by: hourInterval) {
 
 <!--
   - test: `forLoops`
-  
+
   ```swifttest
   -> let hours = 12
   -> let hourInterval = 3
@@ -338,7 +338,7 @@ var board = [Int](repeating: 0, count: finalSquare + 1)
 
 <!--
   - test: `snakesAndLadders1`
-  
+
   ```swifttest
   -> let finalSquare = 25
   -> var board = [Int](repeating: 0, count: finalSquare + 1)
@@ -357,7 +357,7 @@ board[14] = -10; board[19] = -11; board[22] = -02; board[24] = -08
 
 <!--
   - test: `snakesAndLadders1`
-  
+
   ```swifttest
   -> board[03] = +08; board[06] = +11; board[09] = +09; board[10] = +02
   -> board[14] = -10; board[19] = -11; board[22] = -02; board[24] = -08
@@ -398,7 +398,7 @@ print("Game over!")
 
 <!--
   - test: `snakesAndLadders1`
-  
+
   ```swifttest
   -> var square = 0
   -> var diceRoll = 0
@@ -518,7 +518,7 @@ var diceRoll = 0
 
 <!--
   - test: `snakesAndLadders2`
-  
+
   ```swifttest
   -> let finalSquare = 25
   -> var board = [Int](repeating: 0, count: finalSquare + 1)
@@ -554,7 +554,7 @@ print("Game over!")
 
 <!--
   - test: `snakesAndLadders2`
-  
+
   ```swifttest
   -> repeat {
         // move up or down for a snake or ladder
@@ -649,7 +649,7 @@ if temperatureInFahrenheit <= 32 {
 
 <!--
   - test: `ifElse`
-  
+
   ```swifttest
   -> var temperatureInFahrenheit = 30
   -> if temperatureInFahrenheit <= 32 {
@@ -683,7 +683,7 @@ if temperatureInFahrenheit <= 32 {
 
 <!--
   - test: `ifElse`
-  
+
   ```swifttest
   -> temperatureInFahrenheit = 40
   -> if temperatureInFahrenheit <= 32 {
@@ -717,7 +717,7 @@ if temperatureInFahrenheit <= 32 {
 
 <!--
   - test: `ifElse`
-  
+
   ```swifttest
   -> temperatureInFahrenheit = 90
   -> if temperatureInFahrenheit <= 32 {
@@ -749,7 +749,7 @@ if temperatureInFahrenheit <= 32 {
 
 <!--
   - test: `ifElse`
-  
+
   ```swifttest
   -> temperatureInFahrenheit = 72
   -> if temperatureInFahrenheit <= 32 {
@@ -824,7 +824,7 @@ default:
 
 <!--
   - test: `switch`
-  
+
   ```swifttest
   -> let someCharacter: Character = "z"
   -> switch someCharacter {
@@ -881,7 +881,7 @@ default:
 
 <!--
   - test: `noFallthrough`
-  
+
   ```swifttest
   -> let anotherCharacter: Character = "a"
   -> switch anotherCharacter {
@@ -924,7 +924,7 @@ default:
 
 <!--
   - test: `compoundCaseInsteadOfFallthrough`
-  
+
   ```swifttest
   -> let anotherCharacter: Character = "a"
   -> switch anotherCharacter {
@@ -981,7 +981,7 @@ print("There are \(naturalCount) \(countedThings).")
 
 <!--
   - test: `intervalMatching`
-  
+
   ```swifttest
   -> let approximateCount = 62
   -> let countedThings = "moons orbiting Saturn"
@@ -1042,7 +1042,7 @@ default:
 
 <!--
   - test: `tuples`
-  
+
   ```swifttest
   -> let somePoint = (1, 1)
   -> switch somePoint {
@@ -1103,7 +1103,7 @@ case let (x, y):
 
 <!--
   - test: `valueBindings`
-  
+
   ```swifttest
   -> let anotherPoint = (2, 0)
   -> switch anotherPoint {
@@ -1166,7 +1166,7 @@ case let (x, y):
 
 <!--
   - test: `where`
-  
+
   ```swifttest
   -> let yetAnotherPoint = (1, -1)
   -> switch yetAnotherPoint {
@@ -1223,7 +1223,7 @@ default:
 
 <!--
   - test: `compound-switch-case`
-  
+
   ```swifttest
   -> let someCharacter: Character = "e"
   -> switch someCharacter {
@@ -1268,7 +1268,7 @@ default:
 
 <!--
   - test: `compound-switch-case`
-  
+
   ```swifttest
   -> let stillAnotherPoint = (9, 0)
   -> switch stillAnotherPoint {
@@ -1331,7 +1331,7 @@ print(puzzleOutput)
 
 <!--
   - test: `continue`
-  
+
   ```swifttest
   -> let puzzleInput = "great minds think alike"
   -> var puzzleOutput = ""
@@ -1419,7 +1419,7 @@ if let integerValue = possibleIntegerValue {
 
 <!--
   - test: `breakInASwitchStatement`
-  
+
   ```swifttest
   -> let numberSymbol: Character = "三"  // Chinese symbol for the number 3
   -> var possibleIntegerValue: Int?
@@ -1498,7 +1498,7 @@ print(description)
 
 <!--
   - test: `fallthrough`
-  
+
   ```swifttest
   -> let integerToDescribe = 5
   -> var description = "The number \(integerToDescribe) is"
@@ -1601,7 +1601,7 @@ var diceRoll = 0
 
 <!--
   - test: `labels`
-  
+
   ```swifttest
   -> let finalSquare = 25
   -> var board = [Int](repeating: 0, count: finalSquare + 1)
@@ -1643,7 +1643,7 @@ print("Game over!")
 
 <!--
   - test: `labels`
-  
+
   ```swifttest
   -> gameLoop: while square != finalSquare {
         diceRoll += 1
@@ -1780,7 +1780,7 @@ greet(person: ["name": "Jane", "location": "Cupertino"])
 
 <!--
   - test: `guard`
-  
+
   ```swifttest
   -> func greet(person: [String: String]) {
          guard let name = person["name"] else {
@@ -1858,7 +1858,7 @@ if #available(iOS 10, macOS 10.12, *) {
 
 <!--
   - test: `availability`
-  
+
   ```swifttest
   -> if #available(iOS 10, macOS 10.12, *) {
          // Use iOS 10 APIs on iOS, and use macOS 10.12 APIs on macOS
@@ -1910,7 +1910,7 @@ func chooseBestColor() -> String {
 
 <!--
   - test: `guard-with-pound-available`
-  
+
   ```swifttest
   -> @available(macOS 10.12, *)
   -> struct ColorPreference {
@@ -1954,7 +1954,7 @@ if #unavailable(iOS 10) {
 
 <!--
   - test: `availability-and-unavailability`
-  
+
   ```swifttest
   -> if #available(iOS 10, *) {
      } else {

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Deinitialization.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Deinitialization.md
@@ -32,7 +32,7 @@ deinit {
 
 <!--
   - test: `deinitializer`
-  
+
   ```swifttest
   >> class Test {
   -> deinit {
@@ -81,7 +81,7 @@ class Bank {
 
 <!--
   - test: `deinitializer`
-  
+
   ```swifttest
   -> class Bank {
         static var coinsInBank = 10_000
@@ -130,7 +130,7 @@ class Player {
 
 <!--
   - test: `deinitializer`
-  
+
   ```swifttest
   -> class Player {
         var coinsInPurse: Int
@@ -169,7 +169,7 @@ print("There are now \(Bank.coinsInBank) coins left in the bank")
 
 <!--
   - test: `deinitializer`
-  
+
   ```swifttest
   -> var playerOne: Player? = Player(coins: 100)
   -> print("A new player has joined the game with \(playerOne!.coinsInPurse) coins")
@@ -198,7 +198,7 @@ print("The bank now only has \(Bank.coinsInBank) coins left")
 
 <!--
   - test: `deinitializer`
-  
+
   ```swifttest
   -> playerOne!.win(coins: 2_000)
   -> print("PlayerOne won 2000 coins & now has \(playerOne!.coinsInPurse) coins")
@@ -222,7 +222,7 @@ print("The bank now has \(Bank.coinsInBank) coins")
 
 <!--
   - test: `deinitializer`
-  
+
   ```swifttest
   -> playerOne = nil
   -> print("PlayerOne has left the game")

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Enumerations.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Enumerations.md
@@ -51,7 +51,7 @@ enum SomeEnumeration {
 
 <!--
   - test: `enums`
-  
+
   ```swifttest
   -> enum SomeEnumeration {
         // enumeration definition goes here
@@ -72,7 +72,7 @@ enum CompassPoint {
 
 <!--
   - test: `enums`
-  
+
   ```swifttest
   -> enum CompassPoint {
         case north
@@ -107,7 +107,7 @@ enum Planet {
 
 <!--
   - test: `enums`
-  
+
   ```swifttest
   -> enum Planet {
         case mercury, venus, earth, mars, jupiter, saturn, uranus, neptune
@@ -128,7 +128,7 @@ var directionToHead = CompassPoint.west
 
 <!--
   - test: `enums`
-  
+
   ```swifttest
   -> var directionToHead = CompassPoint.west
   ```
@@ -145,7 +145,7 @@ directionToHead = .east
 
 <!--
   - test: `enums`
-  
+
   ```swifttest
   -> directionToHead = .east
   ```
@@ -176,7 +176,7 @@ case .west:
 
 <!--
   - test: `enums`
-  
+
   ```swifttest
   -> directionToHead = .south
   -> switch directionToHead {
@@ -226,7 +226,7 @@ default:
 
 <!--
   - test: `enums`
-  
+
   ```swifttest
   -> let somePlanet = Planet.earth
   -> switch somePlanet {
@@ -260,7 +260,7 @@ print("\(numberOfChoices) beverages available")
 
 <!--
   - test: `enums`
-  
+
   ```swifttest
   -> enum Beverage: CaseIterable {
          case coffee, tea, juice
@@ -291,7 +291,7 @@ for beverage in Beverage.allCases {
 
 <!--
   - test: `enums`
-  
+
   ```swifttest
   -> for beverage in Beverage.allCases {
          print(beverage)
@@ -358,7 +358,7 @@ enum Barcode {
 
 <!--
   - test: `enums`
-  
+
   ```swifttest
   -> enum Barcode {
         case upc(Int, Int, Int, Int)
@@ -387,7 +387,7 @@ var productBarcode = Barcode.upc(8, 85909, 51226, 3)
 
 <!--
   - test: `enums`
-  
+
   ```swifttest
   -> var productBarcode = Barcode.upc(8, 85909, 51226, 3)
   ```
@@ -405,7 +405,7 @@ productBarcode = .qrCode("ABCDEFGHIJKLMNOP")
 
 <!--
   - test: `enums`
-  
+
   ```swifttest
   -> productBarcode = .qrCode("ABCDEFGHIJKLMNOP")
   ```
@@ -439,7 +439,7 @@ case .qrCode(let productCode):
 
 <!--
   - test: `enums`
-  
+
   ```swifttest
   -> switch productBarcode {
         case .upc(let numberSystem, let manufacturer, let product, let check):
@@ -467,7 +467,7 @@ case let .qrCode(productCode):
 
 <!--
   - test: `enums`
-  
+
   ```swifttest
   -> switch productBarcode {
         case let .upc(numberSystem, manufacturer, product, check):
@@ -501,7 +501,7 @@ enum ASCIIControlCharacter: Character {
 
 <!--
   - test: `rawValues`
-  
+
   ```swifttest
   -> enum ASCIIControlCharacter: Character {
         case tab = "\t"
@@ -550,7 +550,7 @@ enum Planet: Int {
 
 <!--
   - test: `rawValues`
-  
+
   ```swifttest
   -> enum Planet: Int {
         case mercury = 1, venus, earth, mars, jupiter, saturn, uranus, neptune
@@ -576,7 +576,7 @@ enum CompassPoint: String {
 
 <!--
   - test: `rawValues`
-  
+
   ```swifttest
   -> enum CompassPoint: String {
         case north, south, east, west
@@ -599,7 +599,7 @@ let sunsetDirection = CompassPoint.west.rawValue
 
 <!--
   - test: `rawValues`
-  
+
   ```swifttest
   -> let earthsOrder = Planet.earth.rawValue
   /> earthsOrder is \(earthsOrder)
@@ -628,7 +628,7 @@ let possiblePlanet = Planet(rawValue: 7)
 
 <!--
   - test: `rawValues`
-  
+
   ```swifttest
   -> let possiblePlanet = Planet(rawValue: 7)
   >> print(type(of: possiblePlanet))
@@ -667,7 +667,7 @@ if let somePlanet = Planet(rawValue: positionToFind) {
 
 <!--
   - test: `rawValues`
-  
+
   ```swifttest
   -> let positionToFind = 11
   -> if let somePlanet = Planet(rawValue: positionToFind) {
@@ -716,7 +716,7 @@ enum ArithmeticExpression {
 
 <!--
   - test: `recursive-enum-intro`
-  
+
   ```swifttest
   -> enum ArithmeticExpression {
          case number(Int)
@@ -739,7 +739,7 @@ indirect enum ArithmeticExpression {
 
 <!--
   - test: `recursive-enum`
-  
+
   ```swifttest
   -> indirect enum ArithmeticExpression {
          case number(Int)
@@ -774,7 +774,7 @@ let product = ArithmeticExpression.multiplication(sum, ArithmeticExpression.numb
 
 <!--
   - test: `recursive-enum`
-  
+
   ```swifttest
   -> let five = ArithmeticExpression.number(5)
   -> let four = ArithmeticExpression.number(4)
@@ -805,7 +805,7 @@ print(evaluate(product))
 
 <!--
   - test: `recursive-enum`
-  
+
   ```swifttest
   -> func evaluate(_ expression: ArithmeticExpression) -> Int {
          switch expression {

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/ErrorHandling.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/ErrorHandling.md
@@ -53,7 +53,7 @@ enum VendingMachineError: Error {
 
 <!--
   - test: `throw-enum-error`
-  
+
   ```swifttest
   -> enum VendingMachineError: Error {
          case invalidSelection
@@ -76,7 +76,7 @@ throw VendingMachineError.insufficientFunds(coinsNeeded: 5)
 
 <!--
   - test: `throw-enum-error`
-  
+
   ```swifttest
   -> throw VendingMachineError.insufficientFunds(coinsNeeded: 5)
   xx fatal error
@@ -138,7 +138,7 @@ func cannotThrowErrors() -> String
 
 <!--
   - test: `throwingFunctionDeclaration`
-  
+
   ```swifttest
   -> func canThrowErrors() throws -> String
   >> { return "foo" }
@@ -150,7 +150,7 @@ func cannotThrowErrors() -> String
 
 <!--
   - test: `throwing-function-cant-overload-nonthrowing`
-  
+
   ```swifttest
   -> func f() -> Int { return 10 }
   -> func f() throws -> Int { return 10 } // Error
@@ -165,7 +165,7 @@ func cannotThrowErrors() -> String
 
 <!--
   - test: `throwing-parameter-can-overload-nonthrowing`
-  
+
   ```swifttest
   -> func f(callback: () -> Int) {}
   -> func f(callback: () throws -> Int) {} // Allowed
@@ -235,7 +235,7 @@ class VendingMachine {
 
 <!--
   - test: `errorHandling`
-  
+
   ```swifttest
   >> enum VendingMachineError: Error {
   >>     case invalidSelection
@@ -259,21 +259,21 @@ class VendingMachine {
              guard let item = inventory[name] else {
                  throw VendingMachineError.invalidSelection
              }
-  
+
              guard item.count > 0 else {
                  throw VendingMachineError.outOfStock
              }
-  
+
              guard item.price <= coinsDeposited else {
                  throw VendingMachineError.insufficientFunds(coinsNeeded: item.price - coinsDeposited)
              }
-  
+
              coinsDeposited -= item.price
-  
+
              var newItem = item
              newItem.count -= 1
              inventory[name] = newItem
-  
+
              print("Dispensing \(name)")
          }
      }
@@ -310,7 +310,7 @@ func buyFavoriteSnack(person: String, vendingMachine: VendingMachine) throws {
 
 <!--
   - test: `errorHandling`
-  
+
   ```swifttest
   -> let favoriteSnacks = [
          "Alice": "Chips",
@@ -352,7 +352,7 @@ struct PurchasedSnack {
 
 <!--
   - test: `errorHandling`
-  
+
   ```swifttest
   -> struct PurchasedSnack {
          let name: String
@@ -441,7 +441,7 @@ do {
 
 <!--
   - test: `errorHandling`
-  
+
   ```swifttest
   -> var vendingMachine = VendingMachine()
   -> vendingMachine.coinsDeposited = 8
@@ -512,7 +512,7 @@ do {
 
 <!--
   - test: `errorHandling`
-  
+
   ```swifttest
   -> func nourish(with item: String) throws {
          do {
@@ -555,7 +555,7 @@ func eat(item: String) throws {
 
 <!--
   - test: `errorHandling`
-  
+
   ```swifttest
   -> func eat(item: String) throws {
          do {
@@ -609,7 +609,7 @@ do {
 
 <!--
   - test: `optional-try`
-  
+
   ```swifttest
   -> func someThrowingFunction() throws -> Int {
         // ...
@@ -654,7 +654,7 @@ func fetchData() -> Data? {
 
 <!--
   - test: `optional-try-cached-data`
-  
+
   ```swifttest
   >> struct Data {}
   >> func fetchDataFromDisk() throws -> Data { return Data() }
@@ -689,7 +689,7 @@ let photo = try! loadImage(atPath: "./Resources/John Appleseed.jpg")
 
 <!--
   - test: `forceTryStatement`
-  
+
   ```swifttest
   >> struct Image {}
   >> func loadImage(atPath path: String) throws -> Image {
@@ -742,7 +742,7 @@ func processFile(filename: String) throws {
 
 <!--
   - test: `defer`
-  
+
   ```swifttest
   >> func exists(_ file: String) -> Bool { return true }
   >> struct File {

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Extensions.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Extensions.md
@@ -29,7 +29,7 @@ For more details, see <doc:Protocols#Protocol-Extensions>.
 
 <!--
   - test: `extensionsCannotOverrideExistingBehavior`
-  
+
   ```swifttest
   -> class C {
         var x = 0
@@ -87,7 +87,7 @@ extension SomeType {
 
 <!--
   - test: `extensionSyntax`
-  
+
   ```swifttest
   >> struct SomeType {}
   -> extension SomeType {
@@ -109,7 +109,7 @@ extension SomeType: SomeProtocol, AnotherProtocol {
 
 <!--
   - test: `extensionSyntax`
-  
+
   ```swifttest
   >> protocol SomeProtocol {}
   >> protocol AnotherProtocol {}
@@ -155,7 +155,7 @@ print("Three feet is \(threeFeet) meters")
 
 <!--
   - test: `extensionsComputedProperties`
-  
+
   ```swifttest
   -> extension Double {
         var km: Double { return self * 1_000.0 }
@@ -205,7 +205,7 @@ print("A marathon is \(aMarathon) meters long")
 
 <!--
   - test: `extensionsComputedProperties`
-  
+
   ```swifttest
   -> let aMarathon = 42.km + 195.m
   -> print("A marathon is \(aMarathon) meters long")
@@ -218,7 +218,7 @@ print("A marathon is \(aMarathon) meters long")
 
 <!--
   - test: `extensionsCannotAddStoredProperties`
-  
+
   ```swifttest
   -> class C {}
   -> extension C { var x = 0 }
@@ -278,7 +278,7 @@ struct Rect {
 
 <!--
   - test: `extensionsInitializers`
-  
+
   ```swifttest
   -> struct Size {
         var width = 0.0, height = 0.0
@@ -306,7 +306,7 @@ let memberwiseRect = Rect(origin: Point(x: 2.0, y: 2.0),
 
 <!--
   - test: `extensionsInitializers`
-  
+
   ```swifttest
   -> let defaultRect = Rect()
   -> let memberwiseRect = Rect(origin: Point(x: 2.0, y: 2.0),
@@ -329,7 +329,7 @@ extension Rect {
 
 <!--
   - test: `extensionsInitializers`
-  
+
   ```swifttest
   -> extension Rect {
         init(center: Point, size: Size) {
@@ -355,7 +355,7 @@ let centerRect = Rect(center: Point(x: 4.0, y: 4.0),
 
 <!--
   - test: `extensionsInitializers`
-  
+
   ```swifttest
   -> let centerRect = Rect(center: Point(x: 4.0, y: 4.0),
         size: Size(width: 3.0, height: 3.0))
@@ -385,7 +385,7 @@ extension Int {
 
 <!--
   - test: `extensionsInstanceMethods`
-  
+
   ```swifttest
   -> extension Int {
         func repetitions(task: () -> Void) {
@@ -415,7 +415,7 @@ to perform a task that many number of times:
 
 <!--
   - test: `extensionsInstanceMethods`
-  
+
   ```swifttest
   -> 3.repetitions {
         print("Hello!")
@@ -449,7 +449,7 @@ someInt.square()
 
 <!--
   - test: `extensionsInstanceMethods`
-  
+
   ```swifttest
   -> extension Int {
         mutating func square() {
@@ -497,7 +497,7 @@ extension Int {
 
 <!--
   - test: `extensionsSubscripts`
-  
+
   ```swifttest
   -> extension Int {
         subscript(digitIndex: Int) -> Int {
@@ -550,7 +550,7 @@ as if the number had been padded with zeros to the left:
 
 <!--
   - test: `extensionsSubscripts`
-  
+
   ```swifttest
   >> let r4 =
   -> 746381295[9]
@@ -594,7 +594,7 @@ extension Int {
 
 <!--
   - test: `extensionsNestedTypes`
-  
+
   ```swifttest
   -> extension Int {
         enum Kind {
@@ -646,7 +646,7 @@ printIntegerKinds([3, 19, -27, 0, -6, 0, 7])
 
 <!--
   - test: `extensionsNestedTypes`
-  
+
   ```swifttest
   -> func printIntegerKinds(_ numbers: [Int]) {
         for number in numbers {

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Functions.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Functions.md
@@ -56,7 +56,7 @@ func greet(person: String) -> String {
 
 <!--
   - test: `definingAndCalling`
-  
+
   ```swifttest
   -> func greet(person: String) -> String {
         let greeting = "Hello, " + person + "!"
@@ -86,7 +86,7 @@ print(greet(person: "Brian"))
 
 <!--
   - test: `definingAndCalling`
-  
+
   ```swifttest
   -> print(greet(person: "Anna"))
   <- Hello, Anna!
@@ -134,7 +134,7 @@ print(greetAgain(person: "Anna"))
 
 <!--
   - test: `definingAndCalling`
-  
+
   ```swifttest
   -> func greetAgain(person: String) -> String {
         return "Hello again, " + person + "!"
@@ -166,7 +166,7 @@ print(sayHelloWorld())
 
 <!--
   - test: `functionsWithoutParameters`
-  
+
   ```swifttest
   -> func sayHelloWorld() -> String {
         return "hello, world"
@@ -204,7 +204,7 @@ print(greet(person: "Tim", alreadyGreeted: true))
 
 <!--
   - test: `definingAndCalling`
-  
+
   ```swifttest
   -> func greet(person: String, alreadyGreeted: Bool) -> String {
          if alreadyGreeted {
@@ -244,7 +244,7 @@ greet(person: "Dave")
 
 <!--
   - test: `functionsWithoutReturnValues`
-  
+
   ```swifttest
   -> func greet(person: String) {
         print("Hello, \(person)!")
@@ -282,7 +282,7 @@ printWithoutCounting(string: "hello, world")
 
 <!--
   - test: `functionsWithoutReturnValues`
-  
+
   ```swifttest
   -> func printAndCount(string: String) -> Int {
         print(string)
@@ -352,7 +352,7 @@ func minMax(array: [Int]) -> (min: Int, max: Int) {
 
 <!--
   - test: `tupleTypesAsReturnTypes`
-  
+
   ```swifttest
   -> func minMax(array: [Int]) -> (min: Int, max: Int) {
         var currentMin = array[0]
@@ -393,7 +393,7 @@ print("min is \(bounds.min) and max is \(bounds.max)")
 
 <!--
   - test: `tupleTypesAsReturnTypes`
-  
+
   ```swifttest
   -> let bounds = minMax(array: [8, -6, 2, 109, 3, 71])
   -> print("min is \(bounds.min) and max is \(bounds.max)")
@@ -449,7 +449,7 @@ func minMax(array: [Int]) -> (min: Int, max: Int)? {
 
 <!--
   - test: `tupleTypesAsReturnTypes2`
-  
+
   ```swifttest
   -> func minMax(array: [Int]) -> (min: Int, max: Int)? {
         if array.isEmpty { return nil }
@@ -479,7 +479,7 @@ if let bounds = minMax(array: [8, -6, 2, 109, 3, 71]) {
 
 <!--
   - test: `tupleTypesAsReturnTypes2`
-  
+
   ```swifttest
   -> if let bounds = minMax(array: [8, -6, 2, 109, 3, 71]) {
         print("min is \(bounds.min) and max is \(bounds.max)")
@@ -511,7 +511,7 @@ print(anotherGreeting(for: "Dave"))
 
 <!--
   - test: `implicit-func-return`
-  
+
   ```swifttest
   -> func greeting(for person: String) -> String {
         "Hello, " + person + "!"
@@ -549,7 +549,7 @@ property getters can also use an implicit return.
 
 <!--
   - test: `implicit-return-print-instead`
-  
+
   ```swifttest
   // This is ok:
   >> func testFatal() -> Int {
@@ -586,7 +586,7 @@ someFunction(firstParameterName: 1, secondParameterName: 2)
 
 <!--
   - test: `functionParameterNames`
-  
+
   ```swifttest
   -> func someFunction(firstParameterName: Int, secondParameterName: Int) {
         // In the function body, firstParameterName and secondParameterName
@@ -603,7 +603,7 @@ unique argument labels help make your code more readable.
 
 <!--
   - test: `non-unique-external-name`
-  
+
   ```swifttest
   -> func foo(external a: Int, external b: Int) {}
   -> foo(external: 7, external: 12)
@@ -624,7 +624,7 @@ func someFunction(argumentLabel parameterName: Int) {
 
 <!--
   - test: `externalParameterNames`
-  
+
   ```swifttest
   -> func someFunction(argumentLabel parameterName: Int) {
         // In the function body, parameterName refers to the argument value
@@ -647,7 +647,7 @@ print(greet(person: "Bill", from: "Cupertino"))
 
 <!--
   - test: `externalParameterNames`
-  
+
   ```swifttest
   -> func greet(person: String, from hometown: String) -> String {
          return "Hello \(person)!  Glad you could visit from \(hometown)."
@@ -676,7 +676,7 @@ someFunction(1, secondParameterName: 2)
 
 <!--
   - test: `omittedExternalParameterNames`
-  
+
   ```swifttest
   -> func someFunction(_ firstParameterName: Int, secondParameterName: Int) {
         // In the function body, firstParameterName and secondParameterName
@@ -706,7 +706,7 @@ someFunction(parameterWithoutDefault: 4) // parameterWithDefault is 12
 
 <!--
   - test: `omittedExternalParameterNames`
-  
+
   ```swifttest
   -> func someFunction(parameterWithoutDefault: Int, parameterWithDefault: Int = 12) {
         // If you omit the second argument when calling this function, then
@@ -759,7 +759,7 @@ arithmeticMean(3, 8.25, 18.75)
 
 <!--
   - test: `variadicParameters`
-  
+
   ```swifttest
   -> func arithmeticMean(_ numbers: Double...) -> Double {
         var total: Double = 0
@@ -794,7 +794,7 @@ that come after the variadic parameter.
 
 <!--
   - test: `variadic-parameters-and-labels`
-  
+
   ```swifttest
   // Labeled, immediately after
   >> func f(_ a: Int..., b: String) {}
@@ -809,7 +809,7 @@ that come after the variadic parameter.
 
 <!--
   - test: `variadic-parameters-and-labels-failure`
-  
+
   ```swifttest
   // Unlabeled, immediately after
   >> func f(_ a: Int..., _ b: String) {}
@@ -861,7 +861,7 @@ func swapTwoInts(_ a: inout Int, _ b: inout Int) {
 
 <!--
   - test: `inoutParameters`
-  
+
   ```swifttest
   -> func swapTwoInts(_ a: inout Int, _ b: inout Int) {
         let temporaryA = a
@@ -892,7 +892,7 @@ print("someInt is now \(someInt), and anotherInt is now \(anotherInt)")
 
 <!--
   - test: `inoutParameters`
-  
+
   ```swifttest
   -> var someInt = 3
   -> var anotherInt = 107
@@ -936,7 +936,7 @@ func multiplyTwoInts(_ a: Int, _ b: Int) -> Int {
 
 <!--
   - test: `functionTypes`
-  
+
   ```swifttest
   -> func addTwoInts(_ a: Int, _ b: Int) -> Int {
         return a + b
@@ -973,7 +973,7 @@ func printHelloWorld() {
 
 <!--
   - test: `functionTypes`
-  
+
   ```swifttest
   -> func printHelloWorld() {
         print("hello, world")
@@ -998,7 +998,7 @@ var mathFunction: (Int, Int) -> Int = addTwoInts
 
 <!--
   - test: `functionTypes`
-  
+
   ```swifttest
   -> var mathFunction: (Int, Int) -> Int = addTwoInts
   ```
@@ -1023,7 +1023,7 @@ print("Result: \(mathFunction(2, 3))")
 
 <!--
   - test: `functionTypes`
-  
+
   ```swifttest
   -> print("Result: \(mathFunction(2, 3))")
   <- Result: 5
@@ -1041,7 +1041,7 @@ print("Result: \(mathFunction(2, 3))")
 
 <!--
   - test: `functionTypes`
-  
+
   ```swifttest
   -> mathFunction = multiplyTwoInts
   -> print("Result: \(mathFunction(2, 3))")
@@ -1060,7 +1060,7 @@ let anotherMathFunction = addTwoInts
 
 <!--
   - test: `functionTypes`
-  
+
   ```swifttest
   -> let anotherMathFunction = addTwoInts
   >> print(type(of: anotherMathFunction))
@@ -1092,7 +1092,7 @@ printMathResult(addTwoInts, 3, 5)
 
 <!--
   - test: `functionTypes`
-  
+
   ```swifttest
   -> func printMathResult(_ mathFunction: (Int, Int) -> Int, _ a: Int, _ b: Int) {
         print("Result: \(mathFunction(a, b))")
@@ -1141,7 +1141,7 @@ func stepBackward(_ input: Int) -> Int {
 
 <!--
   - test: `functionTypes`
-  
+
   ```swifttest
   -> func stepForward(_ input: Int) -> Int {
         return input + 1
@@ -1165,7 +1165,7 @@ func chooseStepFunction(backward: Bool) -> (Int) -> Int {
 
 <!--
   - test: `functionTypes`
-  
+
   ```swifttest
   -> func chooseStepFunction(backward: Bool) -> (Int) -> Int {
         return backward ? stepBackward : stepForward
@@ -1184,7 +1184,7 @@ let moveNearerToZero = chooseStepFunction(backward: currentValue > 0)
 
 <!--
   - test: `functionTypes`
-  
+
   ```swifttest
   -> var currentValue = 3
   -> let moveNearerToZero = chooseStepFunction(backward: currentValue > 0)
@@ -1220,7 +1220,7 @@ print("zero!")
 
 <!--
   - test: `functionTypes`
-  
+
   ```swifttest
   -> print("Counting to zero:")
   </ Counting to zero:
@@ -1274,7 +1274,7 @@ print("zero!")
 
 <!--
   - test: `nestedFunctions`
-  
+
   ```swifttest
   -> func chooseStepFunction(backward: Bool) -> (Int) -> Int {
         func stepForward(input: Int) -> Int { return input + 1 }

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Generics.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Generics.md
@@ -34,7 +34,7 @@ func swapTwoInts(_ a: inout Int, _ b: inout Int) {
 
 <!--
   - test: `whyGenerics`
-  
+
   ```swifttest
   -> func swapTwoInts(_ a: inout Int, _ b: inout Int) {
         let temporaryA = a
@@ -61,7 +61,7 @@ print("someInt is now \(someInt), and anotherInt is now \(anotherInt)")
 
 <!--
   - test: `whyGenerics`
-  
+
   ```swifttest
   -> var someInt = 3
   -> var anotherInt = 107
@@ -93,7 +93,7 @@ func swapTwoDoubles(_ a: inout Double, _ b: inout Double) {
 
 <!--
   - test: `whyGenerics`
-  
+
   ```swifttest
   -> func swapTwoStrings(_ a: inout String, _ b: inout String) {
         let temporaryA = a
@@ -145,7 +145,7 @@ func swapTwoValues<T>(_ a: inout T, _ b: inout T) {
 
 <!--
   - test: `genericFunctions`
-  
+
   ```swifttest
   -> func swapTwoValues<T>(_ a: inout T, _ b: inout T) {
         let temporaryA = a
@@ -175,7 +175,7 @@ func swapTwoValues<T>(_ a: inout T, _ b: inout T)
 
 <!--
   - test: `genericFunctionsComparison`
-  
+
   ```swifttest
   -> func swapTwoInts(_ a: inout Int, _ b: inout Int)
   >> {
@@ -230,7 +230,7 @@ swapTwoValues(&someString, &anotherString)
 
 <!--
   - test: `genericFunctions`
-  
+
   ```swifttest
   -> var someInt = 3
   -> var anotherInt = 107
@@ -343,7 +343,7 @@ struct IntStack {
 
 <!--
   - test: `genericStack`
-  
+
   ```swifttest
   -> struct IntStack {
         var items: [Int] = []
@@ -390,7 +390,7 @@ struct Stack<Element> {
 
 <!--
   - test: `genericStack`
-  
+
   ```swifttest
   -> struct Stack<Element> {
         var items: [Element] = []
@@ -444,7 +444,7 @@ stackOfStrings.push("cuatro")
 
 <!--
   - test: `genericStack`
-  
+
   ```swifttest
   -> var stackOfStrings = Stack<String>()
   -> stackOfStrings.push("uno")
@@ -469,7 +469,7 @@ let fromTheTop = stackOfStrings.pop()
 
 <!--
   - test: `genericStack`
-  
+
   ```swifttest
   -> let fromTheTop = stackOfStrings.pop()
   /> fromTheTop is equal to \"\(fromTheTop)\", and the stack now contains \(stackOfStrings.items.count) strings
@@ -504,7 +504,7 @@ extension Stack {
 
 <!--
   - test: `genericStack`
-  
+
   ```swifttest
   -> extension Stack {
         var topItem: Element? {
@@ -535,7 +535,7 @@ if let topItem = stackOfStrings.topItem {
 
 <!--
   - test: `genericStack`
-  
+
   ```swifttest
   -> if let topItem = stackOfStrings.topItem {
         print("The top item on the stack is \(topItem).")
@@ -602,7 +602,7 @@ func someFunction<T: SomeClass, U: SomeProtocol>(someT: T, someU: U) {
 
 <!--
   - test: `typeConstraints`
-  
+
   ```swifttest
   >> class SomeClass {}
   >> protocol SomeProtocol {}
@@ -640,7 +640,7 @@ func findIndex(ofString valueToFind: String, in array: [String]) -> Int? {
 
 <!--
   - test: `typeConstraints`
-  
+
   ```swifttest
   -> func findIndex(ofString valueToFind: String, in array: [String]) -> Int? {
         for (index, value) in array.enumerated() {
@@ -665,7 +665,7 @@ if let foundIndex = findIndex(ofString: "llama", in: strings) {
 
 <!--
   - test: `typeConstraints`
-  
+
   ```swifttest
   -> let strings = ["cat", "dog", "llama", "parakeet", "terrapin"]
   -> if let foundIndex = findIndex(ofString: "llama", in: strings) {
@@ -700,7 +700,7 @@ func findIndex<T>(of valueToFind: T, in array:[T]) -> Int? {
 
 <!--
   - test: `typeConstraints-err`
-  
+
   ```swifttest
   -> func findIndex<T>(of valueToFind: T, in array:[T]) -> Int? {
         for (index, value) in array.enumerated() {
@@ -759,7 +759,7 @@ func findIndex<T: Equatable>(of valueToFind: T, in array:[T]) -> Int? {
 
 @Comment {
   - test: `typeConstraintsEquatable`
-  
+
   ```swifttest
   -> func findIndex<T: Equatable>(of valueToFind: T, in array:[T]) -> Int? {
         for (index, value) in array.enumerated() {
@@ -787,7 +787,7 @@ let stringIndex = findIndex(of: "Andrea", in: ["Mike", "Malcolm", "Andrea"])
 
 @Comment {
   - test: `typeConstraintsEquatable`
-  
+
   ```swifttest
   -> let doubleIndex = findIndex(of: 9.3, in: [3.14159, 0.1, 0.25])
   /> doubleIndex is an optional Int with no value, because 9.3 isn't in the array
@@ -833,7 +833,7 @@ protocol Container {
 
 @Comment {
   - test: `associatedTypes, associatedTypes-err`
-  
+
   ```swifttest
   -> protocol Container {
         associatedtype Item
@@ -916,7 +916,7 @@ struct IntStack: Container {
 
 @Comment {
   - test: `associatedTypes`
-  
+
   ```swifttest
   -> struct IntStack: Container {
         // original IntStack implementation
@@ -988,7 +988,7 @@ struct Stack<Element>: Container {
 
 @Comment {
   - test: `associatedTypes, associatedTypes-err`
-  
+
   ```swifttest
   -> struct Stack<Element>: Container {
         // original Stack<Element> implementation
@@ -1039,7 +1039,7 @@ extension Array: Container {}
 
 @Comment {
   - test: `associatedTypes`
-  
+
   ```swifttest
   -> extension Array: Container {}
   ```
@@ -1069,7 +1069,7 @@ protocol Container {
 
 @Comment {
   - test: `associatedTypes-equatable`
-  
+
   ```swifttest
   -> protocol Container {
         associatedtype Item: Equatable
@@ -1102,7 +1102,7 @@ protocol SuffixableContainer: Container {
 
 @Comment {
   - test: `associatedTypes`
-  
+
   ```swifttest
   -> protocol SuffixableContainer: Container {
          associatedtype Suffix: SuffixableContainer where Suffix.Item == Item
@@ -1147,7 +1147,7 @@ let suffix = stackOfInts.suffix(2)
 
 @Comment {
   - test: `associatedTypes`
-  
+
   ```swifttest
   -> extension Stack: SuffixableContainer {
          func suffix(_ size: Int) -> Stack {
@@ -1197,7 +1197,7 @@ extension IntStack: SuffixableContainer {
 
 @Comment {
   - test: `associatedTypes`
-  
+
   ```swifttest
   -> extension IntStack: SuffixableContainer {
          func suffix(_ size: Int) -> Stack<Int> {
@@ -1271,7 +1271,7 @@ func allItemsMatch<C1: Container, C2: Container>
 
 @Comment {
   - test: `associatedTypes`
-  
+
   ```swifttest
   -> func allItemsMatch<C1: Container, C2: Container>
            (_ someContainer: C1, _ anotherContainer: C2) -> Bool
@@ -1364,7 +1364,7 @@ if allItemsMatch(stackOfStrings, arrayOfStrings) {
 
 @Comment {
   - test: `associatedTypes`
-  
+
   ```swifttest
   -> var stackOfStrings = Stack<String>()
   -> stackOfStrings.push("uno")
@@ -1414,7 +1414,7 @@ extension Stack where Element: Equatable {
 
 @Comment {
   - test: `associatedTypes`
-  
+
   ```swifttest
   -> extension Stack where Element: Equatable {
          func isTop(_ item: Element) -> Bool {
@@ -1455,7 +1455,7 @@ if stackOfStrings.isTop("tres") {
 
 @Comment {
   - test: `associatedTypes`
-  
+
   ```swifttest
   -> if stackOfStrings.isTop("tres") {
         print("Top element is tres.")
@@ -1480,7 +1480,7 @@ notEquatableStack.isTop(notEquatableValue)  // Error
 
 @Comment {
   - test: `associatedTypes-err`
-  
+
   ```swifttest
   -> struct NotEquatable { }
   -> var notEquatableStack = Stack<NotEquatable>()
@@ -1507,7 +1507,7 @@ extension Container where Item: Equatable {
 
 @Comment {
   - test: `associatedTypes`
-  
+
   ```swifttest
   -> extension Container where Item: Equatable {
         func startsWith(_ item: Item) -> Bool {
@@ -1543,7 +1543,7 @@ if [9, 9, 9].startsWith(42) {
 
 @Comment {
   - test: `associatedTypes`
-  
+
   ```swifttest
   -> if [9, 9, 9].startsWith(42) {
         print("Starts with 42.")
@@ -1576,7 +1576,7 @@ print([1260.0, 1200.0, 98.6, 37.0].average())
 
 @Comment {
   - test: `associatedTypes`
-  
+
   ```swifttest
   -> extension Container where Item == Double {
          func average() -> Double {
@@ -1646,7 +1646,7 @@ print(numbers.endsWith(37))
 
 @Comment {
   - test: `associatedTypes`
-  
+
   ```swifttest
   -> extension Container {
          func average() -> Double where Item == Int {
@@ -1699,7 +1699,7 @@ extension Container where Item: Equatable {
 
 @Comment {
   - test: `associatedTypes-err`
-  
+
   ```swifttest
   -> extension Container where Item == Int {
          func average() -> Double {
@@ -1750,7 +1750,7 @@ protocol Container {
 
 @Comment {
   - test: `associatedTypes-iterator`
-  
+
   ```swifttest
   -> protocol Container {
         associatedtype Item
@@ -1778,23 +1778,23 @@ The `makeIterator()` function provides access to a container's iterator.
 @Comment {
   This example requires SE-0157 Recursive protocol constraints
   which is tracked by rdar://20531108
-  
+
    that accepts a ranged of indexes it its subscript
    and returns a subcontainer ---
    similar to how ``Collection`` works in the standard library.
-  
+
    .. testcode:: associatedTypes-subcontainer
-  
+
       -> protocol Container {
             associatedtype Item
             associatedtype SubContainer: Container where SubContainer.Item == Item
-  
+
             mutating func append(_ item: Item)
             var count: Int { get }
             subscript(i: Int) -> Item { get }
             subscript(range: Range<Int>) -> SubContainer { get }
          }
-  
+
    The generic ``where`` clause on ``SubContainer`` requires that
    the subcontainer must have the same item type as the container has,
    regardless of what type the subcontainer is.
@@ -1818,7 +1818,7 @@ protocol ComparableContainer: Container where Item: Comparable { }
 
 @Comment {
   - test: `associatedTypes`
-  
+
   ```swifttest
   -> protocol ComparableContainer: Container where Item: Comparable { }
   ```
@@ -1828,7 +1828,7 @@ protocol ComparableContainer: Container where Item: Comparable { }
   This version throws a warning as of Swift commit de66b0c25c70:
   "redeclaration of associated type %0 from protocol %1 is better
   expressed as a 'where' clause on the protocol"
-  
+
    -> protocol ComparableContainer: Container {
           associatedtype Item: Comparable
       }
@@ -1837,7 +1837,7 @@ protocol ComparableContainer: Container where Item: Comparable { }
 @Comment {
   Exercise the new container -- this might not actually be needed,
   and it adds a level of complexity.
-  
+
   function < (lhs: ComparableContainer, rhs: ComparableContainer) -> Bool {
       // Sort empty containers before nonempty containers.
       if lhs.count == 0 {
@@ -1845,7 +1845,7 @@ protocol ComparableContainer: Container where Item: Comparable { }
       } else if rhs.count  == 0 {
           return false
       }
-  
+
       // Sort nonempty containers by their first element.
       // (In real code, you would want to compare the second element
       // if the first elements are equal, and so on.)
@@ -1882,7 +1882,7 @@ extension Container {
 
 @Comment {
   - test: `genericSubscript`
-  
+
   ```swifttest
   >> protocol Container {
   >>    associatedtype Item
@@ -1905,7 +1905,7 @@ extension Container {
 
 @Comment {
   - test: `genericSubscript`
-  
+
   ```swifttest
   >> struct IntStack: Container {
         // original IntStack implementation

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Inheritance.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Inheritance.md
@@ -55,7 +55,7 @@ class Vehicle {
 
 <!--
   - test: `inheritance`
-  
+
   ```swifttest
   -> class Vehicle {
         var currentSpeed = 0.0
@@ -78,7 +78,7 @@ let someVehicle = Vehicle()
 
 <!--
   - test: `inheritance`
-  
+
   ```swifttest
   -> let someVehicle = Vehicle()
   ```
@@ -95,7 +95,7 @@ print("Vehicle: \(someVehicle.description)")
 
 <!--
   - test: `inheritance`
-  
+
   ```swifttest
   -> print("Vehicle: \(someVehicle.description)")
   </ Vehicle: traveling at 0.0 miles per hour
@@ -125,7 +125,7 @@ class SomeSubclass: SomeSuperclass {
 
 <!--
   - test: `protocolSyntax`
-  
+
   ```swifttest
   >> class SomeSuperclass {}
   -> class SomeSubclass: SomeSuperclass {
@@ -145,7 +145,7 @@ class Bicycle: Vehicle {
 
 <!--
   - test: `inheritance`
-  
+
   ```swifttest
   -> class Bicycle: Vehicle {
         var hasBasket = false
@@ -172,7 +172,7 @@ bicycle.hasBasket = true
 
 <!--
   - test: `inheritance`
-  
+
   ```swifttest
   -> let bicycle = Bicycle()
   -> bicycle.hasBasket = true
@@ -190,7 +190,7 @@ print("Bicycle: \(bicycle.description)")
 
 <!--
   - test: `inheritance`
-  
+
   ```swifttest
   -> bicycle.currentSpeed = 15.0
   -> print("Bicycle: \(bicycle.description)")
@@ -210,7 +210,7 @@ class Tandem: Bicycle {
 
 <!--
   - test: `inheritance`
-  
+
   ```swifttest
   -> class Tandem: Bicycle {
         var currentNumberOfPassengers = 0
@@ -238,7 +238,7 @@ print("Tandem: \(tandem.description)")
 
 <!--
   - test: `inheritance`
-  
+
   ```swifttest
   -> let tandem = Tandem()
   -> tandem.hasBasket = true
@@ -306,7 +306,7 @@ class Train: Vehicle {
 
 <!--
   - test: `inheritance`
-  
+
   ```swifttest
   -> class Train: Vehicle {
         override func makeNoise() {
@@ -327,7 +327,7 @@ train.makeNoise()
 
 <!--
   - test: `inheritance`
-  
+
   ```swifttest
   -> let train = Train()
   -> train.makeNoise()
@@ -383,7 +383,7 @@ class Car: Vehicle {
 
 <!--
   - test: `inheritance`
-  
+
   ```swifttest
   -> class Car: Vehicle {
         var gear = 1
@@ -414,7 +414,7 @@ print("Car: \(car.description)")
 
 <!--
   - test: `inheritance`
-  
+
   ```swifttest
   -> let car = Car()
   -> car.currentSpeed = 25.0
@@ -458,7 +458,7 @@ class AutomaticCar: Car {
 
 <!--
   - test: `inheritance`
-  
+
   ```swifttest
   -> class AutomaticCar: Car {
         override var currentSpeed: Double {
@@ -487,7 +487,7 @@ print("AutomaticCar: \(automatic.description)")
 
 <!--
   - test: `inheritance`
-  
+
   ```swifttest
   -> let automatic = AutomaticCar()
   -> automatic.currentSpeed = 35.0
@@ -511,7 +511,7 @@ can also be marked as final within the extension's definition.
 
 <!--
   - test: `finalPreventsOverriding`
-  
+
   ```swifttest
   -> class C {
         final var someVar = 0
@@ -549,7 +549,7 @@ Any attempt to subclass a final class is reported as a compile-time error.
 
 <!--
   - test: `finalClassPreventsOverriding`
-  
+
   ```swifttest
   -> final class C {
         var someVar = 0
@@ -599,7 +599,7 @@ Any attempt to subclass a final class is reported as a compile-time error.
 <!--
   TODO: Mention that you can return more-specific types, and take less-specific types,
   when overriding methods that use optionals / unchecked optionals.
-  
+
   TODO: Overriding Type Methods
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 -->

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Initialization.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Initialization.md
@@ -49,7 +49,7 @@ init() {
 
 <!--
   - test: `initializerSyntax`
-  
+
   ```swifttest
   >> class Test {
   -> init() {
@@ -78,7 +78,7 @@ print("The default temperature is \(f.temperature)° Fahrenheit")
 
 <!--
   - test: `fahrenheitInit`
-  
+
   ```swifttest
   -> struct Fahrenheit {
         var temperature: Double
@@ -127,7 +127,7 @@ struct Fahrenheit {
 
 <!--
   - test: `fahrenheitDefault`
-  
+
   ```swifttest
   -> struct Fahrenheit {
         var temperature = 32.0
@@ -174,7 +174,7 @@ let freezingPointOfWater = Celsius(fromKelvin: 273.15)
 
 <!--
   - test: `initialization`
-  
+
   ```swifttest
   -> struct Celsius {
         var temperatureInCelsius: Double
@@ -250,7 +250,7 @@ struct Color {
 
 <!--
   - test: `externalParameterNames, externalParameterNames-err`
-  
+
   ```swifttest
   -> struct Color {
         let red, green, blue: Double
@@ -278,7 +278,7 @@ let halfGray = Color(white: 0.5)
 
 <!--
   - test: `externalParameterNames`
-  
+
   ```swifttest
   -> let magenta = Color(red: 1.0, green: 0.0, blue: 1.0)
   -> let halfGray = Color(white: 0.5)
@@ -300,7 +300,7 @@ let veryGreen = Color(0.0, 1.0, 0.0)
 
 <!--
   - test: `externalParameterNames-err`
-  
+
   ```swifttest
   -> let veryGreen = Color(0.0, 1.0, 0.0)
   // this reports a compile-time error - argument labels are required
@@ -341,7 +341,7 @@ let bodyTemperature = Celsius(37.0)
 
 <!--
   - test: `initializersWithoutExternalParameterNames`
-  
+
   ```swifttest
   -> struct Celsius {
         var temperatureInCelsius: Double
@@ -398,7 +398,7 @@ cheeseQuestion.response = "Yes, I do like cheese."
 
 <!--
   - test: `surveyQuestionVariable`
-  
+
   ```swifttest
   -> class SurveyQuestion {
         var text: String
@@ -433,7 +433,7 @@ it can't be further modified.
 
 <!--
   - test: `constantPropertyAssignment`
-  
+
   ```swifttest
   >> struct S {
         let c: Int
@@ -454,7 +454,7 @@ it can't be further modified.
 
 <!--
   - test: `constantPropertyAssignmentWithInitialValue`
-  
+
   ```swifttest
   >> struct S {
         let c: Int = 0
@@ -505,7 +505,7 @@ beetsQuestion.response = "I also like beets. (But not with cheese.)"
 
 <!--
   - test: `surveyQuestionConstant`
-  
+
   ```swifttest
   -> class SurveyQuestion {
         let text: String
@@ -535,7 +535,7 @@ with all of its properties set to their default values.
 
 <!--
   - test: `defaultInitializersForStructAndClass`
-  
+
   ```swifttest
   -> struct S { var s: String = "s" }
   -> assert(S().s == "s")
@@ -562,7 +562,7 @@ var item = ShoppingListItem()
 
 <!--
   - test: `initialization`
-  
+
   ```swifttest
   -> class ShoppingListItem {
         var name: String?
@@ -595,7 +595,7 @@ even if it has stored properties that don't have default values.
 
 <!--
   - test: `memberwiseInitializersDontRequireDefaultStoredPropertyValues`
-  
+
   ```swifttest
   -> struct S { var int: Int; var string: String }
   -> let s = S(int: 42, string: "hello")
@@ -628,7 +628,7 @@ let twoByTwo = Size(width: 2.0, height: 2.0)
 
 <!--
   - test: `initialization`
-  
+
   ```swifttest
   -> struct Size {
         var width = 0.0, height = 0.0
@@ -659,7 +659,7 @@ print(zeroByZero.width, zeroByZero.height)
 
 <!--
   - test: `initialization`
-  
+
   ```swifttest
   -> let zeroByTwo = Size(height: 2.0)
   -> print(zeroByTwo.width, zeroByTwo.height)
@@ -723,7 +723,7 @@ struct Point {
 
 <!--
   - test: `valueDelegation`
-  
+
   ```swifttest
   -> struct Size {
         var width = 0.0, height = 0.0
@@ -760,7 +760,7 @@ struct Rect {
 
 <!--
   - test: `valueDelegation`
-  
+
   ```swifttest
   -> struct Rect {
         var origin = Point()
@@ -797,7 +797,7 @@ let basicRect = Rect()
 
 <!--
   - test: `valueDelegation`
-  
+
   ```swifttest
   -> let basicRect = Rect()
   /> basicRect's origin is (\(basicRect.origin.x), \(basicRect.origin.y)) and its size is (\(basicRect.size.width), \(basicRect.size.height))
@@ -819,7 +819,7 @@ let originRect = Rect(origin: Point(x: 2.0, y: 2.0),
 
 <!--
   - test: `valueDelegation`
-  
+
   ```swifttest
   -> let originRect = Rect(origin: Point(x: 2.0, y: 2.0),
         size: Size(width: 5.0, height: 5.0))
@@ -842,7 +842,7 @@ let centerRect = Rect(center: Point(x: 4.0, y: 4.0),
 
 <!--
   - test: `valueDelegation`
-  
+
   ```swifttest
   -> let centerRect = Rect(center: Point(x: 4.0, y: 4.0),
         size: Size(width: 3.0, height: 3.0))
@@ -1113,7 +1113,7 @@ and validates that the parameters for your overriding initializer have been spec
 
 <!--
   - test: `youHaveToWriteOverrideWhenOverridingADesignatedInitializer`
-  
+
   ```swifttest
   -> class C {
         init() {}
@@ -1138,7 +1138,7 @@ and validates that the parameters for your overriding initializer have been spec
 
 <!--
   - test: `youHaveToWriteOverrideEvenWhenOverridingADefaultInitializer`
-  
+
   ```swifttest
   -> class C {
         var i = 0
@@ -1170,7 +1170,7 @@ a matching implementation of a superclass convenience initializer.
 
 <!--
   - test: `youDoNotAndCannotWriteOverrideWhenOverridingAConvenienceInitializer`
-  
+
   ```swifttest
   -> class C {
         var i: Int
@@ -1227,7 +1227,7 @@ class Vehicle {
 
 <!--
   - test: `initializerInheritance`
-  
+
   ```swifttest
   -> class Vehicle {
         var numberOfWheels = 0
@@ -1253,7 +1253,7 @@ print("Vehicle: \(vehicle.description)")
 
 <!--
   - test: `initializerInheritance`
-  
+
   ```swifttest
   -> let vehicle = Vehicle()
   -> print("Vehicle: \(vehicle.description)")
@@ -1274,7 +1274,7 @@ class Bicycle: Vehicle {
 
 <!--
   - test: `initializerInheritance`
-  
+
   ```swifttest
   -> class Bicycle: Vehicle {
         override init() {
@@ -1308,7 +1308,7 @@ print("Bicycle: \(bicycle.description)")
 
 <!--
   - test: `initializerInheritance`
-  
+
   ```swifttest
   -> let bicycle = Bicycle()
   -> print("Bicycle: \(bicycle.description)")
@@ -1345,7 +1345,7 @@ class Hoverboard: Vehicle {
 
 <!--
   - test: `initializerInheritance`
-  
+
   ```swifttest
   -> class Hoverboard: Vehicle {
          var color: String
@@ -1371,7 +1371,7 @@ print("Hoverboard: \(hoverboard.description)")
 
 <!--
   - test: `initializerInheritance`
-  
+
   ```swifttest
   -> let hoverboard = Hoverboard(color: "silver")
   -> print("Hoverboard: \(hoverboard.description)")
@@ -1384,7 +1384,7 @@ print("Hoverboard: \(hoverboard.description)")
 
 <!--
   - test: `youCantModifyInheritedConstantPropertiesFromASuperclass`
-  
+
   ```swifttest
   -> class C {
         let constantProperty: Int
@@ -1482,7 +1482,7 @@ class Food {
 
 <!--
   - test: `designatedConvenience`
-  
+
   ```swifttest
   -> class Food {
         var name: String
@@ -1512,7 +1512,7 @@ let namedMeat = Food(name: "Bacon")
 
 <!--
   - test: `designatedConvenience`
-  
+
   ```swifttest
   -> let namedMeat = Food(name: "Bacon")
   /> namedMeat's name is \"\(namedMeat.name)\"
@@ -1540,7 +1540,7 @@ let mysteryMeat = Food()
 
 <!--
   - test: `designatedConvenience`
-  
+
   ```swifttest
   -> let mysteryMeat = Food()
   /> mysteryMeat's name is \"\(mysteryMeat.name)\"
@@ -1569,7 +1569,7 @@ class RecipeIngredient: Food {
 
 <!--
   - test: `designatedConvenience`
-  
+
   ```swifttest
   -> class RecipeIngredient: Food {
         var quantity: Int
@@ -1640,7 +1640,7 @@ let sixEggs = RecipeIngredient(name: "Eggs", quantity: 6)
 
 <!--
   - test: `designatedConvenience`
-  
+
   ```swifttest
   -> let oneMysteryItem = RecipeIngredient()
   -> let oneBacon = RecipeIngredient(name: "Bacon")
@@ -1672,7 +1672,7 @@ class ShoppingListItem: RecipeIngredient {
 
 <!--
   - test: `designatedConvenience`
-  
+
   ```swifttest
   -> class ShoppingListItem: RecipeIngredient {
         var purchased = false
@@ -1719,7 +1719,7 @@ for item in breakfastList {
 
 <!--
   - test: `designatedConvenience`
-  
+
   ```swifttest
   -> var breakfastList = [
         ShoppingListItem(),
@@ -1783,7 +1783,7 @@ by placing a question mark after the `init` keyword (`init?`).
 
 <!--
   - test: `failableAndNonFailableInitializersCannotMatch`
-  
+
   ```swifttest
   -> struct S {
         let s: String
@@ -1835,7 +1835,7 @@ if valueChanged == nil {
 
 <!--
   - test: `failableInitializers`
-  
+
   ```swifttest
   -> let wholeNumber: Double = 12345.0
   -> let pi = 3.14159
@@ -1875,7 +1875,7 @@ struct Animal {
 
 <!--
   - test: `failableInitializers`
-  
+
   ```swifttest
   -> struct Animal {
         let species: String
@@ -1902,7 +1902,7 @@ if let giraffe = someCreature {
 
 <!--
   - test: `failableInitializers`
-  
+
   ```swifttest
   -> let someCreature = Animal(species: "Giraffe")
   // someCreature is of type Animal?, not Animal
@@ -1929,7 +1929,7 @@ if anonymousCreature == nil {
 
 <!--
   - test: `failableInitializers`
-  
+
   ```swifttest
   -> let anonymousCreature = Animal(species: "")
   // anonymousCreature is of type Animal?, not Animal
@@ -1981,7 +1981,7 @@ enum TemperatureUnit {
 
 <!--
   - test: `failableInitializers`
-  
+
   ```swifttest
   -> enum TemperatureUnit {
         case kelvin, celsius, fahrenheit
@@ -2022,7 +2022,7 @@ if unknownUnit == nil {
 
 <!--
   - test: `failableInitializers`
-  
+
   ```swifttest
   -> let fahrenheitUnit = TemperatureUnit(symbol: "F")
   -> if fahrenheitUnit != nil {
@@ -2070,7 +2070,7 @@ if unknownUnit == nil {
 
 <!--
   - test: `failableInitializersForEnumerations`
-  
+
   ```swifttest
   -> enum TemperatureUnit: Character {
         case kelvin = "K", celsius = "C", fahrenheit = "F"
@@ -2102,7 +2102,7 @@ and no further initialization code is executed.
 
 <!--
   - test: `delegatingAcrossInAStructurePropagatesInitializationFailureImmediately`
-  
+
   ```swifttest
   -> struct S {
         init?(string1: String) {
@@ -2118,7 +2118,7 @@ and no further initialization code is executed.
 
 <!--
   - test: `delegatingAcrossInAClassPropagatesInitializationFailureImmediately`
-  
+
   ```swifttest
   -> class C {
         convenience init?(string1: String) {
@@ -2134,7 +2134,7 @@ and no further initialization code is executed.
 
 <!--
   - test: `delegatingUpInAClassPropagatesInitializationFailureImmediately`
-  
+
   ```swifttest
   -> class C {
         init?(string1: String) { return nil }
@@ -2180,7 +2180,7 @@ class CartItem: Product {
 
 <!--
   - test: `failableInitializers`
-  
+
   ```swifttest
   -> class Product {
         let name: String
@@ -2224,7 +2224,7 @@ if let twoSocks = CartItem(name: "sock", quantity: 2) {
 
 <!--
   - test: `failableInitializers`
-  
+
   ```swifttest
   -> if let twoSocks = CartItem(name: "sock", quantity: 2) {
         print("Item: \(twoSocks.name), quantity: \(twoSocks.quantity)")
@@ -2247,7 +2247,7 @@ if let zeroShirts = CartItem(name: "shirt", quantity: 0) {
 
 <!--
   - test: `failableInitializers`
-  
+
   ```swifttest
   -> if let zeroShirts = CartItem(name: "shirt", quantity: 0) {
         print("Item: \(zeroShirts.name), quantity: \(zeroShirts.quantity)")
@@ -2272,7 +2272,7 @@ if let oneUnnamed = CartItem(name: "", quantity: 1) {
 
 <!--
   - test: `failableInitializers`
-  
+
   ```swifttest
   -> if let oneUnnamed = CartItem(name: "", quantity: 1) {
         print("Item: \(oneUnnamed.name), quantity: \(oneUnnamed.quantity)")
@@ -2301,7 +2301,7 @@ is to force-unwrap the result of the failable superclass initializer.
 
 <!--
   - test: `youCannotOverrideANonFailableInitializerWithAFailableInitializer`
-  
+
   ```swifttest
   -> class C {
         init() {}
@@ -2338,7 +2338,7 @@ class Document {
 
 <!--
   - test: `failableInitializers`
-  
+
   ```swifttest
   -> class Document {
         var name: String?
@@ -2380,7 +2380,7 @@ class AutomaticallyNamedDocument: Document {
 
 <!--
   - test: `failableInitializers`
-  
+
   ```swifttest
   -> class AutomaticallyNamedDocument: Document {
         override init() {
@@ -2423,7 +2423,7 @@ class UntitledDocument: Document {
 
 <!--
   - test: `failableInitializers`
-  
+
   ```swifttest
   -> class UntitledDocument: Document {
         override init() {
@@ -2458,7 +2458,7 @@ if the `init!` initializer causes initialization to fail.
 
 <!--
   - test: `structuresCanDelegateAcrossFromOptionalToIUO`
-  
+
   ```swifttest
   -> struct S {
         init?(optional: Int) { self.init(iuo: optional) }
@@ -2469,7 +2469,7 @@ if the `init!` initializer causes initialization to fail.
 
 <!--
   - test: `structuresCanDelegateAcrossFromIUOToOptional`
-  
+
   ```swifttest
   -> struct S {
         init!(iuo: Int) { self.init(optional: iuo) }
@@ -2480,7 +2480,7 @@ if the `init!` initializer causes initialization to fail.
 
 <!--
   - test: `classesCanDelegateAcrossFromOptionalToIUO`
-  
+
   ```swifttest
   -> class C {
         convenience init?(optional: Int) { self.init(iuo: optional) }
@@ -2491,7 +2491,7 @@ if the `init!` initializer causes initialization to fail.
 
 <!--
   - test: `classesCanDelegateAcrossFromIUOToOptional`
-  
+
   ```swifttest
   -> class C {
         convenience init!(iuo: Int) { self.init(optional: iuo) }
@@ -2502,7 +2502,7 @@ if the `init!` initializer causes initialization to fail.
 
 <!--
   - test: `classesCanDelegateUpFromOptionalToIUO`
-  
+
   ```swifttest
   -> class C {
         init!(iuo: Int) {}
@@ -2515,7 +2515,7 @@ if the `init!` initializer causes initialization to fail.
 
 <!--
   - test: `classesCanDelegateUpFromIUOToOptional`
-  
+
   ```swifttest
   -> class C {
         init?(optional: Int) {}
@@ -2528,7 +2528,7 @@ if the `init!` initializer causes initialization to fail.
 
 <!--
   - test: `classesCanOverrideOptionalWithIUO`
-  
+
   ```swifttest
   -> class C {
         init?(i: Int) {}
@@ -2541,7 +2541,7 @@ if the `init!` initializer causes initialization to fail.
 
 <!--
   - test: `classesCanOverrideIUOWithOptional`
-  
+
   ```swifttest
   -> class C {
         init!(i: Int) {}
@@ -2554,7 +2554,7 @@ if the `init!` initializer causes initialization to fail.
 
 <!--
   - test: `structuresCanDelegateAcrossFromNonFailingToIUO`
-  
+
   ```swifttest
   -> struct S {
         init(nonFailing: Int) { self.init(iuo: nonFailing) }
@@ -2565,7 +2565,7 @@ if the `init!` initializer causes initialization to fail.
 
 <!--
   - test: `classesCanDelegateAcrossFromNonFailingToIUO`
-  
+
   ```swifttest
   -> class C {
         convenience init(nonFailing: Int) { self.init(iuo: nonFailing) }
@@ -2576,7 +2576,7 @@ if the `init!` initializer causes initialization to fail.
 
 <!--
   - test: `classesCanDelegateUpFromNonFailingToIUO`
-  
+
   ```swifttest
   -> class C {
         init!(iuo: Int) {}
@@ -2589,7 +2589,7 @@ if the `init!` initializer causes initialization to fail.
 
 <!--
   - test: `structuresAssertWhenDelegatingAcrossFromNonFailingToNilIUO`
-  
+
   ```swifttest
   -> struct S {
         init(nonFailing: Int) { self.init(iuo: nonFailing) }
@@ -2602,7 +2602,7 @@ if the `init!` initializer causes initialization to fail.
 
 <!--
   - test: `classesAssertWhenDelegatingAcrossFromNonFailingToNilIUO`
-  
+
   ```swifttest
   -> class C {
         convenience init(nonFailing: Int) { self.init(iuo: nonFailing) }
@@ -2615,7 +2615,7 @@ if the `init!` initializer causes initialization to fail.
 
 <!--
   - test: `classesAssertWhenDelegatingUpFromNonFailingToNilIUO`
-  
+
   ```swifttest
   -> class C {
         init!(iuo: Int) { return nil }
@@ -2643,7 +2643,7 @@ class SomeClass {
 
 <!--
   - test: `requiredInitializers`
-  
+
   ```swifttest
   -> class SomeClass {
         required init() {
@@ -2655,7 +2655,7 @@ class SomeClass {
 
 <!--
   - test: `requiredDesignatedInitializersMustBeImplementedBySubclasses`
-  
+
   ```swifttest
   -> class C {
         required init(i: Int) {}
@@ -2674,7 +2674,7 @@ class SomeClass {
 
 <!--
   - test: `requiredConvenienceInitializersMustBeImplementedBySubclasses`
-  
+
   ```swifttest
   -> class C {
         init() {}
@@ -2709,7 +2709,7 @@ class SomeSubclass: SomeClass {
 
 <!--
   - test: `requiredInitializers`
-  
+
   ```swifttest
   -> class SomeSubclass: SomeClass {
         required init() {
@@ -2721,7 +2721,7 @@ class SomeSubclass: SomeClass {
 
 <!--
   - test: `youCannotWriteOverrideWhenOverridingARequiredDesignatedInitializer`
-  
+
   ```swifttest
   -> class C {
         required init() {}
@@ -2744,7 +2744,7 @@ class SomeSubclass: SomeClass {
 
 <!--
   - test: `youCanSatisfyARequiredDesignatedInitializerWithAnInheritedInitializer`
-  
+
   ```swifttest
   -> class C {
         var x = 0
@@ -2758,7 +2758,7 @@ class SomeSubclass: SomeClass {
 
 <!--
   - test: `youCanSatisfyARequiredConvenienceInitializerWithAnInheritedInitializer`
-  
+
   ```swifttest
   -> class C {
         var x = 0
@@ -2812,7 +2812,7 @@ class SomeClass {
 
 <!--
   - test: `defaultPropertyWithClosure`
-  
+
   ```swifttest
   >> class SomeType {}
   -> class SomeClass {
@@ -2887,7 +2887,7 @@ struct Chessboard {
 
 <!--
   - test: `chessboard`
-  
+
   ```swifttest
   -> struct Chessboard {
         let boardColors: [Bool] = {
@@ -2929,7 +2929,7 @@ print(board.squareIsBlackAt(row: 7, column: 7))
 
 <!--
   - test: `chessboard`
-  
+
   ```swifttest
   -> let board = Chessboard()
   >> assert(board.boardColors == [false, true, false, true, false, true, false, true, true, false, true, false, true, false, true, false, false, true, false, true, false, true, false, true, true, false, true, false, true, false, true, false, false, true, false, true, false, true, false, true, true, false, true, false, true, false, true, false, false, true, false, true, false, true, false, true, true, false, true, false, true, false, true, false])

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/MemorySafety.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/MemorySafety.md
@@ -22,7 +22,7 @@ you'll get a compile-time or runtime error.
 
 <!--
   TODO: maybe re-introduce this text...
-  
+
   Memory safety refers to...
   The term *safety* usually refers to :newTerm:`memory safety`...
   Unsafe access to memory is available, if you ask for it explicitly...
@@ -46,7 +46,7 @@ print("We're number \(one)!")
 
 <!--
   - test: `memory-read-write`
-  
+
   ```swifttest
   // A write access to the memory where one is stored.
   -> var one = 1
@@ -181,7 +181,7 @@ print(myNumber)
 
 <!--
   - test: `memory-instantaneous`
-  
+
   ```swifttest
   -> func oneMore(than number: Int) -> Int {
          return number + 1
@@ -241,7 +241,7 @@ increment(&stepSize)
 
 <!--
   - test: `memory-increment`
-  
+
   ```swifttest
   -> var stepSize = 1
   ---
@@ -286,7 +286,7 @@ stepSize = copyOfStepSize
 
 <!--
   - test: `memory-increment-copy`
-  
+
   ```swifttest
   >> var stepSize = 1
   >> func increment(_ number: inout Int) {
@@ -332,7 +332,7 @@ balance(&playerOneScore, &playerOneScore)
 
 <!--
   - test: `memory-balance`
-  
+
   ```swifttest
   -> func balance(_ x: inout Int, _ y: inout Int) {
          let sum = x + y
@@ -415,7 +415,7 @@ struct Player {
 
 <!--
   - test: `memory-player-share-with-self`
-  
+
   ```swifttest
   >> func balance(_ x: inout Int, _ y: inout Int) {
   >>     let sum = x + y
@@ -426,7 +426,7 @@ struct Player {
          var name: String
          var health: Int
          var energy: Int
-  
+
          static let maxHealth = 10
          mutating func restoreHealth() {
              health = Player.maxHealth
@@ -459,7 +459,7 @@ oscar.shareHealth(with: &maria)  // OK
 
 <!--
   - test: `memory-player-share-with-self`
-  
+
   ```swifttest
   -> extension Player {
          mutating func shareHealth(with teammate: inout Player) {
@@ -500,7 +500,7 @@ oscar.shareHealth(with: &oscar)
 
 <!--
   - test: `memory-player-share-with-self`
-  
+
   ```swifttest
   -> oscar.shareHealth(with: &oscar)
   // Error: conflicting accesses to oscar
@@ -554,7 +554,7 @@ balance(&playerInformation.health, &playerInformation.energy)
 
 <!--
   - test: `memory-tuple`
-  
+
   ```swifttest
   >> func balance(_ x: inout Int, _ y: inout Int) {
   >>     let sum = x + y
@@ -596,7 +596,7 @@ balance(&holly.health, &holly.energy)  // Error
 
 <!--
   - test: `memory-share-health-global`
-  
+
   ```swifttest
   >> struct Player {
   >>     var name: String
@@ -634,7 +634,7 @@ func someFunction() {
 
 <!--
   - test: `memory-share-health-local`
-  
+
   ```swifttest
   >> struct Player {
   >>     var name: String
@@ -707,18 +707,18 @@ it doesn't allow the access.
   about changing the semantics of nonmutating method calls
   to be long-term reads,
   but it's not clear if/when that change will land.
-  
+
   ::
-  
+
       var global = 4
-  
+
       func foo(_ x: UnsafePointer<Int>){
           global = 7
       }
-  
+
       foo(&global)
       print(global)
-  
+
       // Simultaneous accesses to 0x106761618, but modification requires exclusive access.
       // Previous access (a read) started at temp2`main + 87 (0x10675e417).
       // Current access (a modification) started at:
@@ -731,7 +731,7 @@ it doesn't allow the access.
 
 <!--
   TEXT FOR THE FUTURE
-  
+
   Versions of Swift before Swift 5 ensure memory safety
   by aggressively making a copy of the shared mutable state
   when a conflicting access is possible.

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Methods.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Methods.md
@@ -50,7 +50,7 @@ class Counter {
 
 <!--
   - test: `instanceMethods`
-  
+
   ```swifttest
   -> class Counter {
         var count = 0
@@ -91,7 +91,7 @@ counter.reset()
 
 <!--
   - test: `instanceMethods`
-  
+
   ```swifttest
   -> let counter = Counter()
   /> the initial counter value is \(counter.count)
@@ -131,7 +131,7 @@ func increment() {
 
 <!--
   - test: `instanceMethodsIncrement`
-  
+
   ```swifttest
   >> class Counter {
   >> var count: Int = 0
@@ -179,7 +179,7 @@ if somePoint.isToTheRightOf(x: 1.0) {
 
 <!--
   - test: `self`
-  
+
   ```swifttest
   -> struct Point {
         var x = 0.0, y = 0.0
@@ -235,7 +235,7 @@ print("The point is now at (\(somePoint.x), \(somePoint.y))")
 
 <!--
   - test: `selfStructures`
-  
+
   ```swifttest
   -> struct Point {
         var x = 0.0, y = 0.0
@@ -270,7 +270,7 @@ fixedPoint.moveBy(x: 2.0, y: 3.0)
 
 <!--
   - test: `selfStructures-err`
-  
+
   ```swifttest
   >> struct Point {
   >>    var x = 0.0, y = 0.0
@@ -315,7 +315,7 @@ struct Point {
 
 <!--
   - test: `selfStructuresAssign`
-  
+
   ```swifttest
   -> struct Point {
         var x = 0.0, y = 0.0
@@ -361,7 +361,7 @@ ovenLight.next()
 
 <!--
   - test: `selfEnumerations`
-  
+
   ```swifttest
   -> enum TriStateSwitch {
         case off, low, high
@@ -419,7 +419,7 @@ SomeClass.someTypeMethod()
 
 <!--
   - test: `typeMethods`
-  
+
   ```swifttest
   -> class SomeClass {
         class func someTypeMethod() {
@@ -483,7 +483,7 @@ struct LevelTracker {
 
 <!--
   - test: `typeMethods`
-  
+
   ```swifttest
   -> struct LevelTracker {
         static var highestUnlockedLevel = 1
@@ -559,7 +559,7 @@ class Player {
 
 <!--
   - test: `typeMethods`
-  
+
   ```swifttest
   -> class Player {
         var tracker = LevelTracker()
@@ -597,7 +597,7 @@ print("highest unlocked level is now \(LevelTracker.highestUnlockedLevel)")
 
 <!--
   - test: `typeMethods`
-  
+
   ```swifttest
   -> var player = Player(name: "Argyrios")
   -> player.complete(level: 1)
@@ -622,7 +622,7 @@ if player.tracker.advance(to: 6) {
 
 <!--
   - test: `typeMethods`
-  
+
   ```swifttest
   -> player = Player(name: "Beto")
   -> if player.tracker.advance(to: 6) {

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/NestedTypes.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/NestedTypes.md
@@ -66,7 +66,7 @@ struct BlackjackCard {
 
 <!--
   - test: `nestedTypes`
-  
+
   ```swifttest
   -> struct BlackjackCard {
   ---
@@ -152,7 +152,7 @@ print("theAceOfSpades: \(theAceOfSpades.description)")
 
 <!--
   - test: `nestedTypes`
-  
+
   ```swifttest
   -> let theAceOfSpades = BlackjackCard(rank: .ace, suit: .spades)
   -> print("theAceOfSpades: \(theAceOfSpades.description)")
@@ -179,7 +179,7 @@ let heartsSymbol = BlackjackCard.Suit.hearts.rawValue
 
 <!--
   - test: `nestedTypes`
-  
+
   ```swifttest
   -> let heartsSymbol = BlackjackCard.Suit.hearts.rawValue
   /> heartsSymbol is \"\(heartsSymbol)\"

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/OpaqueTypes.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/OpaqueTypes.md
@@ -47,7 +47,7 @@ print(smallTriangle.draw())
 
 <!--
   - test: `opaque-result`
-  
+
   ```swifttest
   -> protocol Shape {
          func draw() -> String
@@ -94,7 +94,7 @@ print(flippedTriangle.draw())
 
 <!--
   - test: `opaque-result`
-  
+
   ```swifttest
   -> struct FlippedShape<T: Shape>: Shape {
          var shape: T
@@ -136,7 +136,7 @@ print(joinedTriangles.draw())
 
 <!--
   - test: `opaque-result`
-  
+
   ```swifttest
   -> struct JoinedShape<T: Shape, U: Shape>: Shape {
         var top: T
@@ -239,7 +239,7 @@ print(trapezoid.draw())
 
 <!--
   - test: `opaque-result`
-  
+
   ```swifttest
   -> struct Square: Shape {
          var size: Int
@@ -320,7 +320,7 @@ print(opaqueJoinedTriangles.draw())
 
 <!--
   - test: `opaque-result`
-  
+
   ```swifttest
   -> func flip<T: Shape>(_ shape: T) -> some Shape {
          return FlippedShape(shape: shape)
@@ -373,7 +373,7 @@ func invalidFlip<T: Shape>(_ shape: T) -> some Shape {
 
 <!--
   - test: `opaque-result-err`
-  
+
   ```swifttest
   >> protocol Shape {
   >>     func draw() -> String
@@ -426,7 +426,7 @@ struct FlippedShape<T: Shape>: Shape {
 
 <!--
   - test: `opaque-result-special-flip`
-  
+
   ```swifttest
   >> protocol Shape { func draw() -> String }
   >> struct Square: Shape {
@@ -466,7 +466,7 @@ func `repeat`<T: Shape>(shape: T, count: Int) -> some Collection {
 
 <!--
   - test: `opaque-result`
-  
+
   ```swifttest
   -> func `repeat`<T: Shape>(shape: T, count: Int) -> some Collection {
          return Array<T>(repeating: shape, count: count)
@@ -512,7 +512,7 @@ func protoFlip<T: Shape>(_ shape: T) -> Shape {
 
 <!--
   - test: `opaque-result-existential-error`
-  
+
   ```swifttest
   >> protocol Shape {
   >>     func draw() -> String
@@ -559,13 +559,13 @@ func protoFlip<T: Shape>(_ shape: T) -> Shape {
 
 <!--
   - test: `opaque-result-existential-error`
-  
+
   ```swifttest
   -> func protoFlip<T: Shape>(_ shape: T) -> Shape {
         if shape is Square {
            return shape
         }
-  
+
         return FlippedShape(shape: shape)
      }
   !$ error: invalid redeclaration of 'protoFlip'
@@ -598,7 +598,7 @@ protoFlippedTriangle == sameThing  // Error
 
 <!--
   - test: `opaque-result-existential-error`
-  
+
   ```swifttest
   >> let smallTriangle = Triangle(size: 3)
   -> let protoFlippedTriangle = protoFlip(smallTriangle)
@@ -659,7 +659,7 @@ extension Array: Container { }
 
 <!--
   - test: `opaque-result, opaque-result-existential-error`
-  
+
   ```swifttest
   -> protocol Container {
          associatedtype Item
@@ -690,7 +690,7 @@ func makeProtocolContainer<T, C: Container>(item: T) -> C {
 
 <!--
   - test: `opaque-result-existential-error`
-  
+
   ```swifttest
   // Error: Protocol with associated types can't be used as a return type.
   -> func makeProtocolContainer<T>(item: T) -> Container {
@@ -728,7 +728,7 @@ print(type(of: twelve))
 
 <!--
   - test: `opaque-result`
-  
+
   ```swifttest
   -> func makeOpaqueContainer<T>(item: T) -> some Container {
          return [item]
@@ -752,27 +752,27 @@ which means that the type of `twelve` is also inferred to be `Int`.
 
 <!--
   TODO: Expansion for the future
-  
+
   You can combine the flexibility of returning a value of protocol type
   with the API-boundary enforcement of opaque types
   by using type erasure
   like the Swift standard library uses in the
   `AnySequence <//apple_ref/fake/AnySequence`_ type.
-  
+
   protocol P { func f() -> Int }
-  
+
   struct AnyP: P {
       var p: P
       func f() -> Int { return p.f() }
   }
-  
+
   struct P1 {
       func f() -> Int { return 100 }
   }
   struct P2 {
       func f() -> Int { return 200 }
   }
-  
+
   func opaque(x: Int) -> some P {
       let result: P
       if x > 100 {

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/OptionalChaining.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/OptionalChaining.md
@@ -55,7 +55,7 @@ class Residence {
 
 <!--
   - test: `optionalChainingIntro, optionalChainingIntroAssert`
-  
+
   ```swifttest
   -> class Person {
         var residence: Residence?
@@ -82,7 +82,7 @@ let john = Person()
 
 <!--
   - test: `optionalChainingIntro, optionalChainingIntroAssert`
-  
+
   ```swifttest
   -> let john = Person()
   ```
@@ -100,7 +100,7 @@ let roomCount = john.residence!.numberOfRooms
 
 <!--
   - test: `optionalChainingIntroAssert`
-  
+
   ```swifttest
   -> let roomCount = john.residence!.numberOfRooms
   xx assert
@@ -127,7 +127,7 @@ if let roomCount = john.residence?.numberOfRooms {
 
 <!--
   - test: `optionalChainingIntro`
-  
+
   ```swifttest
   -> if let roomCount = john.residence?.numberOfRooms {
         print("John's residence has \(roomCount) room(s).")
@@ -164,7 +164,7 @@ john.residence = Residence()
 
 <!--
   - test: `optionalChainingIntro`
-  
+
   ```swifttest
   -> john.residence = Residence()
   ```
@@ -186,7 +186,7 @@ if let roomCount = john.residence?.numberOfRooms {
 
 <!--
   - test: `optionalChainingIntro`
-  
+
   ```swifttest
   -> if let roomCount = john.residence?.numberOfRooms {
         print("John's residence has \(roomCount) room(s).")
@@ -223,7 +223,7 @@ class Person {
 
 <!--
   - test: `optionalChaining`
-  
+
   ```swifttest
   -> class Person {
         var residence: Residence?
@@ -258,7 +258,7 @@ class Residence {
 
 <!--
   - test: `optionalChaining`
-  
+
   ```swifttest
   -> class Residence {
         var rooms: [Room] = []
@@ -311,7 +311,7 @@ class Room {
 
 <!--
   - test: `optionalChaining`
-  
+
   ```swifttest
   -> class Room {
         let name: String
@@ -345,7 +345,7 @@ class Address {
 
 <!--
   - test: `optionalChaining`
-  
+
   ```swifttest
   -> class Address {
         var buildingName: String?
@@ -392,7 +392,7 @@ if let roomCount = john.residence?.numberOfRooms {
 
 <!--
   - test: `optionalChaining`
-  
+
   ```swifttest
   -> let john = Person()
   -> if let roomCount = john.residence?.numberOfRooms {
@@ -418,7 +418,7 @@ john.residence?.address = someAddress
 
 <!--
   - test: `optionalChaining`
-  
+
   ```swifttest
   -> let someAddress = Address()
   -> someAddress.buildingNumber = "29"
@@ -458,7 +458,7 @@ john.residence?.address = createAddress()
 
 <!--
   - test: `optionalChaining`
-  
+
   ```swifttest
   -> func createAddress() -> Address {
          print("Function was called.")
@@ -496,7 +496,7 @@ func printNumberOfRooms() {
 
 <!--
   - test: `optionalChainingCallouts`
-  
+
   ```swifttest
   -> func printNumberOfRooms() {
   >>    let numberOfRooms = 3
@@ -530,7 +530,7 @@ if john.residence?.printNumberOfRooms() != nil {
 
 <!--
   - test: `optionalChaining`
-  
+
   ```swifttest
   -> if john.residence?.printNumberOfRooms() != nil {
         print("It was possible to print the number of rooms.")
@@ -559,7 +559,7 @@ if (john.residence?.address = someAddress) != nil {
 
 <!--
   - test: `optionalChaining`
-  
+
   ```swifttest
   -> if (john.residence?.address = someAddress) != nil {
         print("It was possible to set the address.")
@@ -598,7 +598,7 @@ if let firstRoomName = john.residence?[0].name {
 
 <!--
   - test: `optionalChaining`
-  
+
   ```swifttest
   -> if let firstRoomName = john.residence?[0].name {
         print("The first room name is \(firstRoomName).")
@@ -622,7 +622,7 @@ john.residence?[0] = Room(name: "Bathroom")
 
 <!--
   - test: `optionalChaining`
-  
+
   ```swifttest
   -> john.residence?[0] = Room(name: "Bathroom")
   ```
@@ -651,7 +651,7 @@ if let firstRoomName = john.residence?[0].name {
 
 <!--
   - test: `optionalChaining`
-  
+
   ```swifttest
   -> let johnsHouse = Residence()
   -> johnsHouse.rooms.append(Room(name: "Living Room"))
@@ -684,7 +684,7 @@ testScores["Brian"]?[0] = 72
 
 <!--
   - test: `optionalChaining`
-  
+
   ```swifttest
   -> var testScores = ["Dave": [86, 82, 84], "Bev": [79, 94, 81]]
   -> testScores["Dave"]?[0] = 91
@@ -747,7 +747,7 @@ if let johnsStreet = john.residence?.address?.street {
 
 <!--
   - test: `optionalChaining`
-  
+
   ```swifttest
   -> if let johnsStreet = john.residence?.address?.street {
         print("John's street name is \(johnsStreet).")
@@ -789,7 +789,7 @@ if let johnsStreet = john.residence?.address?.street {
 
 <!--
   - test: `optionalChaining`
-  
+
   ```swifttest
   -> let johnsAddress = Address()
   -> johnsAddress.buildingName = "The Larches"
@@ -831,7 +831,7 @@ if let buildingIdentifier = john.residence?.address?.buildingIdentifier() {
 
 <!--
   - test: `optionalChaining`
-  
+
   ```swifttest
   -> if let buildingIdentifier = john.residence?.address?.buildingIdentifier() {
         print("John's building identifier is \(buildingIdentifier).")
@@ -857,7 +857,7 @@ if let beginsWithThe =
 
 <!--
   - test: `optionalChaining`
-  
+
   ```swifttest
   -> if let beginsWithThe =
         john.residence?.address?.buildingIdentifier()?.hasPrefix("The") {

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Properties.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Properties.md
@@ -10,7 +10,7 @@ Stored properties are provided only by classes and structures.
 
 <!--
   - test: `enumerationsCantProvideStoredProperties`
-  
+
   ```swifttest
   -> enum E { case a, b; var x = 0 }
   !$ error: enums must not contain stored properties
@@ -30,7 +30,7 @@ and also to properties that a subclass inherits from its superclass.
 
 <!--
   - test: `propertyObserverIntroClaims`
-  
+
   ```swifttest
   -> class C {
         var x: Int = 0 {
@@ -89,7 +89,7 @@ rangeOfThreeItems.firstValue = 6
 
 <!--
   - test: `storedProperties, storedProperties-err`
-  
+
   ```swifttest
   -> struct FixedLengthRange {
         var firstValue: Int
@@ -124,7 +124,7 @@ rangeOfFourItems.firstValue = 6
 
 <!--
   - test: `storedProperties-err`
-  
+
   ```swifttest
   -> let rangeOfFourItems = FixedLengthRange(firstValue: 0, length: 4)
   // this range represents integer values 0, 1, 2, and 3
@@ -176,7 +176,7 @@ the `lazy` modifier before its declaration.
 
 <!--
   - test: `lazyPropertiesMustAlwaysBeVariables`
-  
+
   ```swifttest
   -> class C { lazy let x = 0 }
   !$ error: 'lazy' cannot be used on a let
@@ -227,7 +227,7 @@ manager.data.append("Some more data")
 
 <!--
   - test: `lazyProperties`
-  
+
   ```swifttest
   -> class DataImporter {
         /*
@@ -287,7 +287,7 @@ print(manager.importer.filename)
 
 <!--
   - test: `lazyProperties`
-  
+
   ```swifttest
   -> print(manager.importer.filename)
   </ the DataImporter instance for the importer property has now been created
@@ -366,7 +366,7 @@ print("square.origin is now at (\(square.origin.x), \(square.origin.y))")
 
 <!--
   - test: `computedProperties`
-  
+
   ```swifttest
   -> struct Point {
         var x = 0.0, y = 0.0
@@ -464,7 +464,7 @@ struct AlternativeRect {
 
 <!--
   - test: `computedProperties`
-  
+
   ```swifttest
   -> struct AlternativeRect {
         var origin = Point()
@@ -515,7 +515,7 @@ struct CompactRect {
 
 <!--
   - test: `computedProperties`
-  
+
   ```swifttest
   -> struct CompactRect {
         var origin = Point()
@@ -552,7 +552,7 @@ and can be accessed through dot syntax, but can't be set to a different value.
 
 <!--
   - test: `readOnlyComputedPropertiesMustBeVariables`
-  
+
   ```swifttest
   -> class C {
         let x: Int { return 42 }
@@ -586,7 +586,7 @@ print("the volume of fourByFiveByTwo is \(fourByFiveByTwo.volume)")
 
 <!--
   - test: `computedProperties`
-  
+
   ```swifttest
   -> struct Cuboid {
         var width = 0.0, height = 0.0, depth = 0.0
@@ -633,7 +633,7 @@ even if the new value is the same as the property's current value.
 
 <!--
   - test: `observersAreCalledEvenIfNewValueIsTheSameAsOldValue`
-  
+
   ```swifttest
   -> class C { var x: Int = 0 { willSet { print("willSet") } didSet { print("didSet") } } }
   -> let c = C()
@@ -661,7 +661,7 @@ Overriding properties is described in <doc:Inheritance#Overriding>.
 
 <!--
   - test: `lazyPropertiesCanHaveObservers`
-  
+
   ```swifttest
   >> class C {
         lazy var x: Int = 0 {
@@ -682,7 +682,7 @@ Overriding properties is described in <doc:Inheritance#Overriding>.
 
 <!--
   - test: `storedAndComputedInheritedPropertiesCanBeObserved`
-  
+
   ```swifttest
   -> class C {
         var x = 0
@@ -727,7 +727,7 @@ the new value that you assign replaces the one that was just set.
 
 <!--
   - test: `assigningANewValueInADidSetReplacesTheNewValue`
-  
+
   ```swifttest
   -> class C { var x: Int = 0 { didSet { x = -273 } } }
   -> let c = C()
@@ -747,7 +747,7 @@ the new value that you assign replaces the one that was just set.
 
 <!--
   - test: `observersDuringInitialization`
-  
+
   ```swifttest
   -> class C {
         var x: Int { willSet { print("willSet x") } didSet { print("didSet x") } }
@@ -806,7 +806,7 @@ stepCounter.totalSteps = 896
 
 <!--
   - test: `storedProperties`
-  
+
   ```swifttest
   -> class StepCounter {
         var totalSteps: Int = 0 {
@@ -861,7 +861,7 @@ and the default name of `oldValue` is used instead.
 
 <!--
   - test: `observersCalledAfterInout`
-  
+
   ```swifttest
   -> var a: Int = 0 {
          willSet { print("willSet") }
@@ -917,7 +917,7 @@ struct TwelveOrLess {
 
 <!--
   - test: `small-number-wrapper, property-wrapper-expansion`
-  
+
   ```swifttest
   -> @propertyWrapper
   -> struct TwelveOrLess {
@@ -953,7 +953,7 @@ and the getter returns the stored value.
   but you could write a version of ``EvenNumber``
   that implements ``wrappedValue`` as a stored property
   and uses ``didSet`` to ensure the number is always even.
-  
+
   However, the general framing we use in the docs
   is that didSet is mostly for reacting to the new value,
   not changing it,
@@ -964,7 +964,7 @@ and the getter returns the stored value.
 
 <!--
   - test: `stored-property-wrappedValue`
-  
+
   ```swifttest
   >> @propertyWrapper
   >> struct TwelveOrLess {
@@ -1019,7 +1019,7 @@ print(rectangle.height)
 
 <!--
   - test: `small-number-wrapper`
-  
+
   ```swifttest
   -> struct SmallRectangle {
   ->     @TwelveOrLess var height: Int
@@ -1079,7 +1079,7 @@ struct SmallRectangle {
 
 <!--
   - test: `property-wrapper-expansion`
-  
+
   ```swifttest
   -> struct SmallRectangle {
          private var _height = TwelveOrLess()
@@ -1145,7 +1145,7 @@ struct SmallNumber {
 
 <!--
   - test: `property-wrapper-init, property-wrapper-mixed-init`
-  
+
   ```swifttest
   -> @propertyWrapper
   -> struct SmallNumber {
@@ -1207,7 +1207,7 @@ print(zeroRectangle.height, zeroRectangle.width)
 
 <!--
   - test: `property-wrapper-init`
-  
+
   ```swifttest
   -> struct ZeroRectangle {
   ->     @SmallNumber var height: Int
@@ -1222,7 +1222,7 @@ print(zeroRectangle.height, zeroRectangle.width)
 
 <!--
   - test: `property-wrapper-init`
-  
+
   ```swifttest
   -> struct ZeroRectangle_equiv {
          private var _height = SmallNumber()
@@ -1270,7 +1270,7 @@ print(unitRectangle.height, unitRectangle.width)
 
 <!--
   - test: `property-wrapper-init`
-  
+
   ```swifttest
   -> struct UnitRectangle {
   ->     @SmallNumber var height: Int = 1
@@ -1285,7 +1285,7 @@ print(unitRectangle.height, unitRectangle.width)
 
 <!--
   - test: `property-wrapper-init`
-  
+
   ```swifttest
   -> struct UnitRectangle_equiv {
          private var _height = SmallNumber(wrappedValue: 1)
@@ -1335,7 +1335,7 @@ print(narrowRectangle.height, narrowRectangle.width)
 
 <!--
   - test: `property-wrapper-init`
-  
+
   ```swifttest
   -> struct NarrowRectangle {
   ->     @SmallNumber(wrappedValue: 2, maximum: 5) var height: Int
@@ -1355,7 +1355,7 @@ print(narrowRectangle.height, narrowRectangle.width)
 
 <!--
   - test: `property-wrapper-init`
-  
+
   ```swifttest
   -> struct NarrowRectangle_equiv {
          private var _height = SmallNumber(wrappedValue: 2, maximum: 5)
@@ -1414,7 +1414,7 @@ print(mixedRectangle.height)
 
 <!--
   - test: `property-wrapper-mixed-init`
-  
+
   ```swifttest
   -> struct MixedRectangle {
   ->     @SmallNumber var height: Int = 1
@@ -1496,7 +1496,7 @@ print(someStructure.$someNumber)
 
 <!--
   - test: `small-number-wrapper-projection`
-  
+
   ```swifttest
   -> @propertyWrapper
   -> struct SmallNumber {
@@ -1585,7 +1585,7 @@ struct SizedRectangle {
 
 <!--
   - test: `small-number-wrapper-projection`
-  
+
   ```swifttest
   -> enum Size {
          case small, large
@@ -1656,7 +1656,7 @@ and they're written in the same way as computed properties.
 
 <!--
   - test: `computedVariables`
-  
+
   ```swifttest
   -> var a: Int { get { return 42 } set { print("set a to \(newValue)") } }
   -> a = 37
@@ -1668,7 +1668,7 @@ and they're written in the same way as computed properties.
 
 <!--
   - test: `observersForStoredVariables`
-  
+
   ```swifttest
   -> var a: Int = 0 { willSet { print("willSet") } didSet { print("didSet") } }
   -> a = 42
@@ -1701,7 +1701,7 @@ func someFunction() {
 
 <!--
   - test: `property-wrapper-init`
-  
+
   ```swifttest
   -> func someFunction() {
   ->     @SmallNumber var myNumber: Int = 0
@@ -1812,7 +1812,7 @@ class SomeClass {
 
 <!--
   - test: `typePropertySyntax`
-  
+
   ```swifttest
   -> struct SomeStructure {
         static var storedTypeProperty = "Some value."
@@ -1840,7 +1840,7 @@ class SomeClass {
 
 <!--
   - test: `classComputedTypePropertiesAreOverrideable`
-  
+
   ```swifttest
   -> class A { class var cp: String { return "A" } }
   -> class B: A { override class var cp: String { return "B" } }
@@ -1851,7 +1851,7 @@ class SomeClass {
 
 <!--
   - test: `staticComputedTypePropertiesAreFinal`
-  
+
   ```swifttest
   -> class A { static var cp: String { return "A" } }
   -> class B: A { override static var cp: String { return "B" } }
@@ -1888,7 +1888,7 @@ print(SomeClass.computedTypeProperty)
 
 <!--
   - test: `typePropertySyntax`
-  
+
   ```swifttest
   -> print(SomeStructure.storedTypeProperty)
   <- Some value.
@@ -1939,7 +1939,7 @@ struct AudioChannel {
 
 <!--
   - test: `staticProperties`
-  
+
   ```swifttest
   -> struct AudioChannel {
         static let thresholdLevel = 10
@@ -2002,7 +2002,7 @@ var rightChannel = AudioChannel()
 
 <!--
   - test: `staticProperties`
-  
+
   ```swifttest
   -> var leftChannel = AudioChannel()
   -> var rightChannel = AudioChannel()
@@ -2023,7 +2023,7 @@ print(AudioChannel.maxInputLevelForAllChannels)
 
 <!--
   - test: `staticProperties`
-  
+
   ```swifttest
   -> leftChannel.currentLevel = 7
   -> print(leftChannel.currentLevel)
@@ -2048,7 +2048,7 @@ print(AudioChannel.maxInputLevelForAllChannels)
 
 <!--
   - test: `staticProperties`
-  
+
   ```swifttest
   -> rightChannel.currentLevel = 11
   -> print(rightChannel.currentLevel)

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Protocols.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Protocols.md
@@ -37,7 +37,7 @@ protocol SomeProtocol {
 
 <!--
   - test: `protocolSyntax`
-  
+
   ```swifttest
   -> protocol SomeProtocol {
         // protocol definition goes here
@@ -58,7 +58,7 @@ struct SomeStructure: FirstProtocol, AnotherProtocol {
 
 <!--
   - test: `protocolSyntax`
-  
+
   ```swifttest
   >> protocol FirstProtocol {}
   >> protocol AnotherProtocol {}
@@ -79,7 +79,7 @@ class SomeClass: SomeSuperclass, FirstProtocol, AnotherProtocol {
 
 <!--
   - test: `protocolSyntax`
-  
+
   ```swifttest
   >> class SomeSuperclass {}
   -> class SomeClass: SomeSuperclass, FirstProtocol, AnotherProtocol {
@@ -121,7 +121,7 @@ protocol SomeProtocol {
 
 <!--
   - test: `instanceProperties`
-  
+
   ```swifttest
   -> protocol SomeProtocol {
         var mustBeSettable: Int { get set }
@@ -143,7 +143,7 @@ protocol AnotherProtocol {
 
 <!--
   - test: `instanceProperties`
-  
+
   ```swifttest
   -> protocol AnotherProtocol {
         static var someTypeProperty: Int { get set }
@@ -161,7 +161,7 @@ protocol FullyNamed {
 
 <!--
   - test: `instanceProperties`
-  
+
   ```swifttest
   -> protocol FullyNamed {
         var fullName: String { get }
@@ -188,7 +188,7 @@ let john = Person(fullName: "John Appleseed")
 
 <!--
   - test: `instanceProperties`
-  
+
   ```swifttest
   -> struct Person: FullyNamed {
         var fullName: String
@@ -230,7 +230,7 @@ var ncc1701 = Starship(name: "Enterprise", prefix: "USS")
 
 <!--
   - test: `instanceProperties`
-  
+
   ```swifttest
   -> class Starship: FullyNamed {
         var prefix: String?
@@ -283,7 +283,7 @@ protocol SomeProtocol {
 
 <!--
   - test: `typeMethods`
-  
+
   ```swifttest
   -> protocol SomeProtocol {
         static func someTypeMethod()
@@ -301,7 +301,7 @@ protocol RandomNumberGenerator {
 
 <!--
   - test: `protocols`
-  
+
   ```swifttest
   -> protocol RandomNumberGenerator {
         func random() -> Double
@@ -347,7 +347,7 @@ print("And another one: \(generator.random())")
 
 <!--
   - test: `protocols`
-  
+
   ```swifttest
   -> class LinearCongruentialGenerator: RandomNumberGenerator {
         var lastRandom = 42.0
@@ -408,7 +408,7 @@ protocol Togglable {
 
 <!--
   - test: `mutatingRequirements`
-  
+
   ```swifttest
   -> protocol Togglable {
         mutating func toggle()
@@ -446,7 +446,7 @@ lightSwitch.toggle()
 
 <!--
   - test: `mutatingRequirements`
-  
+
   ```swifttest
   -> enum OnOffSwitch: Togglable {
         case off, on
@@ -481,7 +481,7 @@ protocol SomeProtocol {
 
 <!--
   - test: `initializers`
-  
+
   ```swifttest
   -> protocol SomeProtocol {
         init(someParameter: Int)
@@ -506,7 +506,7 @@ class SomeClass: SomeProtocol {
 
 <!--
   - test: `initializers`
-  
+
   ```swifttest
   -> class SomeClass: SomeProtocol {
         required init(someParameter: Int) {
@@ -518,7 +518,7 @@ class SomeClass: SomeProtocol {
 
 <!--
   - test: `protocolInitializerRequirementsCanBeImplementedAsDesignatedOrConvenience`
-  
+
   ```swifttest
   -> protocol P {
         init(x: Int)
@@ -545,7 +545,7 @@ see <doc:Initialization#Required-Initializers>.
 
 <!--
   - test: `protocolInitializerRequirementsRequireTheRequiredModifierOnTheImplementingClass`
-  
+
   ```swifttest
   -> protocol P {
         init(s: String)
@@ -565,7 +565,7 @@ see <doc:Initialization#Required-Initializers>.
 
 <!--
   - test: `protocolInitializerRequirementsRequireTheRequiredModifierOnSubclasses`
-  
+
   ```swifttest
   -> protocol P {
         init(s: String)
@@ -596,7 +596,7 @@ see <doc:Initialization#Required-Initializers>.
 
 <!--
   - test: `finalClassesDoNotNeedTheRequiredModifierForProtocolInitializerRequirements`
-  
+
   ```swifttest
   -> protocol P {
         init(s: String)
@@ -635,7 +635,7 @@ class SomeSubClass: SomeSuperClass, SomeProtocol {
 
 <!--
   - test: `requiredOverrideInitializers`
-  
+
   ```swifttest
   -> protocol SomeProtocol {
         init()
@@ -668,7 +668,7 @@ a nonfailable initializer or an implicitly unwrapped failable initializer.
 
 <!--
   - test: `failableRequirementCanBeSatisfiedByFailableInitializer`
-  
+
   ```swifttest
   -> protocol P { init?(i: Int) }
   -> class C: P { required init?(i: Int) {} }
@@ -678,7 +678,7 @@ a nonfailable initializer or an implicitly unwrapped failable initializer.
 
 <!--
   - test: `failableRequirementCanBeSatisfiedByIUOInitializer`
-  
+
   ```swifttest
   -> protocol P { init?(i: Int) }
   -> class C: P { required init!(i: Int) {} }
@@ -688,7 +688,7 @@ a nonfailable initializer or an implicitly unwrapped failable initializer.
 
 <!--
   - test: `iuoRequirementCanBeSatisfiedByFailableInitializer`
-  
+
   ```swifttest
   -> protocol P { init!(i: Int) }
   -> class C: P { required init?(i: Int) {} }
@@ -698,7 +698,7 @@ a nonfailable initializer or an implicitly unwrapped failable initializer.
 
 <!--
   - test: `iuoRequirementCanBeSatisfiedByIUOInitializer`
-  
+
   ```swifttest
   -> protocol P { init!(i: Int) }
   -> class C: P { required init!(i: Int) {} }
@@ -708,7 +708,7 @@ a nonfailable initializer or an implicitly unwrapped failable initializer.
 
 <!--
   - test: `failableRequirementCanBeSatisfiedByNonFailableInitializer`
-  
+
   ```swifttest
   -> protocol P { init?(i: Int) }
   -> class C: P { required init(i: Int) {} }
@@ -718,7 +718,7 @@ a nonfailable initializer or an implicitly unwrapped failable initializer.
 
 <!--
   - test: `iuoRequirementCanBeSatisfiedByNonFailableInitializer`
-  
+
   ```swifttest
   -> protocol P { init!(i: Int) }
   -> class C: P { required init(i: Int) {} }
@@ -728,7 +728,7 @@ a nonfailable initializer or an implicitly unwrapped failable initializer.
 
 <!--
   - test: `nonFailableRequirementCanBeSatisfiedByNonFailableInitializer`
-  
+
   ```swifttest
   -> protocol P { init(i: Int) }
   -> class C: P { required init(i: Int) {} }
@@ -738,7 +738,7 @@ a nonfailable initializer or an implicitly unwrapped failable initializer.
 
 <!--
   - test: `nonFailableRequirementCanBeSatisfiedByIUOInitializer`
-  
+
   ```swifttest
   -> protocol P { init(i: Int) }
   -> class C: P { required init!(i: Int) {} }
@@ -785,7 +785,7 @@ class Dice {
 
 <!--
   - test: `protocols`
-  
+
   ```swifttest
   -> class Dice {
         let sides: Int
@@ -854,7 +854,7 @@ for _ in 1...5 {
 
 <!--
   - test: `protocols`
-  
+
   ```swifttest
   -> var d6 = Dice(sides: 6, generator: LinearCongruentialGenerator())
   -> for _ in 1...5 {
@@ -897,7 +897,7 @@ protocol DiceGameDelegate: AnyObject {
 
 <!--
   - test: `protocols`
-  
+
   ```swifttest
   -> protocol DiceGame {
         var dice: Dice { get }
@@ -967,7 +967,7 @@ class SnakesAndLadders: DiceGame {
 
 <!--
   - test: `protocols`
-  
+
   ```swifttest
   -> class SnakesAndLadders: DiceGame {
         let finalSquare = 25
@@ -1068,7 +1068,7 @@ class DiceGameTracker: DiceGameDelegate {
 
 <!--
   - test: `protocols`
-  
+
   ```swifttest
   -> class DiceGameTracker: DiceGameDelegate {
         var numberOfTurns = 0
@@ -1131,7 +1131,7 @@ game.play()
 
 <!--
   - test: `protocols`
-  
+
   ```swifttest
   -> let tracker = DiceGameTracker()
   -> let game = SnakesAndLadders()
@@ -1170,7 +1170,7 @@ protocol TextRepresentable {
 
 <!--
   - test: `protocols`
-  
+
   ```swifttest
   -> protocol TextRepresentable {
         var textualDescription: String { get }
@@ -1196,7 +1196,7 @@ extension Dice: TextRepresentable {
 
 <!--
   - test: `protocols`
-  
+
   ```swifttest
   -> extension Dice: TextRepresentable {
         var textualDescription: String {
@@ -1222,7 +1222,7 @@ print(d12.textualDescription)
 
 <!--
   - test: `protocols`
-  
+
   ```swifttest
   -> let d12 = Dice(sides: 12, generator: LinearCongruentialGenerator())
   -> print(d12.textualDescription)
@@ -1245,7 +1245,7 @@ print(game.textualDescription)
 
 <!--
   - test: `protocols`
-  
+
   ```swifttest
   -> extension SnakesAndLadders: TextRepresentable {
         var textualDescription: String {
@@ -1286,7 +1286,7 @@ print(myDice.textualDescription)
 
 <!--
   - test: `protocols`
-  
+
   ```swifttest
   -> extension Array: TextRepresentable where Element: TextRepresentable {
         var textualDescription: String {
@@ -1318,7 +1318,7 @@ extension Hamster: TextRepresentable {}
 
 <!--
   - test: `protocols`
-  
+
   ```swifttest
   -> struct Hamster {
         var name: String
@@ -1341,7 +1341,7 @@ print(somethingTextRepresentable.textualDescription)
 
 <!--
   - test: `protocols`
-  
+
   ```swifttest
   -> let simonTheHamster = Hamster(name: "Simon")
   -> let somethingTextRepresentable: TextRepresentable = simonTheHamster
@@ -1366,19 +1366,19 @@ to implement the protocol requirements yourself.
   Linking directly to a section of an article like the URLs below do
   is expected to be stable --
   as long as the section stays around, that topic ID will be there too.
-  
+
   Conforming to the Equatable Protocol
   https://developer.apple.com/documentation/swift/equatable#2847780
-  
+
   Conforming to the Hashable Protocol
   https://developer.apple.com/documentation/swift/hashable#2849490
-  
+
   Conforming to the Comparable Protocol
   https://developer.apple.com/documentation/swift/comparable#2845320
-  
+
   ^-- Need to add discussion of synthesized implementation
   to the reference for Comparable, since that's new
-  
+
   Some of the information in the type references above
   is also repeated in the "Conform Automatically to Equatable and Hashable" section
   of the article "Adopting Common Protocols".
@@ -1420,7 +1420,7 @@ if twoThreeFour == anotherTwoThreeFour {
 
 <!--
   - test: `equatable_synthesis`
-  
+
   ```swifttest
   -> struct Vector3D: Equatable {
         var x = 0.0, y = 0.0, z = 0.0
@@ -1438,7 +1438,7 @@ if twoThreeFour == anotherTwoThreeFour {
 <!--
   Need to cross reference here from "Adopting Common Protocols"
   https://developer.apple.com/documentation/swift/adopting_common_protocols
-  
+
   Discussion in the article calls out that
   enums without associated values are Equatable & Hashable
   even if you don't declare the protocol conformance.
@@ -1490,7 +1490,7 @@ for level in levels.sorted() {
 
 <!--
   - test: `comparable-enum-synthesis`
-  
+
   ```swifttest
   -> enum SkillLevel: Comparable {
          case beginner
@@ -1517,7 +1517,7 @@ for level in levels.sorted() {
 
 <!--
   - test: `no-synthesized-comparable-for-raw-value-enum`
-  
+
   ```swifttest
   >> enum E: Int, Comparable {
   >>     case ten = 10
@@ -1566,7 +1566,7 @@ let things: [TextRepresentable] = [game, d12, simonTheHamster]
 
 <!--
   - test: `protocols`
-  
+
   ```swifttest
   -> let things: [TextRepresentable] = [game, d12, simonTheHamster]
   ```
@@ -1586,7 +1586,7 @@ for thing in things {
 
 <!--
   - test: `protocols`
-  
+
   ```swifttest
   -> for thing in things {
         print(thing.textualDescription)
@@ -1619,7 +1619,7 @@ protocol InheritingProtocol: SomeProtocol, AnotherProtocol {
 
 <!--
   - test: `protocols`
-  
+
   ```swifttest
   >> protocol SomeProtocol {}
   >> protocol AnotherProtocol {}
@@ -1640,7 +1640,7 @@ protocol PrettyTextRepresentable: TextRepresentable {
 
 <!--
   - test: `protocols`
-  
+
   ```swifttest
   -> protocol PrettyTextRepresentable: TextRepresentable {
         var prettyTextualDescription: String { get }
@@ -1679,7 +1679,7 @@ extension SnakesAndLadders: PrettyTextRepresentable {
 
 <!--
   - test: `protocols`
-  
+
   ```swifttest
   -> extension SnakesAndLadders: PrettyTextRepresentable {
         var prettyTextualDescription: String {
@@ -1730,7 +1730,7 @@ print(game.prettyTextualDescription)
 
 <!--
   - test: `protocols`
-  
+
   ```swifttest
   -> print(game.prettyTextualDescription)
   </ A game of Snakes and Ladders with 25 squares:
@@ -1751,7 +1751,7 @@ protocol SomeClassOnlyProtocol: AnyObject, SomeInheritedProtocol {
 
 <!--
   - test: `classOnlyProtocols`
-  
+
   ```swifttest
   >> protocol SomeInheritedProtocol {}
   -> protocol SomeClassOnlyProtocol: AnyObject, SomeInheritedProtocol {
@@ -1773,7 +1773,7 @@ that tries to adopt `SomeClassOnlyProtocol`.
 
 <!--
   - test: `anyobject-doesn't-have-to-be-first`
-  
+
   ```swifttest
   >> protocol SomeInheritedProtocol {}
   -> protocol SomeClassOnlyProtocol: SomeInheritedProtocol, AnyObject {
@@ -1827,7 +1827,7 @@ wishHappyBirthday(to: birthdayPerson)
 
 <!--
   - test: `protocolComposition`
-  
+
   ```swifttest
   -> protocol Named {
         var name: String { get }
@@ -1897,7 +1897,7 @@ beginConcert(in: seattle)
 
 <!--
   - test: `protocolComposition`
-  
+
   ```swifttest
   -> class Location {
          var latitude: Double
@@ -1964,7 +1964,7 @@ protocol HasArea {
 
 <!--
   - test: `protocolConformance`
-  
+
   ```swifttest
   -> protocol HasArea {
         var area: Double { get }
@@ -1990,7 +1990,7 @@ class Country: HasArea {
 
 <!--
   - test: `protocolConformance`
-  
+
   ```swifttest
   -> class Circle: HasArea {
         let pi = 3.1415927
@@ -2021,7 +2021,7 @@ class Animal {
 
 <!--
   - test: `protocolConformance`
-  
+
   ```swifttest
   -> class Animal {
         var legs: Int
@@ -2044,7 +2044,7 @@ let objects: [AnyObject] = [
 
 <!--
   - test: `protocolConformance`
-  
+
   ```swifttest
   -> let objects: [AnyObject] = [
         Circle(radius: 2.0),
@@ -2079,7 +2079,7 @@ for object in objects {
 
 <!--
   - test: `protocolConformance`
-  
+
   ```swifttest
   -> for object in objects {
         if let objectWithArea = object as? HasArea {
@@ -2179,7 +2179,7 @@ which has two optional requirements:
 
 <!--
   - test: `protocolConformance`
-  
+
   ```swifttest
   >> import Foundation
   -> @objc protocol CounterDataSource {
@@ -2220,7 +2220,7 @@ class Counter {
 
 <!--
   - test: `protocolConformance`
-  
+
   ```swifttest
   -> class Counter {
         var count = 0
@@ -2299,7 +2299,7 @@ class ThreeSource: NSObject, CounterDataSource {
 
 <!--
   - test: `protocolConformance`
-  
+
   ```swifttest
   -> class ThreeSource: NSObject, CounterDataSource {
         let fixedIncrement = 3
@@ -2324,7 +2324,7 @@ for _ in 1...4 {
 
 <!--
   - test: `protocolConformance`
-  
+
   ```swifttest
   -> var counter = Counter()
   -> counter.dataSource = ThreeSource()
@@ -2365,7 +2365,7 @@ class TowardsZeroSource: NSObject, CounterDataSource {
 
 <!--
   - test: `protocolConformance`
-  
+
   ```swifttest
   -> class TowardsZeroSource: NSObject, CounterDataSource {
         func increment(forCount count: Int) -> Int {
@@ -2407,7 +2407,7 @@ for _ in 1...5 {
 
 <!--
   - test: `protocolConformance`
-  
+
   ```swifttest
   -> counter.count = -4
   -> counter.dataSource = TowardsZeroSource()
@@ -2446,7 +2446,7 @@ extension RandomNumberGenerator {
 
 <!--
   - test: `protocols`
-  
+
   ```swifttest
   -> extension RandomNumberGenerator {
         func randomBool() -> Bool {
@@ -2470,7 +2470,7 @@ print("And here's a random Boolean: \(generator.randomBool())")
 
 <!--
   - test: `protocols`
-  
+
   ```swifttest
   >> do {
   -> let generator = LinearCongruentialGenerator()
@@ -2518,7 +2518,7 @@ extension PrettyTextRepresentable  {
 
 <!--
   - test: `protocols`
-  
+
   ```swifttest
   -> extension PrettyTextRepresentable  {
         var prettyTextualDescription: String {
@@ -2589,7 +2589,7 @@ extension Collection where Element: Equatable {
 
 <!--
   - test: `protocols`
-  
+
   ```swifttest
   -> extension Collection where Element: Equatable {
          func allEqual() -> Bool {
@@ -2618,7 +2618,7 @@ let differentNumbers = [100, 100, 200, 100, 200]
 
 <!--
   - test: `protocols`
-  
+
   ```swifttest
   -> let equalNumbers = [100, 100, 100, 100, 100]
   -> let differentNumbers = [100, 100, 200, 100, 200]
@@ -2638,7 +2638,7 @@ print(differentNumbers.allEqual())
 
 <!--
   - test: `protocols`
-  
+
   ```swifttest
   -> print(equalNumbers.allEqual())
   <- true

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/StringsAndCharacters.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/StringsAndCharacters.md
@@ -46,7 +46,7 @@ let someString = "Some string literal value"
 
 <!--
   - test: `stringLiterals`
-  
+
   ```swifttest
   -> let someString = "Some string literal value"
   ```
@@ -79,12 +79,12 @@ till you come to the end; then stop."
 
 <!--
   - test: `multiline-string-literals`
-  
+
   ```swifttest
   -> let quotation = """
      The White Rabbit put on his spectacles.  "Where shall I begin,
      please your Majesty?" he asked.
-  
+
      "Begin at the beginning," the King said gravely, "and go on
      till you come to the end; then stop."
      """
@@ -110,7 +110,7 @@ These are the same.
 
 <!--
   - test: `multiline-string-literals`
-  
+
   ```swifttest
   -> let singleLineString = "These are the same."
   -> let multilineString = """
@@ -141,12 +141,12 @@ till you come to the end; then stop."
 
 <!--
   - test: `multiline-string-literals`
-  
+
   ```swifttest
   -> let softWrappedQuotation = """
      The White Rabbit put on his spectacles.  "Where shall I begin, \
      please your Majesty?" he asked.
-  
+
      "Begin at the beginning," the King said gravely, "and go on \
      till you come to the end; then stop."
      """
@@ -171,13 +171,13 @@ It also ends with a line break.
 
 <!--
   - test: `multiline-string-literals`
-  
+
   ```swifttest
   -> let lineBreaks = """
-  
+
      This string starts with a line break.
      It also ends with a line break.
-  
+
      """
   ```
 -->
@@ -204,7 +204,7 @@ that whitespace *is* included.
 
 <!--
   - test: `multiline-string-literal-whitespace`
-  
+
   ```swifttest
   -> let linesWithIndentation = """
          This line doesn't begin with whitespace.
@@ -233,7 +233,7 @@ String literals can include the following special characters:
 
 <!--
   - test: `stringLiteralUnicodeScalar`
-  
+
   ```swifttest
   >> _ = "\u{0}"
   >> _ = "\u{00000000}"
@@ -264,7 +264,7 @@ let sparklingHeart = "\u{1F496}" // 💖, Unicode scalar U+1F496
 
 <!--
   - test: `specialCharacters`
-  
+
   ```swifttest
   -> let wiseWords = "\"Imagination is more important than knowledge\" - Einstein"
   >> print(wiseWords)
@@ -294,7 +294,7 @@ Escaping all three quotation marks \"\"\"
 
 <!--
   - test: `multiline-string-literals`
-  
+
   ```swifttest
   -> let threeDoubleQuotationMarks = """
      Escaping the first quotation mark \"""
@@ -337,7 +337,7 @@ Here are three more double quotes: """
 
 <!--
   - test: `extended-string-delimiters`
-  
+
   ```swifttest
   -> let threeMoreDoubleQuotationMarks = #"""
      Here are three more double quotes: """
@@ -362,7 +362,7 @@ var anotherEmptyString = String()  // initializer syntax
 
 <!--
   - test: `emptyStrings`
-  
+
   ```swifttest
   -> var emptyString = ""               // empty string literal
   -> var anotherEmptyString = String()  // initializer syntax
@@ -383,7 +383,7 @@ if emptyString.isEmpty {
 
 <!--
   - test: `emptyStrings`
-  
+
   ```swifttest
   -> if emptyString.isEmpty {
         print("Nothing to see here")
@@ -414,7 +414,7 @@ constantString += " and another Highlander"
 
 <!--
   - test: `stringMutability`
-  
+
   ```swifttest
   -> var variableString = "Horse"
   -> variableString += " and carriage"
@@ -435,7 +435,7 @@ constantString += " and another Highlander"
 
 <!--
   - test: `stringMutability-ok`
-  
+
   ```swifttest
   -> var variableString = "Horse"
   -> variableString += " and carriage"
@@ -488,7 +488,7 @@ for character in "Dog!🐶" {
 
 <!--
   - test: `characters`
-  
+
   ```swifttest
   -> for character in "Dog!🐶" {
         print(character)
@@ -512,7 +512,7 @@ let exclamationMark: Character = "!"
 
 <!--
   - test: `characters`
-  
+
   ```swifttest
   -> let exclamationMark: Character = "!"
   ```
@@ -530,7 +530,7 @@ print(catString)
 
 <!--
   - test: `characters`
-  
+
   ```swifttest
   -> let catCharacters: [Character] = ["C", "a", "t", "!", "🐱"]
   -> let catString = String(catCharacters)
@@ -553,7 +553,7 @@ var welcome = string1 + string2
 
 <!--
   - test: `concatenation`
-  
+
   ```swifttest
   -> let string1 = "hello"
   -> let string2 = " there"
@@ -574,7 +574,7 @@ instruction += string2
 
 <!--
   - test: `concatenation`
-  
+
   ```swifttest
   -> var instruction = "look over"
   -> instruction += string2
@@ -594,7 +594,7 @@ welcome.append(exclamationMark)
 
 <!--
   - test: `concatenation`
-  
+
   ```swifttest
   -> let exclamationMark: Character = "!"
   -> welcome.append(exclamationMark)
@@ -639,7 +639,7 @@ print(goodStart + end)
 
 <!--
   - test: `concatenate-multiline-string-literals`
-  
+
   ```swifttest
   -> let badStart = """
          one
@@ -656,7 +656,7 @@ print(goodStart + end)
   -> let goodStart = """
          one
          two
-  
+
          """
   -> print(goodStart + end)
   // Prints three lines:
@@ -697,7 +697,7 @@ let message = "\(multiplier) times 2.5 is \(Double(multiplier) * 2.5)"
 
 <!--
   - test: `stringInterpolation`
-  
+
   ```swifttest
   -> let multiplier = 3
   -> let message = "\(multiplier) times 2.5 is \(Double(multiplier) * 2.5)"
@@ -728,7 +728,7 @@ print(#"Write an interpolated string in Swift using \(multiplier)."#)
 
 <!--
   - test: `stringInterpolation`
-  
+
   ```swifttest
   -> print(#"Write an interpolated string in Swift using \(multiplier)."#)
   <- Write an interpolated string in Swift using \(multiplier).
@@ -748,7 +748,7 @@ print(#"6 times 7 is \#(6 * 7)."#)
 
 <!--
   - test: `stringInterpolation`
-  
+
   ```swifttest
   -> print(#"6 times 7 is \#(6 * 7)."#)
   <- 6 times 7 is 42.
@@ -812,7 +812,7 @@ let combinedEAcute: Character = "\u{65}\u{301}"          // e followed by ́
 
 <!--
   - test: `graphemeClusters1`
-  
+
   ```swifttest
   -> let eAcute: Character = "\u{E9}"                         // é
   >> assert(eAcute == "é")
@@ -838,7 +838,7 @@ let decomposed: Character = "\u{1112}\u{1161}\u{11AB}"   // ᄒ, ᅡ, ᆫ
 
 <!--
   - test: `graphemeClusters2`
-  
+
   ```swifttest
   -> let precomposed: Character = "\u{D55C}"                  // 한
   >> assert(precomposed == "한")
@@ -860,7 +860,7 @@ let enclosedEAcute: Character = "\u{E9}\u{20DD}"
 
 <!--
   - test: `graphemeClusters3`
-  
+
   ```swifttest
   -> let enclosedEAcute: Character = "\u{E9}\u{20DD}"
   >> assert(enclosedEAcute == "é⃝")
@@ -881,7 +881,7 @@ let regionalIndicatorForUS: Character = "\u{1F1FA}\u{1F1F8}"
 
 <!--
   - test: `graphemeClusters4`
-  
+
   ```swifttest
   -> let regionalIndicatorForUS: Character = "\u{1F1FA}\u{1F1F8}"
   >> assert(regionalIndicatorForUS == "🇺🇸")
@@ -903,7 +903,7 @@ print("unusualMenagerie has \(unusualMenagerie.count) characters")
 
 <!--
   - test: `characterCount`
-  
+
   ```swifttest
   -> let unusualMenagerie = "Koala 🐨, Snail 🐌, Penguin 🐧, Dromedary 🐪"
   -> print("unusualMenagerie has \(unusualMenagerie.count) characters")
@@ -933,7 +933,7 @@ print("the number of characters in \(word) is \(word.count)")
 
 <!--
   - test: `characterCount`
-  
+
   ```swifttest
   -> var word = "cafe"
   -> print("the number of characters in \(word) is \(word.count)")
@@ -1013,7 +1013,7 @@ greeting[index]
 
 <!--
   - test: `stringIndex`
-  
+
   ```swifttest
   -> let greeting = "Guten Tag!"
   >> print(
@@ -1056,7 +1056,7 @@ greeting.index(after: greeting.endIndex) // Error
 
 <!--
   - test: `emptyStringIndices`
-  
+
   ```swifttest
   -> let emptyString = ""
   -> assert(
@@ -1077,7 +1077,7 @@ for index in greeting.indices {
 
 <!--
   - test: `stringIndex`
-  
+
   ```swifttest
   -> for index in greeting.indices {
         print("\(greeting[index]) ", terminator: "")
@@ -1116,7 +1116,7 @@ welcome.insert(contentsOf: " there", at: welcome.index(before: welcome.endIndex)
 
 <!--
   - test: `stringInsertionAndRemoval`
-  
+
   ```swifttest
   -> var welcome = "hello"
   -> welcome.insert("!", at: welcome.endIndex)
@@ -1145,7 +1145,7 @@ welcome.removeSubrange(range)
 
 <!--
   - test: `stringInsertionAndRemoval`
-  
+
   ```swifttest
   -> welcome.remove(at: welcome.index(before: welcome.endIndex))
   /> welcome now equals \"\(welcome)\"
@@ -1197,7 +1197,7 @@ let newString = String(beginning)
 
 <!--
   - test: `string-and-substring`
-  
+
   ```swifttest
   -> let greeting = "Hello, world!"
   -> let index = greeting.firstIndex(of: ",") ?? greeting.endIndex
@@ -1276,7 +1276,7 @@ if quotation == sameQuotation {
 
 <!--
   - test: `stringEquality`
-  
+
   ```swifttest
   -> let quotation = "We're a lot alike, you and I."
   -> let sameQuotation = "We're a lot alike, you and I."
@@ -1295,7 +1295,7 @@ even if they're composed from different Unicode scalars behind the scenes.
 
 <!--
   - test: `characterComparisonUsesCanonicalEquivalence`
-  
+
   ```swifttest
   -> let eAcute: Character = "\u{E9}"
   -> let combinedEAcute: Character = "\u{65}\u{301}"
@@ -1310,7 +1310,7 @@ even if they're composed from different Unicode scalars behind the scenes.
 
 <!--
   - test: `stringComparisonUsesCanonicalEquivalence`
-  
+
   ```swifttest
   -> let cafe1 = "caf\u{E9}"
   -> let cafe2 = "caf\u{65}\u{301}"
@@ -1344,7 +1344,7 @@ if eAcuteQuestion == combinedEAcuteQuestion {
 
 <!--
   - test: `stringEquality`
-  
+
   ```swifttest
   // "Voulez-vous un café?" using LATIN SMALL LETTER E WITH ACUTE
   -> let eAcuteQuestion = "Voulez-vous un caf\u{E9}?"
@@ -1379,7 +1379,7 @@ if latinCapitalLetterA != cyrillicCapitalLetterA {
 
 <!--
   - test: `stringEquality`
-  
+
   ```swifttest
   -> let latinCapitalLetterA: Character = "\u{41}"
   >> assert(latinCapitalLetterA == "A")
@@ -1410,7 +1410,7 @@ both of which take a single argument of type `String` and return a Boolean value
 
 <!--
   - test: `prefixComparisonUsesCharactersNotScalars`
-  
+
   ```swifttest
   -> let ecole = "\u{E9}cole"
   -> if ecole.hasPrefix("\u{E9}") {
@@ -1430,7 +1430,7 @@ both of which take a single argument of type `String` and return a Boolean value
 
 <!--
   - test: `suffixComparisonUsesCharactersNotScalars`
-  
+
   ```swifttest
   -> let cafe = "caf\u{E9}"
   -> if cafe.hasSuffix("\u{E9}") {
@@ -1469,7 +1469,7 @@ let romeoAndJuliet = [
 
 <!--
   - test: `prefixesAndSuffixes`
-  
+
   ```swifttest
   -> let romeoAndJuliet = [
         "Act 1 Scene 1: Verona, A public place",
@@ -1503,7 +1503,7 @@ print("There are \(act1SceneCount) scenes in Act 1")
 
 <!--
   - test: `prefixesAndSuffixes`
-  
+
   ```swifttest
   -> var act1SceneCount = 0
   -> for scene in romeoAndJuliet {
@@ -1535,7 +1535,7 @@ print("\(mansionCount) mansion scenes; \(cellCount) cell scenes")
 
 <!--
   - test: `prefixesAndSuffixes`
-  
+
   ```swifttest
   -> var mansionCount = 0
   -> var cellCount = 0
@@ -1591,7 +1591,7 @@ let dogString = "Dog‼🐶"
 
 <!--
   - test: `unicodeRepresentations`
-  
+
   ```swifttest
   -> let dogString = "Dog‼🐶"
   ```
@@ -1617,7 +1617,7 @@ print("")
 
 <!--
   - test: `unicodeRepresentations`
-  
+
   ```swifttest
   -> for codeUnit in dogString.utf8 {
         print("\(codeUnit) ", terminator: "")
@@ -1671,7 +1671,7 @@ print("")
 
 <!--
   - test: `unicodeRepresentations`
-  
+
   ```swifttest
   -> for codeUnit in dogString.utf16 {
         print("\(codeUnit) ", terminator: "")
@@ -1725,7 +1725,7 @@ print("")
 
 <!--
   - test: `unicodeRepresentations`
-  
+
   ```swifttest
   -> for scalar in dogString.unicodeScalars {
         print("\(scalar.value) ", terminator: "")
@@ -1770,7 +1770,7 @@ for scalar in dogString.unicodeScalars {
 
 <!--
   - test: `unicodeRepresentations`
-  
+
   ```swifttest
   -> for scalar in dogString.unicodeScalars {
         print("\(scalar) ")

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Subscripts.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Subscripts.md
@@ -46,7 +46,7 @@ subscript(index: Int) -> Int {
 
 <!--
   - test: `subscriptSyntax`
-  
+
   ```swifttest
   >> class Test1 {
   -> subscript(index: Int) -> Int {
@@ -80,7 +80,7 @@ subscript(index: Int) -> Int {
 
 <!--
   - test: `subscriptSyntax`
-  
+
   ```swifttest
   >> class Test2 {
   -> subscript(index: Int) -> Int {
@@ -108,7 +108,7 @@ print("six times three is \(threeTimesTable[6])")
 
 <!--
   - test: `timesTable`
-  
+
   ```swifttest
   -> struct TimesTable {
         let multiplier: Int
@@ -157,7 +157,7 @@ numberOfLegs["bird"] = 2
 
 <!--
   - test: `dictionarySubscript`
-  
+
   ```swifttest
   -> var numberOfLegs = ["spider": 8, "ant": 6, "cat": 4]
   -> numberOfLegs["bird"] = 2
@@ -199,7 +199,7 @@ subscripts can't use in-out parameters.
 
 <!--
   - test: `subscripts-can-have-default-arguments`
-  
+
   ```swifttest
   >> struct Subscriptable {
   >>     subscript(x: Int, y: Int = 0) -> Int {
@@ -252,7 +252,7 @@ struct Matrix {
 
 <!--
   - test: `matrixSubscript, matrixSubscriptAssert`
-  
+
   ```swifttest
   -> struct Matrix {
         let rows: Int, columns: Int
@@ -296,7 +296,7 @@ var matrix = Matrix(rows: 2, columns: 2)
 
 <!--
   - test: `matrixSubscript, matrixSubscriptAssert`
-  
+
   ```swifttest
   -> var matrix = Matrix(rows: 2, columns: 2)
   >> assert(matrix.grid == [0.0, 0.0, 0.0, 0.0])
@@ -320,7 +320,7 @@ matrix[1, 0] = 3.2
 
 <!--
   - test: `matrixSubscript, matrixSubscriptAssert`
-  
+
   ```swifttest
   -> matrix[0, 1] = 1.5
   >> print(matrix[0, 1])
@@ -354,7 +354,7 @@ func indexIsValid(row: Int, column: Int) -> Bool {
 
 <!--
   - test: `matrixSubscript`
-  
+
   ```swifttest
   >> var rows = 2
   >> var columns = 2
@@ -374,7 +374,7 @@ let someValue = matrix[2, 2]
 
 <!--
   - test: `matrixSubscriptAssert`
-  
+
   ```swifttest
   -> let someValue = matrix[2, 2]
   xx assert
@@ -407,7 +407,7 @@ print(mars)
 
 <!--
   - test: `static-subscript`
-  
+
   ```swifttest
   -> enum Planet: Int {
         case mercury = 1, venus, earth, mars, jupiter, saturn, uranus, neptune

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/TheBasics.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/TheBasics.md
@@ -66,7 +66,7 @@ var currentLoginAttempt = 0
 
 <!--
   - test: `constantsAndVariables`
-  
+
   ```swifttest
   -> let maximumNumberOfLoginAttempts = 10
   -> var currentLoginAttempt = 0
@@ -95,7 +95,7 @@ var x = 0.0, y = 0.0, z = 0.0
 
 <!--
   - test: `multipleDeclarations`
-  
+
   ```swifttest
   -> var x = 0.0, y = 0.0, z = 0.0
   >> print(x, y, z)
@@ -123,7 +123,7 @@ var welcomeMessage: String
 
 <!--
   - test: `typeAnnotations`
-  
+
   ```swifttest
   -> var welcomeMessage: String
   ```
@@ -145,7 +145,7 @@ welcomeMessage = "Hello"
 
 <!--
   - test: `typeAnnotations`
-  
+
   ```swifttest
   -> welcomeMessage = "Hello"
   >> print(welcomeMessage)
@@ -162,7 +162,7 @@ var red, green, blue: Double
 
 <!--
   - test: `typeAnnotations`
-  
+
   ```swifttest
   -> var red, green, blue: Double
   ```
@@ -189,7 +189,7 @@ let 🐶🐮 = "dogcow"
 
 <!--
   - test: `constantsAndVariables`
-  
+
   ```swifttest
   -> let π = 3.14159
   -> let 你好 = "你好世界"
@@ -225,7 +225,7 @@ friendlyWelcome = "Bonjour!"
 
 <!--
   - test: `constantsAndVariables`
-  
+
   ```swifttest
   -> var friendlyWelcome = "Hello!"
   -> friendlyWelcome = "Bonjour!"
@@ -245,7 +245,7 @@ languageName = "Swift++"
 
 <!--
   - test: `constantsAndVariables_err`
-  
+
   ```swifttest
   -> let languageName = "Swift"
   -> languageName = "Swift++"
@@ -271,7 +271,7 @@ print(friendlyWelcome)
 
 <!--
   - test: `constantsAndVariables`
-  
+
   ```swifttest
   -> print(friendlyWelcome)
   <- Bonjour!
@@ -294,7 +294,7 @@ see <doc:Functions#Default-Parameter-Values>.
 
 <!--
   - test: `printingWithoutNewline`
-  
+
   ```swifttest
   >> let someValue = 10
   -> print(someValue, terminator: "")
@@ -325,7 +325,7 @@ print("The current value of friendlyWelcome is \(friendlyWelcome)")
 
 <!--
   - test: `constantsAndVariables`
-  
+
   ```swifttest
   -> print("The current value of friendlyWelcome is \(friendlyWelcome)")
   <- The current value of friendlyWelcome is Bonjour!
@@ -350,7 +350,7 @@ Single-line comments begin with two forward-slashes (`//`):
 
 <!--
   - test: `comments`
-  
+
   ```swifttest
   -> // This is a comment.
   ```
@@ -366,7 +366,7 @@ but is written over multiple lines. */
 
 <!--
   - test: `comments`
-  
+
   ```swifttest
   -> /* This is also a comment
      but is written over multiple lines. */
@@ -387,7 +387,7 @@ This is the end of the first multiline comment. */
 
 <!--
   - test: `comments`
-  
+
   ```swifttest
   -> /* This is the start of the first multiline comment.
         /* This is the second, nested multiline comment. */
@@ -413,7 +413,7 @@ let cat = "🐱"; print(cat)
 
 <!--
   - test: `semiColons`
-  
+
   ```swifttest
   -> let cat = "🐱"; print(cat)
   <- 🐱
@@ -445,7 +445,7 @@ let maxValue = UInt8.max  // maxValue is equal to 255, and is of type UInt8
 
 <!--
   - test: `integerBounds`
-  
+
   ```swifttest
   -> let minValue = UInt8.min  // minValue is equal to 0, and is of type UInt8
   -> let maxValue = UInt8.max  // maxValue is equal to 255, and is of type UInt8
@@ -561,7 +561,7 @@ let meaningOfLife = 42
 
 <!--
   - test: `typeInference`
-  
+
   ```swifttest
   -> let meaningOfLife = 42
   // meaningOfLife is inferred to be of type Int
@@ -580,7 +580,7 @@ let pi = 3.14159
 
 <!--
   - test: `typeInference`
-  
+
   ```swifttest
   -> let pi = 3.14159
   // pi is inferred to be of type Double
@@ -602,7 +602,7 @@ let anotherPi = 3 + 0.14159
 
 <!--
   - test: `typeInference`
-  
+
   ```swifttest
   -> let anotherPi = 3 + 0.14159
   // anotherPi is also inferred to be of type Double
@@ -635,7 +635,7 @@ let hexadecimalInteger = 0x11     // 17 in hexadecimal notation
 
 <!--
   - test: `numberLiterals`
-  
+
   ```swifttest
   -> let decimalInteger = 17
   -> let binaryInteger = 0b10001       // 17 in binary notation
@@ -656,7 +656,7 @@ indicated by an uppercase or lowercase `p`.
 
 <!--
   - test: `float-required-vs-optional-exponent-err`
-  
+
   ```swifttest
   -> let hexWithout = 0x1.5
   !$ error: hexadecimal floating point literal must end with an exponent
@@ -667,7 +667,7 @@ indicated by an uppercase or lowercase `p`.
 
 <!--
   - test: `float-required-vs-optional-exponent`
-  
+
   ```swifttest
   -> let hexWith = 0x1.5p7
   -> let decimalWithout = 0.5
@@ -697,7 +697,7 @@ let hexadecimalDouble = 0xC.3p0
 
 <!--
   - test: `numberLiterals`
-  
+
   ```swifttest
   -> let decimalDouble = 12.1875
   -> let exponentDouble = 1.21875e1
@@ -718,7 +718,7 @@ let justOverOneMillion = 1_000_000.000_000_1
 
 <!--
   - test: `numberLiterals`
-  
+
   ```swifttest
   -> let paddedDouble = 000123.456
   -> let oneMillion = 1_000_000
@@ -760,7 +760,7 @@ let tooBig: Int8 = Int8.max + 1
 
 <!--
   - test: `constantsAndVariablesOverflowError`
-  
+
   ```swifttest
   -> let cannotBeNegative: UInt8 = -1
   // UInt8 can't store negative numbers, and so this will report an error
@@ -800,7 +800,7 @@ let twoThousandAndOne = twoThousand + UInt16(one)
 
 <!--
   - test: `typeConversion`
-  
+
   ```swifttest
   -> let twoThousand: UInt16 = 2_000
   -> let one: UInt8 = 1
@@ -838,7 +838,7 @@ let pi = Double(three) + pointOneFourOneFiveNine
 
 <!--
   - test: `typeConversion`
-  
+
   ```swifttest
   -> let three = 3
   -> let pointOneFourOneFiveNine = 0.14159
@@ -862,7 +862,7 @@ let integerPi = Int(pi)
 
 <!--
   - test: `typeConversion`
-  
+
   ```swifttest
   -> let integerPi = Int(pi)
   /> integerPi equals \(integerPi), and is inferred to be of type Int
@@ -900,7 +900,7 @@ typealias AudioSample = UInt16
 
 <!--
   - test: `typeAliases`
-  
+
   ```swifttest
   -> typealias AudioSample = UInt16
   ```
@@ -916,7 +916,7 @@ var maxAmplitudeFound = AudioSample.min
 
 <!--
   - test: `typeAliases`
-  
+
   ```swifttest
   -> var maxAmplitudeFound = AudioSample.min
   /> maxAmplitudeFound is now \(maxAmplitudeFound)
@@ -944,7 +944,7 @@ let turnipsAreDelicious = false
 
 <!--
   - test: `booleans`
-  
+
   ```swifttest
   -> let orangesAreOrange = true
   -> let turnipsAreDelicious = false
@@ -974,7 +974,7 @@ if turnipsAreDelicious {
 
 <!--
   - test: `booleans`
-  
+
   ```swifttest
   -> if turnipsAreDelicious {
         print("Mmm, tasty turnips!")
@@ -999,7 +999,7 @@ if i {
 
 <!--
   - test: `booleansNotBoolean`
-  
+
   ```swifttest
   -> let i = 1
   -> if i {
@@ -1023,7 +1023,7 @@ if i == 1 {
 
 <!--
   - test: `booleansIsBoolean`
-  
+
   ```swifttest
   -> let i = 1
   -> if i == 1 {
@@ -1057,7 +1057,7 @@ let http404Error = (404, "Not Found")
 
 <!--
   - test: `tuples`
-  
+
   ```swifttest
   -> let http404Error = (404, "Not Found")
   /> http404Error is of type (Int, String), and equals (\(http404Error.0), \"\(http404Error.1)\")
@@ -1089,7 +1089,7 @@ print("The status message is \(statusMessage)")
 
 <!--
   - test: `tuples`
-  
+
   ```swifttest
   -> let (statusCode, statusMessage) = http404Error
   -> print("The status code is \(statusCode)")
@@ -1111,7 +1111,7 @@ print("The status code is \(justTheStatusCode)")
 
 <!--
   - test: `tuples`
-  
+
   ```swifttest
   -> let (justTheStatusCode, _) = http404Error
   -> print("The status code is \(justTheStatusCode)")
@@ -1131,7 +1131,7 @@ print("The status message is \(http404Error.1)")
 
 <!--
   - test: `tuples`
-  
+
   ```swifttest
   -> print("The status code is \(http404Error.0)")
   <- The status code is 404
@@ -1148,7 +1148,7 @@ let http200Status = (statusCode: 200, description: "OK")
 
 <!--
   - test: `tuples`
-  
+
   ```swifttest
   -> let http200Status = (statusCode: 200, description: "OK")
   ```
@@ -1166,7 +1166,7 @@ print("The status message is \(http200Status.description)")
 
 <!--
   - test: `tuples`
-  
+
   ```swifttest
   -> print("The status code is \(http200Status.statusCode)")
   <- The status code is 200
@@ -1228,7 +1228,7 @@ let convertedNumber = Int(possibleNumber)
 
 <!--
   - test: `optionals`
-  
+
   ```swifttest
   -> let possibleNumber = "123"
   -> let convertedNumber = Int(possibleNumber)
@@ -1261,7 +1261,7 @@ serverResponseCode = nil
 
 <!--
   - test: `optionals`
-  
+
   ```swifttest
   -> var serverResponseCode: Int? = 404
   /> serverResponseCode contains an actual Int value of \(serverResponseCode!)
@@ -1286,7 +1286,7 @@ var surveyAnswer: String?
 
 <!--
   - test: `optionals`
-  
+
   ```swifttest
   -> var surveyAnswer: String?
   // surveyAnswer is automatically set to nil
@@ -1316,7 +1316,7 @@ if convertedNumber != nil {
 
 <!--
   - test: `optionals`
-  
+
   ```swifttest
   -> if convertedNumber != nil {
         print("convertedNumber contains some integer value.")
@@ -1341,7 +1341,7 @@ if convertedNumber != nil {
 
 <!--
   - test: `optionals`
-  
+
   ```swifttest
   -> if convertedNumber != nil {
         print("convertedNumber has an integer value of \(convertedNumber!).")
@@ -1390,7 +1390,7 @@ if let actualNumber = Int(possibleNumber) {
 
 <!--
   - test: `optionals`
-  
+
   ```swifttest
   -> if let actualNumber = Int(possibleNumber) {
         print("The string \"\(possibleNumber)\" has an integer value of \(actualNumber)")
@@ -1429,7 +1429,7 @@ if let myNumber = myNumber {
 
 <!--
   - test: `optionals`
-  
+
   ```swifttest
   -> let myNumber = Int(possibleNumber)
   // Here, myNumber is an optional integer
@@ -1465,7 +1465,7 @@ if let myNumber {
 
 <!--
   - test: `optionals`
-  
+
   ```swifttest
   -> if let myNumber {
          print("My number is \(myNumber)")
@@ -1511,7 +1511,7 @@ if let firstNumber = Int("4") {
 
 <!--
   - test: `multipleOptionalBindings`
-  
+
   ```swifttest
   -> if let firstNumber = Int("4"), let secondNumber = Int("42"), firstNumber < secondNumber && secondNumber < 100 {
         print("\(firstNumber) < \(secondNumber) < 100")
@@ -1587,7 +1587,7 @@ let implicitString: String = assumedString // no need for an exclamation point
 
 <!--
   - test: `implicitlyUnwrappedOptionals`
-  
+
   ```swifttest
   -> let possibleString: String? = "An optional string."
   -> let forcedString: String = possibleString! // requires an exclamation point
@@ -1617,7 +1617,7 @@ let optionalString = assumedString
 
 <!--
   - test: `implicitlyUnwrappedOptionals`
-  
+
   ```swifttest
   -> let optionalString = assumedString
   // The type of optionalString is "String?" and assumedString isn't force-unwrapped.
@@ -1643,7 +1643,7 @@ if assumedString != nil {
 
 <!--
   - test: `implicitlyUnwrappedOptionals`
-  
+
   ```swifttest
   -> if assumedString != nil {
         print(assumedString!)
@@ -1664,7 +1664,7 @@ if let definiteString = assumedString {
 
 <!--
   - test: `implicitlyUnwrappedOptionals`
-  
+
   ```swifttest
   -> if let definiteString = assumedString {
         print(definiteString)
@@ -1700,7 +1700,7 @@ func canThrowAnError() throws {
 
 <!--
   - test: `errorHandling`
-  
+
   ```swifttest
   >> enum SimpleError: Error {
   >>    case someError
@@ -1734,7 +1734,7 @@ do {
 
 <!--
   - test: `errorHandling`
-  
+
   ```swifttest
   -> do {
   ->    try canThrowAnError()
@@ -1771,7 +1771,7 @@ do {
 
 <!--
   - test: `errorHandlingTwo`
-  
+
   ```swifttest
   >> enum SandwichError: Error {
   >>     case outOfCleanDishes
@@ -1890,7 +1890,7 @@ assert(age >= 0, "A person's age can't be less than zero.")
 
 <!--
   - test: `assertions-1`
-  
+
   ```swifttest
   -> let age = -3
   -> assert(age >= 0, "A person's age can't be less than zero.")
@@ -1914,7 +1914,7 @@ assert(age >= 0)
 
 <!--
   - test: `assertions-2`
-  
+
   ```swifttest
   >> let age = -3
   -> assert(age >= 0)
@@ -1924,7 +1924,7 @@ assert(age >= 0)
 
 <!--
   - test: `assertionsCanUseStringInterpolation`
-  
+
   ```swifttest
   -> let age = -3
   -> assert(age >= 0, "A person's age can't be less than zero, but value is \(age).")
@@ -1950,7 +1950,7 @@ if age > 10 {
 
 <!--
   - test: `assertions-3`
-  
+
   ```swifttest
   >> let age = -3
   -> if age > 10 {
@@ -1984,7 +1984,7 @@ precondition(index > 0, "Index must be greater than zero.")
 
 <!--
   - test: `preconditions`
-  
+
   ```swifttest
   >> let index = -1
   // In the implementation of a subscript...
@@ -2017,7 +2017,7 @@ by one of the switch's other cases.
 <!--
   "\ " in the first cell below lets it be empty.
   Otherwise RST treats the row as a continuation.
-  
+
   ============ =====  ==========  ===============================
   \            Debug  Production  Production with ``-Ounchecked``
   ============ =====  ==========  ===============================

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/TypeCasting.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/TypeCasting.md
@@ -40,7 +40,7 @@ class MediaItem {
 
 <!--
   - test: `typeCasting, typeCasting-err`
-  
+
   ```swifttest
   -> class MediaItem {
         var name: String
@@ -78,7 +78,7 @@ class Song: MediaItem {
 
 <!--
   - test: `typeCasting, typeCasting-err`
-  
+
   ```swifttest
   -> class Movie: MediaItem {
         var director: String
@@ -119,7 +119,7 @@ let library = [
 
 <!--
   - test: `typeCasting`
-  
+
   ```swifttest
   -> let library = [
         Movie(name: "Casablanca", director: "Michael Curtiz"),
@@ -171,7 +171,7 @@ print("Media library contains \(movieCount) movies and \(songCount) songs")
 
 <!--
   - test: `typeCasting`
-  
+
   ```swifttest
   -> var movieCount = 0
   -> var songCount = 0
@@ -256,7 +256,7 @@ for item in library {
 
 <!--
   - test: `typeCasting`
-  
+
   ```swifttest
   -> for item in library {
         if let movie = item as? Movie {
@@ -347,7 +347,7 @@ things.append({ (name: String) -> String in "Hello, \(name)" })
 
 <!--
   - test: `typeCasting, typeCasting-err`
-  
+
   ```swifttest
   -> var things: [Any] = []
   ---
@@ -415,7 +415,7 @@ for thing in things {
 
 <!--
   - test: `typeCasting`
-  
+
   ```swifttest
   -> for thing in things {
         switch thing {
@@ -459,7 +459,7 @@ for thing in things {
 > If you really do need to use an optional value as an `Any` value,
 > you can use the `as` operator to explicitly cast the optional to `Any`,
 > as shown below.
-> 
+>
 > ```swift
 > let optionalNumber: Int? = 3
 > things.append(optionalNumber)        // Warning
@@ -495,17 +495,17 @@ for thing in things {
   Rejected examples to illustrate AnyObject:
 
   Array of delegates which may conform to one or more of the class's delegate protocols.
-  
+
   ```
   protocol MovieDelegate {
       func willPlay(movie: Movie)
   }
-  
+
   class Library {
       var delegates = [AnyObject]
       ...
   }
-  
+
   for delegate in delegates {
       guard let delegate = delegate as MovieDelegate else { continue }
       delegate.willPlay(movie: m)
@@ -513,7 +513,7 @@ for thing in things {
   ```
 
   A userData object for associating some opaque piece of data or state with an API call.
-  
+
   ```
   class C {
       // Not userInfo -- that's usually a Dictionary

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Attributes.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Attributes.md
@@ -75,7 +75,7 @@ including important milestones.
 - The `introduced` argument indicates the first version
   of the specified platform or language in which the declaration was introduced.
   It has the following form:
-  
+
   ```swift
   introduced: <#version number#>
   ```
@@ -84,7 +84,7 @@ including important milestones.
 - The `deprecated` argument indicates the first version
   of the specified platform or language in which the declaration was deprecated.
   It has the following form:
-  
+
   ```swift
   deprecated: <#version number#>
   ```
@@ -98,7 +98,7 @@ including important milestones.
   When a declaration is obsoleted,
   it's removed from the specified platform or language and can no longer be used.
   It has the following form:
-  
+
   ```swift
   obsoleted: <#version number#>
   ```
@@ -106,7 +106,7 @@ including important milestones.
 - The `message` argument provides a textual message that the compiler displays
   when emitting a warning or error about the use of a deprecated or obsoleted declaration.
   It has the following form:
-  
+
   ```swift
   message: <#message#>
   ```
@@ -116,7 +116,7 @@ including important milestones.
   The compiler displays the new name
   when emitting an error about the use of a renamed declaration.
   It has the following form:
-  
+
   ```swift
   renamed: <#new name#>
   ```
@@ -127,18 +127,18 @@ including important milestones.
   between releases of a framework or library.
   This combination results in a compile-time error
   that the declaration has been renamed.
-  
+
   ```swift
   // First release
   protocol MyProtocol {
       // protocol definition
   }
   ```
-  
-  
+
+
   <!--
     - test: `renamed1`
-    
+
     ```swifttest
     -> // First release
     -> protocol MyProtocol {
@@ -146,21 +146,21 @@ including important milestones.
        }
     ```
   -->
-  
+
   ```swift
   // Subsequent release renames MyProtocol
   protocol MyRenamedProtocol {
       // protocol definition
   }
-  
+
   @available(*, unavailable, renamed: "MyRenamedProtocol")
   typealias MyProtocol = MyRenamedProtocol
   ```
-  
-  
+
+
   <!--
     - test: `renamed2`
-    
+
     ```swifttest
     -> // Subsequent release renames MyProtocol
     -> protocol MyRenamedProtocol {
@@ -184,7 +184,7 @@ the platform and Swift availabilities.
 
 <!--
   - test: `multipleAvailableAttributes`
-  
+
   ```swifttest
   -> @available(iOS 9, *)
   -> @available(macOS 10.9, *)
@@ -216,7 +216,7 @@ class MyClass {
 
 <!--
   - test: `availableShorthand`
-  
+
   ```swifttest
   -> @available(iOS 10.0, macOS 10.12, *)
   -> class MyClass {
@@ -241,7 +241,7 @@ struct MyStruct {
 
 <!--
   - test: `availableMultipleAvailabilities`
-  
+
   ```swifttest
   -> @available(swift 3.0.2)
   -> @available(macOS 10.12, *)
@@ -296,7 +296,7 @@ dial.dynamicallyCall(withArguments: [4, 1, 1])
 
 <!--
   - test: `dynamicCallable`
-  
+
   ```swifttest
   -> @dynamicCallable
   -> struct TelephoneExchange {
@@ -356,7 +356,7 @@ print(repeatLabels(a: 1, b: 2, c: 3, b: 2, a: 1))
 
 <!--
   - test: `dynamicCallable`
-  
+
   ```swifttest
   -> @dynamicCallable
      struct Repeater {
@@ -410,7 +410,7 @@ repeatLabels(a: "four") // Error
 
 <!--
   - test: `dynamicCallable-err`
-  
+
   ```swifttest
   >> @dynamicCallable
   >> struct Repeater {
@@ -485,7 +485,7 @@ print(dynamic == equivalent)
 
 <!--
   - test: `dynamicMemberLookup`
-  
+
   ```swifttest
   -> @dynamicMemberLookup
   -> struct DynamicStruct {
@@ -532,7 +532,7 @@ print(wrapper.x)
 
 <!--
   - test: `dynamicMemberLookup`
-  
+
   ```swifttest
   -> struct Point { var x, y: Int }
   ---
@@ -569,7 +569,7 @@ but they break ABI compatibility for frozen types.
 
 <!--
   - test: `can-use-frozen-without-evolution`
-  
+
   ```swifttest
   >> @frozen public enum E { case x, y }
   >> @frozen public struct S { var a: Int = 10 }
@@ -582,7 +582,7 @@ but they break ABI compatibility for frozen types.
 
 <!--
   - test: `frozen-is-fine-with-evolution`
-  
+
   ```swifttest
   >> @frozen public enum E { case x, y }
   >> @frozen public struct S { var a: Int = 10 }
@@ -614,7 +614,7 @@ as discussed in <doc:Attributes#inlinable>.
 
 <!--
   - test: `frozen-struct-prop-init-cant-refer-to-private-type`
-  
+
   ```swifttest
   >> public protocol P { }
   >> private struct PrivateStruct: P { }
@@ -658,7 +658,7 @@ produces a warning because that code is never executed.
 
 <!--
   - test: `NoUnknownDefaultOverFrozenEnum`
-  
+
   ```swifttest
   >> public enum E { case x, y }
   >> @frozen public enum F { case x, y }
@@ -667,7 +667,7 @@ produces a warning because that code is never executed.
 
 <!--
   - test: `NoUnknownDefaultOverFrozenEnum_Test1`
-  
+
   ```swifttest
   >> import NoUnknownDefaultOverFrozenEnum
   >> func main() {
@@ -684,7 +684,7 @@ produces a warning because that code is never executed.
 
 <!--
   - test: `NoUnknownDefaultOverFrozenEnum_Test2`
-  
+
   ```swifttest
   >> import NoUnknownDefaultOverFrozenEnum
   >> func main() {
@@ -749,7 +749,7 @@ even though they can't be marked with this attribute.
 
 <!--
   - test: `cant-inline-private`
-  
+
   ```swifttest
   >> @inlinable private func f() { }
   !$ error: '@inlinable' attribute can only be applied to public declarations, but 'f' is private
@@ -760,7 +760,7 @@ even though they can't be marked with this attribute.
 
 <!--
   - test: `cant-inline-nested`
-  
+
   ```swifttest
   >> public func outer() {
   >>    @inlinable func f() { }
@@ -776,7 +776,7 @@ even though they can't be marked with this attribute.
   TODO: When we get resilience, this will actually be a problem.
   Until then, per discussion with [Contributor 6004], there's no (supported) way
   for folks to get into the state where this behavior would be triggered.
-  
+
   If a project uses a module that includes inlinable functions,
   the inlined copies aren't necessarily updated
   when the module's implementation of the function changes.
@@ -811,7 +811,7 @@ struct MyTopLevel {
 
 <!--
   - test: `atMain`
-  
+
   ```swifttest
   -> @main
   -> struct MyTopLevel {
@@ -837,7 +837,7 @@ protocol ProvidesMain {
 
 <!--
   - test: `atMain_ProvidesMain`
-  
+
   ```swifttest
   -> protocol ProvidesMain {
          static func main() throws
@@ -851,7 +851,7 @@ as discussed in <doc:Declarations#Top-Level-Code>.
 
 <!--
   - test: `no-at-main-in-top-level-code`
-  
+
   ```swifttest
   // This is the same example as atMain, but without :compile: true.
   >> @main
@@ -871,7 +871,7 @@ as discussed in <doc:Declarations#Top-Level-Code>.
 
 <!--
   - test: `atMain_library`
-  
+
   ```swifttest
   -> // In file "library.swift"
   -> open class C {
@@ -882,7 +882,7 @@ as discussed in <doc:Declarations#Top-Level-Code>.
 
 <!--
   - test: `atMain_client`
-  
+
   ```swifttest
   -> import atMain_library
   -> @main class CC: C { }
@@ -1039,7 +1039,7 @@ class ExampleClass: NSObject {
 
 <!--
   - test: `objc-attribute`
-  
+
   ```swifttest
   >> import Foundation
   -> class ExampleClass: NSObject {
@@ -1108,7 +1108,7 @@ Computed variables, global variables, and constants can't use property wrappers.
 
 <!--
   - test: `property-wrappers-can-go-on-stored-variable`
-  
+
   ```swifttest
   >> @propertyWrapper struct UselessWrapper { var wrappedValue: Int }
   >> func f() {
@@ -1122,7 +1122,7 @@ Computed variables, global variables, and constants can't use property wrappers.
 
 <!--
   - test: `property-wrappers-cant-go-on-constants`
-  
+
   ```swifttest
   >> @propertyWrapper struct UselessWrapper { var wrappedValue: Int }
   >> func f() {
@@ -1137,7 +1137,7 @@ Computed variables, global variables, and constants can't use property wrappers.
 
 <!--
   - test: `property-wrappers-cant-go-on-computed-variable`
-  
+
   ```swifttest
   >> @propertyWrapper struct UselessWrapper { var wrappedValue: Int }
   >> func f() {
@@ -1213,7 +1213,7 @@ struct SomeStruct {
 
 <!--
   - test: `propertyWrapper`
-  
+
   ```swifttest
   -> @propertyWrapper
   -> struct SomeWrapper {
@@ -1259,7 +1259,7 @@ struct SomeStruct {
   However, you can only see that behavior using local variables
   which currently can't have a property wrapper.
   It would look like this:
-  
+
   -> @SomeWrapper var e
   -> e = 20  // Uses init(wrappedValue:)
   -> e = 30  // Uses the property setter
@@ -1301,7 +1301,7 @@ s.$x.wrapper  // WrapperWithProjection value
 
 <!--
   - test: `propertyWrapper-projection`
-  
+
   ```swifttest
   -> @propertyWrapper
   -> struct WrapperWithProjection {
@@ -1435,7 +1435,7 @@ struct ArrayBuilder {
 
 <!--
   - test: `array-result-builder`
-  
+
   ```swifttest
   -> @resultBuilder
   -> struct ArrayBuilder {
@@ -1477,16 +1477,16 @@ into code that calls the static methods of the result builder type:
   each expression becomes a call to that method.
   This transformation is always first.
   For example, the following declarations are equivalent:
-  
+
   ```swift
   @ArrayBuilder var builderNumber: [Int] { 10 }
   var manualNumber = ArrayBuilder.buildExpression(10)
   ```
-  
-  
+
+
   <!--
     - test: `array-result-builder`
-    
+
     ```swifttest
     -> @ArrayBuilder var builderNumber: [Int] { 10 }
     -> var manualNumber = ArrayBuilder.buildExpression(10)
@@ -1506,7 +1506,7 @@ into code that calls the static methods of the result builder type:
   For example,
   the `buildEither(first:)` and  `buildEither(second:)` methods below
   use a generic type that captures type information about both branches.
-  
+
   ```swift
   protocol Drawable {
       func draw() -> String
@@ -1526,7 +1526,7 @@ into code that calls the static methods of the result builder type:
       var content: Drawable
       func draw() -> String { return content.draw() }
   }
-  
+
   @resultBuilder
   struct DrawingBuilder {
       static func buildBlock<D: Drawable>(_ components: D...) -> Line<D> {
@@ -1542,11 +1542,11 @@ into code that calls the static methods of the result builder type:
       }
   }
   ```
-  
+
   <!-- Comment block with swifttest for the code listing above is after the end of this bulleted list, due to tooling limitations. -->
 
   However, this approach causes a problem in code that has availability checks:
-  
+
   ```swift
   @available(macOS 99, *)
   struct FutureText: Drawable {
@@ -1563,9 +1563,9 @@ into code that calls the static methods of the result builder type:
   }
   // The type of brokenDrawing is Line<DrawEither<Line<FutureText>, Line<Text>>>
   ```
-  
+
   <!-- Comment block with swifttest for the code listing above is after the end of this bulleted list, due to tooling limitations. -->
-  
+
   In the code above,
   `FutureText` appears as part of the type of `brokenDrawing`
   because it's one of the types in the `DrawEither` generic type.
@@ -1576,7 +1576,7 @@ into code that calls the static methods of the result builder type:
   to erase type information.
   For example, the code below builds an `AnyDrawable` value
   from its availability check.
-  
+
   ```swift
   struct AnyDrawable: Drawable {
       var content: Drawable
@@ -1587,7 +1587,7 @@ into code that calls the static methods of the result builder type:
           return AnyDrawable(content: content)
       }
   }
-  
+
   @DrawingBuilder var typeErasedDrawing: Drawable {
       if #available(macOS 99, *) {
           FutureText("Inside.future")
@@ -1597,7 +1597,7 @@ into code that calls the static methods of the result builder type:
   }
   // The type of typeErasedDrawing is Line<DrawEither<AnyDrawable, Line<Text>>>
   ```
-  
+
   <!-- Comment block with swifttest for the code listing above is after the end of this bulleted list, due to tooling limitations. -->
 
 - A branch statement becomes a series of nested calls to the
@@ -1614,7 +1614,7 @@ into code that calls the static methods of the result builder type:
   that case becomes a nested call like
   `buildEither(first: buildEither(second: ... ))`.
   The following declarations are equivalent:
-  
+
   ```swift
   let someNumber = 19
   @ArrayBuilder var builderConditional: [Int] {
@@ -1626,7 +1626,7 @@ into code that calls the static methods of the result builder type:
           33
       }
   }
-  
+
   var manualConditional: [Int]
   if someNumber < 12 {
       let partialResult = ArrayBuilder.buildExpression(31)
@@ -1641,11 +1641,11 @@ into code that calls the static methods of the result builder type:
       manualConditional = ArrayBuilder.buildEither(second: partialResult)
   }
   ```
-  
-  
+
+
   <!--
     - test: `array-result-builder`
-    
+
     ```swifttest
     -> let someNumber = 19
     -> @ArrayBuilder var builderConditional: [Int] {
@@ -1685,23 +1685,23 @@ into code that calls the static methods of the result builder type:
   its code block is transformed and passed as the argument;
   otherwise, `buildOptional(_:)` is called with `nil` as its argument.
   For example, the following declarations are equivalent:
-  
+
   ```swift
   @ArrayBuilder var builderOptional: [Int] {
       if (someNumber % 2) == 1 { 20 }
   }
-  
+
   var partialResult: [Int]? = nil
   if (someNumber % 2) == 1 {
       partialResult = ArrayBuilder.buildExpression(20)
   }
   var manualOptional = ArrayBuilder.buildOptional(partialResult)
   ```
-  
-  
+
+
   <!--
     - test: `array-result-builder`
-    
+
     ```swifttest
     -> @ArrayBuilder var builderOptional: [Int] {
            if (someNumber % 2) == 1 { 20 }
@@ -1723,25 +1723,25 @@ into code that calls the static methods of the result builder type:
   one at a time,
   and they become the arguments to the `buildBlock(_:)` method.
   For example, the following declarations are equivalent:
-  
+
   ```swift
   @ArrayBuilder var builderBlock: [Int] {
       100
       200
       300
   }
-  
+
   var manualBlock = ArrayBuilder.buildBlock(
       ArrayBuilder.buildExpression(100),
       ArrayBuilder.buildExpression(200),
       ArrayBuilder.buildExpression(300)
   )
   ```
-  
-  
+
+
   <!--
     - test: `array-result-builder`
-    
+
     ```swifttest
     -> @ArrayBuilder var builderBlock: [Int] {
            100
@@ -1763,14 +1763,14 @@ into code that calls the static methods of the result builder type:
   and appends each partial result to that array.
   The temporary array is passed as the argument in the `buildArray(_:)` call.
   For example, the following declarations are equivalent:
-  
+
   ```swift
   @ArrayBuilder var builderArray: [Int] {
       for i in 5...7 {
           100 + i
       }
   }
-  
+
   var temporary: [[Int]] = []
   for i in 5...7 {
       let partialResult = ArrayBuilder.buildExpression(100 + i)
@@ -1778,11 +1778,11 @@ into code that calls the static methods of the result builder type:
   }
   let manualArray = ArrayBuilder.buildArray(temporary)
   ```
-  
-  
+
+
   <!--
     - test: `array-result-builder`
-    
+
     ```swifttest
     -> @ArrayBuilder var builderArray: [Int] {
            for i in 5...7 {
@@ -1805,7 +1805,7 @@ into code that calls the static methods of the result builder type:
 
 <!--
   - test: `result-builder-limited-availability-broken, result-builder-limited-availability-ok`
-  
+
   ```swifttest
   -> protocol Drawable {
          func draw() -> String
@@ -1845,7 +1845,7 @@ into code that calls the static methods of the result builder type:
 
 <!--
   - test: `result-builder-limited-availability-broken`
-  
+
   ```swifttest
   -> @available(macOS 99, *)
   -> struct FutureText: Drawable {
@@ -1873,7 +1873,7 @@ into code that calls the static methods of the result builder type:
 
 <!--
   - test: `result-builder-limited-availability-ok`
-  
+
   ```swifttest
   >> @available(macOS 99, *)
   >> struct FutureText: Drawable {
@@ -1936,7 +1936,7 @@ a single binary tree of calls to the `buildEither` methods.
 
 <!--
   - test: `result-builder-transform-complex-expression`
-  
+
   ```swifttest
   >> @resultBuilder
   >> struct ArrayBuilder {
@@ -1985,7 +1985,7 @@ that inherits from `NSManagedObject`.
 
 <!--
   - test: `requires_stored_property_inits-requires-default-values`
-  
+
   ```swifttest
   >> @requires_stored_property_inits class DefaultValueProvided {
          var value: Int = -1
@@ -2078,7 +2078,7 @@ applying both attributes is an error.
 
 <!--
   - test: `usableFromInline-and-inlinable-is-redundant`
-  
+
   ```swifttest
   >> @usableFromInline @inlinable internal func f() { }
   !$ warning: '@usableFromInline' attribute has no effect on '@inlinable' global function 'f()'

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Declarations.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Declarations.md
@@ -189,7 +189,7 @@ let (firstNumber, secondNumber) = (10, 42)
 
 <!--
   - test: `constant-decl`
-  
+
   ```swifttest
   -> let (firstNumber, secondNumber) = (10, 42)
   ```
@@ -209,7 +209,7 @@ print("The second number is \(secondNumber).")
 
 <!--
   - test: `constant-decl`
-  
+
   ```swifttest
   -> print("The first number is \(firstNumber).")
   <- The first number is 10.
@@ -231,7 +231,7 @@ Type properties are discussed in <doc:Properties#Type-Properties>.
 
 <!--
   - test: `class-constants-cant-have-class-or-final`
-  
+
   ```swifttest
   -> class Super { class let x = 10 }
   !$ error: class stored properties not supported in classes; did you mean 'static'?
@@ -384,7 +384,7 @@ this expression is evaluated before the first time you write to the property.
 
 <!--
   - test: `overwriting-property-without-writing`
-  
+
   ```swifttest
   >> func loudConst(_ x: Int) -> Int {
   >>     print("initial value:", x)
@@ -474,7 +474,7 @@ newAndOld.x = 200
 
 <!--
   - test: `didSet-calls-superclass-getter`
-  
+
   ```swifttest
   -> class Superclass {
          private var xValue = 12
@@ -518,7 +518,7 @@ see <doc:Properties#Property-Observers>.
 
 <!--
   - test: `cant-mix-get-set-and-didSet`
-  
+
   ```swifttest
   >> struct S {
   >>     var x: Int {
@@ -631,7 +631,7 @@ var dictionary2: Dictionary<String, Int> = [:]
 
 <!--
   - test: `typealias-with-generic`
-  
+
   ```swifttest
   -> typealias StringDictionary<Value> = Dictionary<String, Value>
   ---
@@ -651,7 +651,7 @@ typealias DictionaryOfInts<Key: Hashable> = Dictionary<Key, Int>
 
 <!--
   - test: `typealias-with-generic-constraint`
-  
+
   ```swifttest
   -> typealias DictionaryOfInts<Key: Hashable> = Dictionary<Key, Int>
   ```
@@ -672,7 +672,7 @@ typealias Diccionario = Dictionary
 
 <!--
   - test: `typealias-using-shorthand`
-  
+
   ```swifttest
   -> typealias Diccionario = Dictionary
   ```
@@ -709,7 +709,7 @@ func sum<T: Sequence>(_ sequence: T) -> Int where T.Element == Int {
 
 <!--
   - test: `typealias-in-protocol`
-  
+
   ```swifttest
   -> protocol Sequence {
          associatedtype Iterator: IteratorProtocol
@@ -834,7 +834,7 @@ f(x: 1, y: 2) // both x and y are labeled
 
 <!--
   - test: `default-parameter-names`
-  
+
   ```swifttest
   -> func f(x: Int, y: Int) -> Int { return x + y }
   >> let r0 =
@@ -873,7 +873,7 @@ repeatGreeting("Hello, world!", count: 2) //  count is labeled, greeting is not
 
 <!--
   - test: `overridden-parameter-names`
-  
+
   ```swifttest
   -> func repeatGreeting(_ greeting: String, count n: Int) { /* Greet n times */ }
   -> repeatGreeting("Hello, world!", count: 2) //  count is labeled, greeting is not
@@ -942,7 +942,7 @@ func someFunction(a: inout Int) -> () -> Int {
 
 <!--
   - test: `explicit-capture-for-inout`
-  
+
   ```swifttest
   -> func someFunction(a: inout Int) -> () -> Int {
          return { [a] in return a + 1 }
@@ -976,7 +976,7 @@ func multithreadedFunction(queue: DispatchQueue, x: inout Int) {
 
 <!--
   - test: `cant-pass-inout-aliasing`
-  
+
   ```swifttest
   >> import Dispatch
   >> func someMutatingOperation(_ a: inout Int) {}
@@ -984,7 +984,7 @@ func multithreadedFunction(queue: DispatchQueue, x: inout Int) {
         // Make a local copy and manually copy it back.
         var localX = x
         defer { x = localX }
-  
+
         // Operate on localX asynchronously, then wait before returning.
         queue.async { someMutatingOperation(&localX) }
         queue.sync {}
@@ -997,7 +997,7 @@ see <doc:Functions#In-Out-Parameters>.
 
 <!--
   - test: `escaping-cant-capture-inout`
-  
+
   ```swifttest
   -> func outer(a: inout Int) -> () -> Void {
          func inner() {
@@ -1070,7 +1070,7 @@ f(7)      // Invalid, missing argument label
 
 <!--
   - test: `default-args-and-labels`
-  
+
   ```swifttest
   -> func f(x: Int = 42) -> Int { return x }
   >> let _ =
@@ -1093,7 +1093,7 @@ f(7)      // Invalid, missing argument label
 
 <!--
   - test: `default-args-evaluated-at-call-site`
-  
+
   ```swifttest
   -> func shout() -> Int {
         print("evaluated")
@@ -1132,7 +1132,7 @@ a class type method marked with `class final` or `static` can't be overridden.
 
 <!--
   - test: `overriding-class-methods-err`
-  
+
   ```swifttest
   -> class S { class final func f() -> Int { return 12 } }
   -> class SS: S { override class func f() -> Int { return 120 } }
@@ -1155,7 +1155,7 @@ a class type method marked with `class final` or `static` can't be overridden.
 
 <!--
   - test: `overriding-class-methods`
-  
+
   ```swifttest
   -> class S3 { class func f() -> Int { return 12 } }
   -> class SS3: S3 { override class func f() -> Int { return 120 } }
@@ -1215,7 +1215,7 @@ callable.callAsFunction(4, scale: 2)
 
 <!--
   - test: `call-as-function`
-  
+
   ```swifttest
   -> struct CallableStruct {
          var value: Int
@@ -1256,7 +1256,7 @@ let someFunction2: (Int, Int) -> Void = callable.callAsFunction(_:scale:)
 
 <!--
   - test: `call-as-function-err`
-  
+
   ```swifttest
   >> struct CallableStruct {
   >>     var value: Int
@@ -1324,7 +1324,7 @@ func someFunction(callback: () throws -> Void) rethrows {
 
 <!--
   - test: `rethrows`
-  
+
   ```swifttest
   -> func someFunction(callback: () throws -> Void) rethrows {
          try callback()
@@ -1360,7 +1360,7 @@ func someFunction(callback: () throws -> Void) rethrows {
 
 <!--
   - test: `double-negative-rethrows`
-  
+
   ```swifttest
   >> enum SomeError: Error { case error }
   >> enum AnotherError: Error { case error }
@@ -1383,7 +1383,7 @@ func someFunction(callback: () throws -> Void) rethrows {
 
 <!--
   - test: `throwing-in-rethrowing-function`
-  
+
   ```swifttest
   -> enum SomeError: Error { case c, d }
   -> func f1(callback: () throws -> Void) rethrows {
@@ -1445,7 +1445,7 @@ and a synchronous method can satisfy a protocol requirement for an asynchronous 
 
 <!--
   - test: `sync-satisfy-async-protocol-requirements`
-  
+
   ```swifttest
   >> protocol P { func f() async -> Int }
   >> class Super: P {
@@ -1595,7 +1595,7 @@ let evenInts: [Number] = [0, 2, 4, 6].map(f)
 
 <!--
   - test: `enum-case-as-function`
-  
+
   ```swifttest
   -> enum Number {
         case integer(Int)
@@ -1649,7 +1649,7 @@ enum Tree<T> {
 
 <!--
   - test: `indirect-enum`
-  
+
   ```swifttest
   -> enum Tree<T> {
         case empty
@@ -1680,7 +1680,7 @@ it can't contain any cases that are also marked with the `indirect` modifier.
 
 <!--
   assertion indirect-in-indirect
-  
+
   -> indirect enum E { indirect case c(E) }
   !! <REPL Input>:1:19: error: enum case in 'indirect' enum cannot also be 'indirect'
   !! indirect enum E { indirect case c(E) }
@@ -1689,7 +1689,7 @@ it can't contain any cases that are also marked with the `indirect` modifier.
 
 <!--
   assertion indirect-without-recursion
-  
+
   -> enum E { indirect case c }
   !! <REPL Input>:1:10: error: enum case 'c' without associated value cannot be 'indirect'
   !! enum E { indirect case c }
@@ -1748,7 +1748,7 @@ enum ExampleEnum: Int {
 
 <!--
   - test: `raw-value-enum`
-  
+
   ```swifttest
   -> enum ExampleEnum: Int {
         case a, b, c = 5, d
@@ -1773,7 +1773,7 @@ enum GamePlayMode: String {
 
 <!--
   - test: `raw-value-enum-implicit-string-values`
-  
+
   ```swifttest
   -> enum GamePlayMode: String {
         case cooperative, individual, competitive
@@ -1893,11 +1893,11 @@ as described in <doc:Patterns#Enumeration-Case-Pattern>.
 <!--
   old-grammar
   Grammar of an enumeration declaration
-  
+
   enum-declaration -> attribute-list-OPT ``enum`` enum-name generic-parameter-clause-OPT type-inheritance-clause-OPT enum-body
   enum-name -> identifier
   enum-body -> ``{`` declarations-OPT ``}``
-  
+
   enum-member-declaration -> attribute-list-OPT ``case`` enumerator-list
   enumerator-list -> enumerator raw-value-assignment-OPT | enumerator raw-value-assignment-OPT ``,`` enumerator-list
   enumerator -> enumerator-name tuple-type-OPT
@@ -2011,7 +2011,7 @@ and designated initializers must be marked with the `override` declaration modif
 
 <!--
   - test: `designatedInitializersRequireOverride`
-  
+
   ```swifttest
   -> class C { init() {} }
   -> class D: C { override init() { super.init() } }
@@ -2137,7 +2137,7 @@ as discussed in <doc:Declarations#Extension-Declaration>.
 
 <!--
   TODO Additional bits from the SE-0306 actors proposal:
-  
+
   Partial applications of isolated functions are only permitted
   when the expression is a direct argument
   whose corresponding parameter is non-escaping and non-Sendable.
@@ -2245,7 +2245,7 @@ enum MyEnum: SomeProtocol {
 
 <!--
   - test: `enum-case-satisfy-protocol-requirement`
-  
+
   ```swifttest
   -> protocol SomeProtocol {
          static var someValue: Self { get }
@@ -2271,7 +2271,7 @@ protocol SomeProtocol: AnyObject {
 
 <!--
   - test: `protocol-declaration`
-  
+
   ```swifttest
   -> protocol SomeProtocol: AnyObject {
          /* Protocol members go here */
@@ -2365,7 +2365,7 @@ use the `static` keyword.
 
 <!--
   - test: `protocols-with-type-property-requirements`
-  
+
   ```swifttest
   -> protocol P { static var x: Int { get } }
   -> protocol P2 { class var x: Int { get } }
@@ -2384,7 +2384,7 @@ use the `static` keyword.
 
 <!--
   - test: `protocol-type-property-default-implementation`
-  
+
   ```swifttest
   -> protocol P { static var x: Int { get } }
   -> extension P { static var x: Int { return 100 } }
@@ -2525,7 +2525,7 @@ protocol SubProtocolB: SomeProtocol where SomeType: Equatable { }
 
 <!--
   - test: `protocol-associatedtype`
-  
+
   ```swifttest
   -> protocol SomeProtocol {
          associatedtype SomeType
@@ -2556,21 +2556,21 @@ protocol SubProtocolB: SomeProtocol where SomeType: Equatable { }
   NOTE:
   What are associated types? What are they "associated" with? Is "Self"
   an implicit associated type of every protocol? [...]
-  
+
   Here's an initial stab:
   An Associated Type is associated with an implementation of that protocol.
   The protocol declares it, and is defined as part of the protocol's implementation.
-  
+
   "The ``Self`` type allows you to refer to the eventual type of ``self``
   (where ``self`` is the type that conforms to the protocol).
   In addition to ``Self``, a protocol's operations often need to refer to types
   that are related to the type of ``Self``, such as a type of data stored in a
   collection or the node and edge types of a graph." Is this still true?
-  
+
     -> If we expand the discussion here,
     -> add a link from Types_SelfType
     -> to give more details about Self in protocols.
-  
+
   NOTES from Doug:
   At one point, Self was an associated type, but that's the wrong modeling of
   the problem.  Self is the stand-in type for the thing that conforms to the
@@ -2578,16 +2578,16 @@ protocol SubProtocolB: SomeProtocol where SomeType: Equatable { }
   primary thing.  It's certainly not an associated type.  In many ways, you
   can think of associated types as being parameters that get filled in by the
   conformance of a specific concrete type to that protocol.
-  
+
   There's a substitution mapping here.  The parameters are associated with
   Self because they're derived from Self.  When you have a concrete type that
   conforms to a protocol, it supplies concrete types for Self and all the
   associated types.
-  
+
   The associated types are like parameters, but they're associated with Self in
   the protocol.  Self is the eventual type of the thing that conforms to the
   protocol -- you have to have a name for it so you can do things with it.
-  
+
   We use "associated" in contrast with generic parameters in interfaces in C#.
   The interesting thing there is that they don't have a name like Self for the
   actual type, but you can name any of these independent types.    In theory,
@@ -2596,24 +2596,24 @@ protocol SubProtocolB: SomeProtocol where SomeType: Equatable { }
   the same as Self.  Instead of having these independent parameters to an
   interface, we have a named thing (Self) and all these other things that hand
   off of it.
-  
+
   Here's a stupid simple way to see the distinction:
-  
+
   C#:
-  
+
   interface Sequence <Element> {}
-  
+
   class String : Sequence <UnicodeScalar>
   class String : Sequence <GraphemeCluster>
-  
+
   These are both fine in C#
-  
+
   Swift:
-  
+
   protocol Sequence { typealias Element }
-  
+
   class String : Sequence { typealias Element = ... }
-  
+
   Here you have to pick one or the other -- you can't have both.
 -->
 
@@ -2732,7 +2732,7 @@ struct SomeStruct {
 
 <!--
   - test: `failable`
-  
+
   ```swifttest
   -> struct SomeStruct {
          let property: String
@@ -2761,7 +2761,7 @@ if let actualInstance = SomeStruct(input: "Hello") {
 
 <!--
   - test: `failable`
-  
+
   ```swifttest
   -> if let actualInstance = SomeStruct(input: "Hello") {
          // do something with the instance of 'SomeStruct'
@@ -2967,7 +2967,7 @@ extension String: TitledLoggable {
 
 <!--
   - test: `conditional-conformance`
-  
+
   ```swifttest
   -> protocol Loggable {
          func log()
@@ -3027,7 +3027,7 @@ oneAndTwo.log()
 
 <!--
   - test: `conditional-conformance`
-  
+
   ```swifttest
   -> let oneAndTwo = Pair(first: "one", second: "two")
   -> oneAndTwo.log()
@@ -3053,7 +3053,7 @@ doSomething(with: oneAndTwo)
 
 <!--
   - test: `conditional-conformance`
-  
+
   ```swifttest
   -> func doSomething<T: Loggable>(with x: T) {
         x.log()
@@ -3110,7 +3110,7 @@ extension Array: Serializable where Element == String {
 
 <!--
   - test: `multiple-conformances`
-  
+
   ```swifttest
   -> protocol Serializable {
         func serialize() -> Any
@@ -3156,7 +3156,7 @@ extension Array: Serializable where Element: SerializableInArray {
 
 <!--
   - test: `multiple-conformances-success`
-  
+
   ```swifttest
   >> protocol Serializable { }
   -> protocol SerializableInArray { }
@@ -3212,7 +3212,7 @@ extension Array: MarkedLoggable where Element: MarkedLoggable { }
 
 <!--
   - test: `conditional-conformance`
-  
+
   ```swifttest
   -> protocol MarkedLoggable: Loggable {
         func markAndLog()
@@ -3248,7 +3248,7 @@ extension Array: Loggable where Element: MarkedLoggable { }
 
 <!--
   - test: `conditional-conformance-implicit-overlap`
-  
+
   ```swifttest
   >> protocol Loggable { }
   >> protocol MarkedLoggable : Loggable { }
@@ -3267,7 +3267,7 @@ extension Array: Loggable where Element: MarkedLoggable { }
 
 <!--
   - test: `types-cant-have-multiple-implicit-conformances`
-  
+
   ```swifttest
   >> protocol Loggable { }
      protocol TitledLoggable: Loggable { }
@@ -3302,7 +3302,7 @@ extension Array: Loggable where Element: MarkedLoggable { }
 
 <!--
   - test: `extension-can-have-where-clause`
-  
+
   ```swifttest
   >> extension Array where Element: Equatable {
          func f(x: Array) -> Int { return 7 }
@@ -3316,7 +3316,7 @@ extension Array: Loggable where Element: MarkedLoggable { }
 
 <!--
   - test: `extensions-can-have-where-clause-and-inheritance-together`
-  
+
   ```swifttest
   >> protocol P { func foo() -> Int }
   >> extension Array: P where Element: Equatable {
@@ -3415,7 +3415,7 @@ with both the `class` and `final` declaration modifiers.
 
 <!--
   - test: `cant-override-static-subscript-in-subclass`
-  
+
   ```swifttest
   -> class Super { static subscript(i: Int) -> Int { return 10 } }
   -> class Sub: Super { override static subscript(i: Int) -> Int { return 100 } }

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Expressions.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Expressions.md
@@ -120,7 +120,7 @@ sum = (try someThrowingFunction()) + anotherThrowingFunction()
 
 <!--
   - test: `placement-of-try`
-  
+
   ```swifttest
   >> func someThrowingFunction() throws -> Int { return 10 }
   >> func anotherThrowingFunction() throws -> Int { return 5 }
@@ -157,7 +157,7 @@ or the `try` expression is enclosed in parentheses.
 
 <!--
   - test: `try-on-right`
-  
+
   ```swifttest
   >> func someThrowingFunction() throws -> Int { return 10 }
   >> var sum = 0
@@ -230,7 +230,7 @@ sum = (await someAsyncFunction()) + anotherAsyncFunction()
 
 <!--
   - test: `placement-of-await`
-  
+
   ```swifttest
   >> func someAsyncFunction() async -> Int { return 10 }
   >> func anotherAsyncFunction() async -> Int { return 5 }
@@ -262,7 +262,7 @@ or the `await` expression is enclosed in parentheses.
 
 <!--
   - test: `await-on-right`
-  
+
   ```swifttest
   >> func f() async {
   >> func someAsyncFunction() async -> Int { return 10 }
@@ -365,7 +365,7 @@ For example:
 
 <!--
   - test: `assignmentOperator`
-  
+
   ```swifttest
   >> var (a, _, (b, c)) = ("test", 9.45, (12, 3))
   -> (a, _, (b, c)) = ("test", 9.45, (12, 3))
@@ -428,7 +428,7 @@ otherwise, it returns `false`.
 
 <!--
   - test: `triviallyTrueIsAndAs`
-  
+
   ```swifttest
   -> assert("hello" is String)
   -> assert(!("hello" is Int))
@@ -443,7 +443,7 @@ otherwise, it returns `false`.
 
 <!--
   - test: `is-operator-tautology`
-  
+
   ```swifttest
   -> class Base {}
   -> class Subclass: Base {}
@@ -482,7 +482,7 @@ f(x as Any)
 
 <!--
   - test: `explicit-type-with-as-operator`
-  
+
   ```swifttest
   -> func f(_ any: Any) { print("Function for Any") }
   -> func f(_ int: Int) { print("Function for Int") }
@@ -631,7 +631,7 @@ or other code that doesn't become part of the shipping program.
 
 <!--
   - test: `pound-file-flavors`
-  
+
   ```swifttest
   >> print(#file == #filePath)
   << true
@@ -668,7 +668,7 @@ func myFunction() {
 
 <!--
   - test: `special-literal-evaluated-at-call-site`
-  
+
   ```swifttest
   -> func logFunctionName(string: String = #function) {
          print(string)
@@ -712,7 +712,7 @@ var emptyArray: [Double] = []
 
 <!--
   - test: `array-literal-brackets`
-  
+
   ```swifttest
   -> var emptyArray: [Double] = []
   ```
@@ -745,7 +745,7 @@ var emptyDictionary: [String: Double] = [:]
 
 <!--
   - test: `dictionary-literal-brackets`
-  
+
   ```swifttest
   -> var emptyDictionary: [String: Double] = [:]
   ```
@@ -834,7 +834,7 @@ class SomeClass {
 
 <!--
   - test: `self-expression`
-  
+
   ```swifttest
   -> class SomeClass {
          var greeting: String
@@ -860,7 +860,7 @@ struct Point {
 
 <!--
   - test: `self-expression`
-  
+
   ```swifttest
   -> struct Point {
         var x = 0.0, y = 0.0
@@ -997,7 +997,7 @@ myFunction { $0 + $1 }
 
 <!--
   - test: `closure-expression-forms`
-  
+
   ```swifttest
   >> func myFunction(f: (Int, Int) -> Int) {}
   -> myFunction { (x: Int, y: Int) -> Int in
@@ -1071,7 +1071,7 @@ closure()
 
 <!--
   - test: `capture-list-value-semantics`
-  
+
   ```swifttest
   -> var a = 0
   -> var b = 0
@@ -1137,7 +1137,7 @@ closure()
 
 <!--
   - test: `capture-list-reference-semantics`
-  
+
   ```swifttest
   -> class SimpleClass {
          var value: Int = 0
@@ -1157,7 +1157,7 @@ closure()
 
 <!--
   - test: `capture-list-with-commas`
-  
+
   ```swifttest
   -> var x = 100
   -> var y = 7
@@ -1174,7 +1174,7 @@ closure()
 
 <!--
   - test: `capture-list-is-not-exhaustive`
-  
+
   ```swifttest
   -> var x = 100
      var y = 7
@@ -1202,7 +1202,7 @@ myFunction { [unowned self] in print(self.title) }  // unowned capture
 
 <!--
   - test: `closure-expression-weak`
-  
+
   ```swifttest
   >> func myFunction(f: () -> Void) { f() }
   >> class C {
@@ -1234,7 +1234,7 @@ myFunction { [weak parent = self.parent] in print(parent!.title) }
 
 <!--
   - test: `closure-expression-capture`
-  
+
   ```swifttest
   >> func myFunction(f: () -> Void) { f() }
   >> class P { let title = "Title" }
@@ -1256,7 +1256,7 @@ see <doc:AutomaticReferenceCounting#Resolving-Strong-Reference-Cycles-for-Closur
 
 <!--
   - test: `async-throwing-closure-syntax`
-  
+
   ```swifttest
   >> var a = 12
   >> let c1 = { [a] in return a }                  // OK -- no async or throws
@@ -1331,7 +1331,7 @@ x = .anotherValue
 
 <!--
   - test: `implicitMemberEnum`
-  
+
   ```swifttest
   >> enum MyEnumeration { case someValue, anotherValue }
   -> var x = MyEnumeration.someValue
@@ -1349,7 +1349,7 @@ var someOptional: MyEnumeration? = .someValue
 
 <!--
   - test: `implicitMemberEnum`
-  
+
   ```swifttest
   -> var someOptional: MyEnumeration? = .someValue
   ```
@@ -1388,7 +1388,7 @@ let z: SomeClass = .sharedSubclass
 
 <!--
   - test: `implicit-member-chain`
-  
+
   ```swifttest
   -> class SomeClass {
          static var shared = SomeClass()
@@ -1426,7 +1426,7 @@ and the type of `z` is convertible from `SomeSubclass` to `SomeClass`.
 
 <!--
   - test: `implicit-member-grammar`
-  
+
   ```swifttest
   // self expression
   >> enum E { case left, right }
@@ -1498,7 +1498,7 @@ it appears once in the outer tuple and once in the inner tuple.
 
 <!--
   - test: `tuple-labels-must-be-unique`
-  
+
   ```swifttest
   >> let bad = (a: 10, a: 20)
   >> let good = (a: 10, b: (a: 1, x: 2))
@@ -1541,7 +1541,7 @@ For example, in the following assignment
 
 <!--
   - test: `wildcardTuple`
-  
+
   ```swifttest
   >> var (x, _) = (10, 20)
   -> (x, _) = (10, 20)
@@ -1607,7 +1607,7 @@ let value = s[keyPath: pathToProperty]
 
 <!--
   - test: `keypath-expression`
-  
+
   ```swifttest
   -> struct SomeStructure {
          var someValue: Int
@@ -1644,7 +1644,7 @@ c.observe(\.someProperty) { object, change in
 
 <!--
   - test: `keypath-expression-implicit-type-name`
-  
+
   ```swifttest
   >> import Foundation
   -> class SomeClass: NSObject {
@@ -1681,7 +1681,7 @@ compoundValue[keyPath: \.self] = (a: 10, b: 20)
 
 <!--
   - test: `keypath-expression-self-keypath`
-  
+
   ```swifttest
   -> var compoundValue = (a: 1, b: 2)
   // Equivalent to compoundValue = (a: 10, b: 20)
@@ -1714,7 +1714,7 @@ let nestedValue = nested[keyPath: nestedKeyPath]
 
 <!--
   - test: `keypath-expression`
-  
+
   ```swifttest
   -> struct OuterStructure {
          var outer: SomeStructure
@@ -1745,7 +1745,7 @@ let myGreeting = greetings[keyPath: \[String].[1]]
 
 <!--
   - test: `keypath-expression`
-  
+
   ```swifttest
   -> let greetings = ["hello", "hola", "bonjour", "안녕"]
   -> let myGreeting = greetings[keyPath: \[String].[1]]
@@ -1792,7 +1792,7 @@ print(fn(greetings))
 
 <!--
   - test: `keypath-expression`
-  
+
   ```swifttest
   -> var index = 2
   -> let path = \[String].[index]
@@ -1831,7 +1831,7 @@ print(count as Any)
 
 <!--
   - test: `keypath-expression`
-  
+
   ```swifttest
   -> let firstGreeting: String? = greetings.first
   -> print(firstGreeting?.count as Any)
@@ -1872,7 +1872,7 @@ print(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count.bitWidth
 
 <!--
   - test: `keypath-expression`
-  
+
   ```swifttest
   -> let interestingNumbers = ["prime": [2, 3, 5, 7, 11, 13, 17],
                                "triangular": [1, 3, 6, 10, 15, 21, 28],
@@ -1914,7 +1914,7 @@ let descriptions2 = toDoList.filter { $0.completed }.map { $0.description }
 
 <!--
   - test: `keypath-expression`
-  
+
   ```swifttest
   -> struct Task {
          var description: String
@@ -1961,7 +1961,7 @@ let someTask = toDoList[keyPath: taskKeyPath]
 
 <!--
   - test: `keypath-expression`
-  
+
   ```swifttest
   -> func makeIndex() -> Int {
          print("Made an index")
@@ -2034,7 +2034,7 @@ let selectorForPropertyGetter = #selector(getter: SomeClass.property)
 
 <!--
   - test: `selector-expression`
-  
+
   ```swifttest
   >> import Foundation
   -> class SomeClass: NSObject {
@@ -2072,7 +2072,7 @@ let anotherSelector = #selector(SomeClass.doSomething(_:) as (SomeClass) -> (Str
 
 <!--
   - test: `selector-expression-with-as`
-  
+
   ```swifttest
   >> import Foundation
   >> class SomeClass: NSObject {
@@ -2152,7 +2152,7 @@ if let value = c.value(forKey: keyPath) {
 
 <!--
   - test: `keypath-string-expression`
-  
+
   ```swifttest
   >> import Foundation
   -> class SomeClass: NSObject {
@@ -2188,7 +2188,7 @@ print(keyPath == c.getSomeKeyPath())
 
 <!--
   - test: `keypath-string-expression`
-  
+
   ```swifttest
   -> extension SomeClass {
         func getSomeKeyPath() -> String {
@@ -2297,7 +2297,7 @@ anotherFunction(x: x) { $0 == 13 } g: { print(99) }
 
 <!--
   - test: `trailing-closure`
-  
+
   ```swifttest
   >> func someFunction (x: Int, f: (Int) -> Bool) -> Bool {
   >>    return f(x)
@@ -2342,7 +2342,7 @@ myData.someMethod { $0 == 13 }
 
 <!--
   - test: `no-paren-trailing-closure`
-  
+
   ```swifttest
   >> class Data {
   >>    let data = 10
@@ -2409,7 +2409,7 @@ the closure is wrapped in `Optional` automatically.
 
 <!--
   - test: `when-can-you-use-trailing-closure`
-  
+
   ```swifttest
   // These tests match the example types given above
   // when describing what "structurally resembles" a function type.
@@ -2456,7 +2456,7 @@ someFunction { return $0 } secondClosure: { return $0 }  // Prints "10 20"
 
 <!--
   - test: `trailing-closure-scanning-direction`
-  
+
   ```swifttest
   -> typealias Callback = (Int) -> Int
   -> func someFunction(firstClosure: Callback? = nil,
@@ -2525,7 +2525,7 @@ withUnsafePointer(to: myNumber) { unsafeFunction(pointer: $0) }
 
 <!--
   - test: `inout-unsafe-pointer`
-  
+
   ```swifttest
   -> func unsafeFunction(pointer: UnsafePointer<Int>) {
   ->     // ...
@@ -2564,7 +2564,7 @@ avoid using `&` instead of using the unsafe APIs explicitly.
 
 <!--
   - test: `implicit-conversion-to-pointer`
-  
+
   ```swifttest
   >> import Foundation
   >> func takesUnsafePointer(p: UnsafePointer<Int>) { }
@@ -2656,7 +2656,7 @@ class SomeSubClass: SomeSuperClass {
 
 <!--
   - test: `init-call-superclass`
-  
+
   ```swifttest
   >> class SomeSuperClass { }
   -> class SomeSubClass: SomeSuperClass {
@@ -2681,7 +2681,7 @@ print(oneTwoThree)
 
 <!--
   - test: `init-as-value`
-  
+
   ```swifttest
   // Type annotation is required because String has multiple initializers.
   -> let initializer: (Int) -> String = String.init
@@ -2705,7 +2705,7 @@ let s4 = type(of: someValue)(data: 5)       // Error
 
 <!--
   - test: `explicit-implicit-init`
-  
+
   ```swifttest
   >> struct SomeType {
   >>     let data: Int
@@ -2754,7 +2754,7 @@ let y = c.someProperty  // Member access
 
 <!--
   - test: `explicitMemberExpression`
-  
+
   ```swifttest
   -> class SomeClass {
          var someProperty = 42
@@ -2777,7 +2777,7 @@ t.0 = t.1
 
 <!--
   - test: `explicit-member-expression`
-  
+
   ```swifttest
   -> var t = (10, 20, 30)
   -> t.0 = t.1
@@ -2820,7 +2820,7 @@ let d: (Int, Bool) -> Void  = instance.overloadedMethod(x:y:)  // Unambiguous
 
 <!--
   - test: `function-with-argument-names`
-  
+
   ```swifttest
   -> class SomeClass {
          func someMethod(x: Int, y: Int) {}
@@ -2881,7 +2881,7 @@ let x = [10, 3, 20, 15, 4]
 
 <!--
   - test: `period-at-start-of-line`
-  
+
   ```swifttest
   -> let x = [10, 3, 20, 15, 4]
   ->     .sorted()
@@ -2909,7 +2909,7 @@ let numbers = [10, 20, 33, 43, 50]
 
 <!--
   - test: `pound-if-inside-postfix-expression`
-  
+
   ```swifttest
   -> let numbers = [10, 20, 33, 43, 50]
      #if os(iOS)
@@ -2951,7 +2951,7 @@ The other branches can be empty.
 
 <!--
   - test: `pound-if-empty-if-not-allowed`
-  
+
   ```swifttest
   >> let numbers = [10, 20, 33, 43, 50]
   >> #if os(iOS)
@@ -2966,7 +2966,7 @@ The other branches can be empty.
 
 <!--
   - test: `pound-if-else-can-be-empty`
-  
+
   ```swifttest
   >> let numbers = [10, 20, 33, 43, 50]
   >> #if os(iOS)
@@ -2980,7 +2980,7 @@ The other branches can be empty.
 
 <!--
   - test: `pound-if-cant-use-binary-operators`
-  
+
   ```swifttest
   >> let s = "some string"
   >> #if os(iOS)
@@ -3081,7 +3081,7 @@ see <doc:Declarations#Protocol-Subscript-Declaration>.
 
 <!--
   - test: `subscripts-can-take-operators`
-  
+
   ```swifttest
   >> struct S {
          let x: Int
@@ -3127,7 +3127,7 @@ someDictionary["a"]![0] = 100
 
 <!--
   - test: `optional-as-lvalue`
-  
+
   ```swifttest
   -> var x: Int? = 0
   -> x! += 1
@@ -3186,7 +3186,7 @@ var result: Bool? = c?.property.performAction()
 
 <!--
   - test: `optional-chaining`
-  
+
   ```swifttest
   >> class OtherClass { func performAction() -> Bool {return true} }
   >> class SomeClass { var property: OtherClass = OtherClass() }
@@ -3209,7 +3209,7 @@ if let unwrappedC = c {
 
 <!--
   - test: `optional-chaining-alt`
-  
+
   ```swifttest
   >> class OtherClass { func performAction() -> Bool {return true} }
   >> class SomeClass { var property: OtherClass = OtherClass() }
@@ -3246,7 +3246,7 @@ someDictionary["a"]?[0] = someFunctionWithSideEffects()
 
 <!--
   - test: `optional-chaining-as-lvalue`
-  
+
   ```swifttest
   -> func someFunctionWithSideEffects() -> Int {
         return 42  // No actual side effects.

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/GenericParametersAndArguments.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/GenericParametersAndArguments.md
@@ -59,7 +59,7 @@ func simpleMax<T: Comparable>(_ x: T, _ y: T) -> T {
 
 <!--
   - test: `generic-params`
-  
+
   ```swifttest
   -> func simpleMax<T: Comparable>(_ x: T, _ y: T) -> T {
         if x < y {
@@ -83,7 +83,7 @@ simpleMax(3.14159, 2.71828) // T is inferred to be Double
 
 <!--
   - test: `generic-params`
-  
+
   ```swifttest
   >> let r0 =
   -> simpleMax(17, 42) // T is inferred to be Int
@@ -159,7 +159,7 @@ extension Collection where Element: SomeProtocol {
 
 <!--
   - test: `contextual-where-clauses-combine`
-  
+
   ```swifttest
   >> protocol SomeProtocol { }
   >> extension Int: SomeProtocol { }
@@ -175,7 +175,7 @@ extension Collection where Element: SomeProtocol {
 
 <!--
   - test: `contextual-where-clause-combine-err`
-  
+
   ```swifttest
   >> protocol SomeProtocol { }
   >> extension Bool: SomeProtocol { }
@@ -286,7 +286,7 @@ let arrayOfArrays: Array<Array<Int>> = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
 <!--
   - test: `array-of-arrays`
-  
+
   ```swifttest
   -> let arrayOfArrays: Array<Array<Int>> = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
   ```

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/LexicalStructure.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/LexicalStructure.md
@@ -224,7 +224,7 @@ so they must be escaped with backticks in that context.
 
 <!--
   - test: `keywords-without-backticks`
-  
+
   ```swifttest
   -> func f(x: Int, in y: Int) {
         print(x+y)
@@ -234,7 +234,7 @@ so they must be escaped with backticks in that context.
 
 <!--
   - test: `var-requires-backticks`
-  
+
   ```swifttest
   -> func g(`var` x: Int) {}
   -> func f(var x: Int) {}
@@ -247,7 +247,7 @@ so they must be escaped with backticks in that context.
 
 <!--
   - test: `let-requires-backticks`
-  
+
   ```swifttest
   -> func g(`let` x: Int) {}
   -> func f(let x: Int) {}
@@ -260,7 +260,7 @@ so they must be escaped with backticks in that context.
 
 <!--
   - test: `inout-requires-backticks`
-  
+
   ```swifttest
   -> func g(`inout` x: Int) {}
   -> func f(inout x: Int) {}
@@ -276,7 +276,7 @@ so they must be escaped with backticks in that context.
   is derived from the file "swift/include/swift/Parse/Tokens.def"
   and from "utils/gyb_syntax_support/Token.py",
   which generates the TokenKinds.def file.
-  
+
   Last updated at Swift commit 2f1987567f5, for Swift 5.4.
 -->
 
@@ -450,7 +450,7 @@ true             // Boolean literal
 
 <!--
   - test: `basic-literals`
-  
+
   ```swifttest
   >> let r0 =
   -> 42               // Integer literal
@@ -799,7 +799,7 @@ let x = 3; "1 2 \(x)"
 
 <!--
   - test: `string-literals`
-  
+
   ```swifttest
   >> let r0 =
   -> "1 2 3"
@@ -861,7 +861,7 @@ print(string == escaped)
 
 <!--
   - test: `extended-string-delimiters`
-  
+
   ```swifttest
   -> let string = #"\(x) \ " \u{2603}"#
   -> let escaped = "\\(x) \\ \" \\u{2603}"
@@ -878,7 +878,7 @@ don't place whitespace in between the number signs:
 
 <!--
   - test: `extended-string-delimiters`
-  
+
   ```swifttest
   -> print(###"Line 1\###nLine 2"###) // OK
   << Line 1
@@ -893,7 +893,7 @@ print(# # #"Line 1\# # #nLine 2"# # #) // Error
 
 <!--
   - test: `extended-string-delimiters-err`
-  
+
   ```swifttest
   -> print(###"Line 1\###nLine 2"###) // OK
   -> print(# # #"Line 1\# # #nLine 2"# # #) // Error
@@ -927,7 +927,7 @@ let textB = "Hello world"
 
 <!--
   - test: `concatenated-strings`
-  
+
   ```swifttest
   -> let textA = "Hello " + "world"
   -> let textB = "Hello world"
@@ -1017,9 +1017,9 @@ let textB = "Hello world"
 <!--
   Now that single quotes are gone, we don't have a character literal.
   Because we may one bring them back, here's the old grammar for them:
-  
+
   textual-literal -> character-literal | string-literal
-  
+
   character-literal -> ``'`` quoted-character ``'``
   quoted-character -> escaped-character
   quoted-character -> Any Unicode scalar value except ``'``, ``\``, U+000A, or U+000D
@@ -1053,19 +1053,19 @@ and `/\d/` matches a single digit.
 
 <!--
   OUTLINE
-  
+
   Doc comments on Regex struct don't have more syntax details,
   or a cross reference to where you can learn more.
   We probably need at least some baseline coverage
   of the supported syntax here.
   (Unified dialect/superset of POSIX + PCRE 2 + Oniguruma + .NET)
-  
+
   https://github.com/apple/swift-experimental-string-processing/blob/main/Sources/_StringProcessing/Regex/Core.swift
-  
+
   Regex literals and the DSL take different approaches to captures.
   The literals give you more type safety.
   The DSL lets you access stuff by name.
-  
+
   From SE-0354:
   A regex literal may be used with a prefix operator,
   e.g `let r = ^^/x/` is parsed as `let r = ^^(/x/)`.
@@ -1117,7 +1117,7 @@ let regex2 = # #/abc/# #     // Error
 
 <!--
   - test: `extended-regex-delimiters-err`
-  
+
   ```swifttest
   -> let regex1 = ##/abc/##       // OK
   -> let regex2 = # #/abc/# #     // Error
@@ -1171,7 +1171,7 @@ the `+` operator followed by the `.+` operator.
 
 <!--
   - test: `dot-operator-must-start-with-dot`
-  
+
   ```swifttest
   >> infix operator +.+ ;
   !$ error: consecutive statements on a line must be separated by ';'
@@ -1196,7 +1196,7 @@ postfix operators can't begin with either a question mark or an exclamation poin
 
 <!--
   - test: `postfix-operators-dont-need-unique-prefix`
-  
+
   ```swifttest
   >> struct Num { var value: Int }
      postfix operator +
@@ -1213,7 +1213,7 @@ postfix operators can't begin with either a question mark or an exclamation poin
 
 <!--
   - test: `postfix-operator-cant-start-with-question-mark`
-  
+
   ```swifttest
   >> postfix operator ?+
   >> postfix func ?+ (x: Int) -> Int {
@@ -1287,10 +1287,10 @@ that may then be misinterpreted as a bit shift `>>` operator.
   matches < and > and looks at what token comes after the > -- if it's a . or
   a ( it treats the <...> as a generic parameter list, otherwise it treats
   them as less than and greater than.
-  
+
   This fails to parse things like x<<2>>(1+2) but it's the same as C#.  So
   don't write that.
-  
+
   We call out the > > vs >> because
   C++ typically needs whitespace to resolve the ambiguity.
 -->

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Patterns.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Patterns.md
@@ -64,7 +64,7 @@ for _ in 1...3 {
 
 <!--
   - test: `wildcard-pattern`
-  
+
   ```swifttest
   -> for _ in 1...3 {
         // Do something three times.
@@ -89,7 +89,7 @@ let someValue = 42
 
 <!--
   - test: `identifier-pattern`
-  
+
   ```swifttest
   -> let someValue = 42
   ```
@@ -130,7 +130,7 @@ case let (x, y):
 
 <!--
   - test: `value-binding-pattern`
-  
+
   ```swifttest
   -> let point = (3, 2)
   -> switch point {
@@ -186,7 +186,7 @@ for (x, 0) in points {
 
 <!--
   - test: `tuple-pattern`
-  
+
   ```swifttest
   -> let points = [(0, 0), (1, 0), (1, 1), (2, 0), (2, 1)]
   -> // This code isn't valid.
@@ -218,7 +218,7 @@ let (a): Int = 2 // a: Int = 2
 
 <!--
   - test: `single-element-tuple-pattern`
-  
+
   ```swifttest
   -> let a = 2        // a: Int = 2
   -> let (a) = 2      // a: Int = 2
@@ -283,7 +283,7 @@ case nil:
 
 <!--
   - test: `enum-pattern-matching-optional`
-  
+
   ```swifttest
   -> enum SomeEnum { case left, right }
   -> let x: SomeEnum? = .left
@@ -329,7 +329,7 @@ if case let x? = someOptional {
 
 <!--
   - test: `optional-pattern`
-  
+
   ```swifttest
   -> let someOptional: Int? = 42
   -> // Match using an enumeration case pattern.
@@ -363,7 +363,7 @@ for case let number? in arrayOfOptionalInts {
 
 <!--
   - test: `optional-pattern-for-in`
-  
+
   ```swifttest
   -> let arrayOfOptionalInts: [Int?] = [nil, 2, 3, nil, 5]
   -> // Match only non-nil values.
@@ -445,7 +445,7 @@ default:
 
 <!--
   - test: `expression-pattern`
-  
+
   ```swifttest
   -> let point = (1, 2)
   -> switch point {
@@ -480,7 +480,7 @@ default:
 
 <!--
   - test: `expression-pattern`
-  
+
   ```swifttest
   -> // Overload the ~= operator to match a string with an integer.
   -> func ~= (pattern: String, value: Int) -> Bool {

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Statements.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Statements.md
@@ -352,7 +352,7 @@ case let (x, y) where x == y:
 
 <!--
   - test: `switch-case-statement`
-  
+
   ```swifttest
   >> switch (1, 1) {
   -> case let (x, y) where x == y:
@@ -392,7 +392,7 @@ the program executes only the code within the first matching case in source orde
 
 <!--
   - test: `switch-case-with-multiple-patterns`
-  
+
   ```swifttest
   >> let tuple = (1, 1)
   >> switch tuple {
@@ -405,7 +405,7 @@ the program executes only the code within the first matching case in source orde
 
 <!--
   - test: `switch-case-with-multiple-patterns-err`
-  
+
   ```swifttest
   >> let tuple = (1, 1)
   >> switch tuple {
@@ -482,7 +482,7 @@ case .suppressed:
 
 <!--
   - test: `unknown-case`
-  
+
   ```swifttest
   -> let representation: Mirror.AncestorRepresentation = .generated
   -> switch representation {
@@ -574,7 +574,7 @@ see <doc:ControlFlow#Labeled-Statements> in <doc:ControlFlow>.
 
 <!--
   - test: `backtick-identifier-is-legal-label`
-  
+
   ```swifttest
   -> var i = 0
   -> `return`: while i < 100 {
@@ -1096,7 +1096,7 @@ otherwise, it returns `false`.
 
 <!--
   - test: `canImport_A, canImport`
-  
+
   ```swifttest
   >> public struct SomeStruct {
   >>     public init() { }
@@ -1106,7 +1106,7 @@ otherwise, it returns `false`.
 
 <!--
   - test: `canImport_A.B, canImport`
-  
+
   ```swifttest
   >> public struct AnotherStruct {
   >>     public init() { }
@@ -1116,7 +1116,7 @@ otherwise, it returns `false`.
 
 <!--
   - test: `canImport`
-  
+
   ```swifttest
   >> import canImport_A
   >> let s = SomeStruct()
@@ -1142,7 +1142,7 @@ otherwise, it returns `false`.
 
 <!--
   - test: `pound-if-swift-version`
-  
+
   ```swifttest
   -> #if swift(>=2.1)
          print(1)
@@ -1164,7 +1164,7 @@ otherwise, it returns `false`.
 
 <!--
   - test: `pound-if-swift-version-err`
-  
+
   ```swifttest
   -> #if swift(>= 2.1)
          print(4)
@@ -1178,7 +1178,7 @@ otherwise, it returns `false`.
 
 <!--
   - test: `pound-if-compiler-version`
-  
+
   ```swifttest
   -> #if compiler(>=4.2)
          print(1)
@@ -1297,10 +1297,10 @@ see <doc:Expressions#Explicit-Member-Expression>.
 
 <!--
   Testing notes:
-  
+
   !!true doesn't work but !(!true) does -- this matches normal expressions
   #if can be nested, as expected
-  
+
   Also, the body of a conditional compilation block contains *zero* or more statements.
   Thus, this is allowed:
       #if
@@ -1380,7 +1380,7 @@ but they can use the multiline string literal syntax.
 
 <!--
   - test: `good-diagnostic-statement-messages`
-  
+
   ```swifttest
   >> #warning("Single-line static string")
   !! /tmp/swifttest.swift:1:10: warning: Single-line static string
@@ -1406,7 +1406,7 @@ but they can use the multiline string literal syntax.
 
 <!--
   - test: `bad-diagnostic-statement-messages`
-  
+
   ```swifttest
   >> #warning("Interpolated \(1+1) string")
   !$ error: string interpolation is not allowed in #warning directives
@@ -1503,7 +1503,7 @@ It has the same meaning as the `*` argument in an availability condition.
 
 <!--
   - test: `pound-available-platform-names`
-  
+
   ```swifttest
   >> if #available(iOS 1, iOSApplicationExtension 1,
   >>               macOS 1, macOSApplicationExtension 1,
@@ -1536,7 +1536,7 @@ It has the same meaning as the `*` argument in an availability condition.
 
 <!--
   - test: `empty-availability-condition`
-  
+
   ```swifttest
   >> if #available(*) { print("1") }
   << 1
@@ -1545,7 +1545,7 @@ It has the same meaning as the `*` argument in an availability condition.
 
 <!--
   - test: `empty-unavailability-condition`
-  
+
   ```swifttest
   >> if #unavailable() { print("2") }
   !$ error: expected platform name

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Types.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Types.md
@@ -76,7 +76,7 @@ func someFunction(a: Int) { /* ... */ }
 
 <!--
   - test: `type-annotation`
-  
+
   ```swifttest
   -> let someTuple: (Double, Double) = (3.14159, 2.71828)
   -> func someFunction(a: Int) { /* ... */ }
@@ -117,7 +117,7 @@ let origin: Point = (0, 0)
 
 <!--
   - test: `type-identifier`
-  
+
   ```swifttest
   -> typealias Point = (Int, Int)
   -> let origin: Point = (0, 0)
@@ -135,7 +135,7 @@ var someValue: ExampleModule.MyType
 
 <!--
   - test: `type-identifier-dot`
-  
+
   ```swifttest
   -> var someValue: ExampleModule.MyType
   !$ error: cannot find type 'ExampleModule' in scope
@@ -173,7 +173,7 @@ someTuple = (left: 5, right: 5)  // Error: names don't match
 
 <!--
   - test: `tuple-type-names`
-  
+
   ```swifttest
   -> var someTuple = (top: 10, bottom: 12)  // someTuple is of type (top: Int, bottom: Int)
   -> someTuple = (top: 4, bottom: 42) // OK: names match
@@ -260,7 +260,7 @@ For example:
 
 <!--
   - test: `argument-names`
-  
+
   ```swifttest
   -> func someFunction(left: Int, right: Int) {}
   -> func anotherFunction(left: Int, right: Int) {}
@@ -292,7 +292,7 @@ f = functionWithDifferentNumberOfArguments // Error
 
 <!--
   - test: `argument-names-err`
-  
+
   ```swifttest
   -> func someFunction(left: Int, right: Int) {}
   -> func anotherFunction(left: Int, right: Int) {}
@@ -327,7 +327,7 @@ var operation: (Int, Int) -> Int               // OK
 
 <!--
   - test: `omit-argument-names-in-function-type`
-  
+
   ```swifttest
   -> var operation: (lhs: Int, rhs: Int) -> Int     // Error
   !$ error: function types cannot have argument labels; use '_' before 'lhs'
@@ -382,7 +382,7 @@ see <doc:Declarations#Asynchronous-Functions-and-Methods>.
 
 <!--
   - test: `function-arrow-is-right-associative`
-  
+
   ```swifttest
   >> func f(i: Int) -> (Int) -> Int {
   >>     func g(j: Int) -> Int {
@@ -409,7 +409,7 @@ because that might allow the value to escape.
 
 <!--
   - test: `cant-store-nonescaping-as-Any`
-  
+
   ```swifttest
   -> func f(g: ()->Void) { let x: Any = g }
   !$ error: converting non-escaping value to 'Any' may allow it to escape
@@ -441,16 +441,16 @@ func takesTwoFunctions(first: (() -> Void) -> Void, second: (() -> Void) -> Void
 
 <!--
   - test: `memory-nonescaping-functions`
-  
+
   ```swifttest
   -> let external: (() -> Void) -> Void = { _ in () }
   -> func takesTwoFunctions(first: (() -> Void) -> Void, second: (() -> Void) -> Void) {
          first { first {} }       // Error
          second { second {}  }    // Error
-  
+
          first { second {} }      // Error
          second { first {} }      // Error
-  
+
          first { external {} }    // OK
          external { first {} }    // OK
      }
@@ -514,13 +514,13 @@ see <doc:MemorySafety>.
   This means that monomorphic functions can be assigned to variables
   and can be passed as arguments to other functions.
   As an example, the following three lines of code are OK::
-  
+
       func polymorphicF<T>(a: Int) -> T { return a }
       func monomorphicF(a: Int) -> Int { return a }
       var myMonomorphicF = monomorphicF
-  
+
   But, the following is NOT allowed::
-  
+
       var myPolymorphicF = polymorphicF
 -->
 
@@ -542,7 +542,7 @@ let someArray: [String] = ["Alex", "Brian", "Dave"]
 
 <!--
   - test: `array-literal`
-  
+
   ```swifttest
   >> let someArray1: Array<String> = ["Alex", "Brian", "Dave"]
   >> let someArray2: [String] = ["Alex", "Brian", "Dave"]
@@ -567,7 +567,7 @@ var array3D: [[[Int]]] = [[[1, 2], [3, 4]], [[5, 6], [7, 8]]]
 
 <!--
   - test: `array-3d`
-  
+
   ```swifttest
   -> var array3D: [[[Int]]] = [[[1, 2], [3, 4]], [[5, 6], [7, 8]]]
   ```
@@ -605,7 +605,7 @@ let someDictionary: Dictionary<String, Int> = ["Alex": 31, "Paul": 39]
 
 <!--
   - test: `dictionary-literal`
-  
+
   ```swifttest
   >> let someDictionary1: [String: Int] = ["Alex": 31, "Paul": 39]
   >> let someDictionary2: Dictionary<String, Int> = ["Alex": 31, "Paul": 39]
@@ -651,7 +651,7 @@ var optionalInteger: Optional<Int>
 
 <!--
   - test: `optional-literal`
-  
+
   ```swifttest
   >> var optionalInteger1: Int?
   >> var optionalInteger2: Optional<Int>
@@ -689,7 +689,7 @@ optionalInteger! // 42
 
 <!--
   - test: `optional-type`
-  
+
   ```swifttest
   >> var optionalInteger: Int?
   -> optionalInteger = 42
@@ -831,7 +831,7 @@ typealias PQR = PQ & Q & R
 
 <!--
   - test: `protocol-composition-can-have-repeats`
-  
+
   ```swifttest
   >> protocol P {}
   >> protocol Q {}
@@ -938,7 +938,7 @@ type(of: someInstance).printClassName()
 
 <!--
   - test: `metatype-type`
-  
+
   ```swifttest
   -> class SomeBaseClass {
          class func printClassName() {
@@ -984,7 +984,7 @@ let anotherInstance = metatype.init(string: "some string")
 
 <!--
   - test: `metatype-type`
-  
+
   ```swifttest
   -> class AnotherSubClass: SomeBaseClass {
         let string: String
@@ -1021,7 +1021,7 @@ let mixed: [Any] = ["one", 2, true, (4, 5.3), { () -> Int in return 6 }]
 
 <!--
   - test: `any-type`
-  
+
   ```swifttest
   -> let mixed: [Any] = ["one", 2, true, (4, 5.3), { () -> Int in return 6 }]
   ```
@@ -1047,7 +1047,7 @@ if let first = mixed.first as? String {
 
 <!--
   - test: `any-type`
-  
+
   ```swifttest
   -> if let first = mixed.first as? String {
          print("The first item, '\(first)', is a string.")
@@ -1098,7 +1098,7 @@ whose return type is `Self`.
 
 <!--
   - test: `self-in-class-cant-be-a-parameter-type`
-  
+
   ```swifttest
   -> class C { func f(c: Self) { } }
   !$ error: covariant 'Self' or 'Self?' can only appear as the type of a property, subscript or method result; did you mean 'C'?
@@ -1110,7 +1110,7 @@ whose return type is `Self`.
 
 <!--
   - test: `self-in-class-can-be-a-subscript-param`
-  
+
   ```swifttest
   >> class C { subscript(s: Int) -> Self { return self } }
   >> let c = C()
@@ -1120,7 +1120,7 @@ whose return type is `Self`.
 
 <!--
   - test: `self-in-class-can-be-a-computed-property-type`
-  
+
   ```swifttest
   >> class C { var s: Self { return self } }
   >> let c = C()
@@ -1148,7 +1148,7 @@ print(type(of: z.f()))
 
 <!--
   - test: `self-gives-dynamic-type`
-  
+
   ```swifttest
   -> class Superclass {
          func f() -> Self { return self }
@@ -1257,7 +1257,7 @@ let eFloat: Float = 2.71828 // The type of eFloat is Float.
 
 <!--
   - test: `type-inference`
-  
+
   ```swifttest
   -> let e = 2.71828 // The type of e is inferred to be Double.
   -> let eFloat: Float = 2.71828 // The type of eFloat is Float.


### PR DESCRIPTION
Most of this came from places where the RST to markdown export process included indentation on blank lines in comments.