### PR TITLE
Minor fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.md linguist-detectable=true
 *.md linguist-documentation=false
+*.md diff=markdown

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Initialization.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Initialization.md
@@ -925,9 +925,14 @@ convenience init(<#parameters#>) {
 To simplify the relationships between designated and convenience initializers,
 Swift applies the following three rules for delegation calls between initializers:
 
-- term **Rule 1**: A designated initializer must call a designated initializer from its immediate superclass.
-- term **Rule 2**: A convenience initializer must call another initializer from the *same* class.
-- term **Rule 3**: A convenience initializer must ultimately call a designated initializer.
+- term **Rule 1**:
+  A designated initializer must call a designated initializer from its immediate superclass.
+
+- term **Rule 2**:
+  A convenience initializer must call another initializer from the *same* class.
+
+- term **Rule 3**:
+  A convenience initializer must ultimately call a designated initializer.
 
 A simple way to remember this is:
 
@@ -990,8 +995,9 @@ by another initializer unexpectedly.
 Swift's compiler performs four helpful safety-checks to make sure that
 two-phase initialization is completed without error:
 
-- term **Safety check 1**: A designated initializer must ensure that all of the properties introduced by its class
-are initialized before it delegates up to a superclass initializer.
+- term **Safety check 1**:
+  A designated initializer must ensure that all of the properties introduced by its class
+  are initialized before it delegates up to a superclass initializer.
 
 As mentioned above,
 the memory for an object is only considered fully initialized
@@ -999,19 +1005,24 @@ once the initial state of all of its stored properties is known.
 In order for this rule to be satisfied, a designated initializer must make sure that
 all of its own properties are initialized before it hands off up the chain.
 
-- term **Safety check 2**: A designated initializer must delegate up to a superclass initializer
-before assigning a value to an inherited property.
-If it doesn't, the new value the designated initializer assigns
-will be overwritten by the superclass as part of its own initialization.
-- term **Safety check 3**: A convenience initializer must delegate to another initializer
-before assigning a value to *any* property
-(including properties defined by the same class).
-If it doesn't, the new value the convenience initializer assigns
-will be overwritten by its own class's designated initializer.
-- term **Safety check 4**: An initializer can't call any instance methods,
-read the values of any instance properties,
-or refer to `self` as a value
-until after the first phase of initialization is complete.
+- term **Safety check 2**:
+  A designated initializer must delegate up to a superclass initializer
+  before assigning a value to an inherited property.
+  If it doesn't, the new value the designated initializer assigns
+  will be overwritten by the superclass as part of its own initialization.
+
+- term **Safety check 3**:
+  A convenience initializer must delegate to another initializer
+  before assigning a value to *any* property
+  (including properties defined by the same class).
+  If it doesn't, the new value the convenience initializer assigns
+  will be overwritten by its own class's designated initializer.
+
+- term **Safety check 4**:
+  An initializer can't call any instance methods,
+  read the values of any instance properties,
+  or refer to `self` as a value
+  until after the first phase of initialization is complete.
 
 The class instance isn't fully valid until the first phase ends.
 Properties can only be accessed, and methods can only be called,
@@ -1431,13 +1442,16 @@ and can inherit your superclass initializers with minimal effort whenever it's s
 Assuming that you provide default values for any new properties you introduce in a subclass,
 the following two rules apply:
 
-- term **Rule 1**: If your subclass doesn't define any designated initializers,
-it automatically inherits all of its superclass designated initializers.
-- term **Rule 2**: If your subclass provides an implementation of
-*all* of its superclass designated initializers ---
-either by inheriting them as per rule 1,
-or by providing a custom implementation as part of its definition ---
-then it automatically inherits all of the superclass convenience initializers.
+- term **Rule 1**:
+  If your subclass doesn't define any designated initializers,
+  it automatically inherits all of its superclass designated initializers.
+
+- term **Rule 2**:
+  If your subclass provides an implementation of
+  *all* of its superclass designated initializers ---
+  either by inheriting them as per rule 1,
+  or by providing a custom implementation as part of its definition ---
+  then it automatically inherits all of the superclass convenience initializers.
 
 These rules apply even if your subclass adds further convenience initializers.
 

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Attributes.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Attributes.md
@@ -1364,42 +1364,49 @@ they default to being the same as `Component`.
 
 The result-building methods are as follows:
 
-<!--
-  start of term/defn list
--->
+- term `static func buildBlock(_ components: Component...) -> Component`:
+  Combines an array of partial results into a single partial result.
+  A result builder must implement this method.
 
-- term `static func buildBlock(_ components: Component...) -> Component`: Combines an array of partial results into a single partial result.
-A result builder must implement this method.
-- term `static func buildOptional(_ component: Component?) -> Component`: Builds a partial result from a partial result that can be `nil`.
-Implement this method to support `if` statements
-that don’t include an `else` clause.
-- term `static func buildEither(first: Component) -> Component`: Builds a partial result whose value varies depending on some condition.
-Implement both this method and `buildEither(second:)`
-to support `switch` statements
-and `if` statements that include an `else` clause.
-- term `static func buildEither(second: Component) -> Component`: Builds a partial result whose value varies depending on some condition.
-Implement both this method and `buildEither(first:)`
-to support `switch` statements
-and `if` statements that include an `else` clause.
-- term `static func buildArray(_ components: [Component]) -> Component`: Builds a partial result from an array of partial results.
-Implement this method to support `for` loops.
-- term `static func buildExpression(_ expression: Expression) -> Component`: Builds a partial result from an expression.
-You can implement this method to perform preprocessing ---
-for example, converting expressions to an internal type ---
-or to provide additional information for type inference at use sites.
-- term `static func buildFinalResult(_ component: Component) -> FinalResult`: Builds a final result from a partial result.
-You can implement this method as part of a result builder
-that uses a different type for partial and final results,
-or to perform other postprocessing on a result before returning it.
-- term `static func buildLimitedAvailability(_ component: Component) -> Component`: Builds a partial result that propagates or erases type information
-outside a compiler-control statement
-that performs an availability check.
-You can use this to erase type information
-that varies between the conditional branches.
+- term `static func buildOptional(_ component: Component?) -> Component`:
+  Builds a partial result from a partial result that can be `nil`.
+  Implement this method to support `if` statements
+  that don’t include an `else` clause.
 
-<!--
-  end of term/defn list
--->
+- term `static func buildEither(first: Component) -> Component`:
+  Builds a partial result whose value varies depending on some condition.
+  Implement both this method and `buildEither(second:)`
+  to support `switch` statements
+  and `if` statements that include an `else` clause.
+
+- term `static func buildEither(second: Component) -> Component`:
+  Builds a partial result whose value varies depending on some condition.
+  Implement both this method and `buildEither(first:)`
+  to support `switch` statements
+  and `if` statements that include an `else` clause.
+
+- term `static func buildArray(_ components: [Component]) -> Component`:
+  Builds a partial result from an array of partial results.
+  Implement this method to support `for` loops.
+
+- term `static func buildExpression(_ expression: Expression) -> Component`:
+  Builds a partial result from an expression.
+  You can implement this method to perform preprocessing ---
+  for example, converting expressions to an internal type ---
+  or to provide additional information for type inference at use sites.
+
+- term `static func buildFinalResult(_ component: Component) -> FinalResult`:
+  Builds a final result from a partial result.
+  You can implement this method as part of a result builder
+  that uses a different type for partial and final results,
+  or to perform other postprocessing on a result before returning it.
+
+- term `static func buildLimitedAvailability(_ component: Component) -> Component`:
+  Builds a partial result that propagates or erases type information
+  outside a compiler-control statement
+  that performs an availability check.
+  You can use this to erase type information
+  that varies between the conditional branches.
 
 For example, the code below defines a simple result builder
 that builds an array of integers.

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Declarations.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Declarations.md
@@ -3644,38 +3644,47 @@ or meaning of a declaration. You specify a declaration modifier by writing the a
 keyword or context-sensitive keyword between a declaration's attributes (if any) and the keyword
 that introduces the declaration.
 
-- term `class`: Apply this modifier to a member of a class
-to indicate that the member is a member of the class itself,
-rather than a member of instances of the class.
-Members of a superclass that have this modifier
-and don't have the `final` modifier
-can be overridden by subclasses.
-- term `dynamic`: Apply this modifier to any member of a class that can be represented by Objective-C.
-When you mark a member declaration with the `dynamic` modifier,
-access to that member is always dynamically dispatched using the Objective-C runtime.
-Access to that member is never inlined or devirtualized by the compiler.Because declarations marked with the `dynamic` modifier are dispatched
-using the Objective-C runtime, they must be marked with the
-`objc` attribute.
-- term `final`: Apply this modifier to a class or to a property, method,
-or subscript member of a class. It's applied to a class to indicate that the class
-can't be subclassed. It's applied to a property, method, or subscript of a class
-to indicate that a class member can't be overridden in any subclass.
-For an example of how to use the `final` attribute,
-see <doc:Inheritance#Preventing-Overrides>.
-- term `lazy`: Apply this modifier to a stored variable property of a class or structure
-to indicate that the property's initial value is calculated and stored at most
-once, when the property is first accessed.
-For an example of how to use the `lazy` modifier,
-see <doc:Properties#Lazy-Stored-Properties>.
-- term `optional`: Apply this modifier to a protocol's property, method,
-or subscript members to indicate that a conforming type isn't required
-to implement those members.You can apply the `optional` modifier only to protocols that are marked
-with the `objc` attribute. As a result, only class types can adopt and conform
-to a protocol that contains optional member requirements.
-For more information about how to use the `optional` modifier
-and for guidance about how to access optional protocol members---
-for example, when you're not sure whether a conforming type implements them---
-see <doc:Protocols#Optional-Protocol-Requirements>.
+- term `class`:
+  Apply this modifier to a member of a class
+  to indicate that the member is a member of the class itself,
+  rather than a member of instances of the class.
+  Members of a superclass that have this modifier
+  and don't have the `final` modifier
+  can be overridden by subclasses.
+
+- term `dynamic`:
+  Apply this modifier to any member of a class that can be represented by Objective-C.
+  When you mark a member declaration with the `dynamic` modifier,
+  access to that member is always dynamically dispatched using the Objective-C runtime.
+  Access to that member is never inlined or devirtualized by the compiler.Because declarations marked with the `dynamic` modifier are dispatched
+  using the Objective-C runtime, they must be marked with the
+  `objc` attribute.
+
+- term `final`:
+  Apply this modifier to a class or to a property, method,
+  or subscript member of a class. It's applied to a class to indicate that the class
+  can't be subclassed. It's applied to a property, method, or subscript of a class
+  to indicate that a class member can't be overridden in any subclass.
+  For an example of how to use the `final` attribute,
+  see <doc:Inheritance#Preventing-Overrides>.
+
+- term `lazy`:
+  Apply this modifier to a stored variable property of a class or structure
+  to indicate that the property's initial value is calculated and stored at most
+  once, when the property is first accessed.
+  For an example of how to use the `lazy` modifier,
+  see <doc:Properties#Lazy-Stored-Properties>.
+
+- term `optional`:
+  Apply this modifier to a protocol's property, method,
+  or subscript members to indicate that a conforming type isn't required
+  to implement those members.You can apply the `optional` modifier only to protocols that are marked
+  with the `objc` attribute. As a result, only class types can adopt and conform
+  to a protocol that contains optional member requirements.
+  For more information about how to use the `optional` modifier
+  and for guidance about how to access optional protocol members---
+  for example, when you're not sure whether a conforming type implements them---
+  see <doc:Protocols#Optional-Protocol-Requirements>.
 
 <!--
   TODO: Currently, you can't check for an optional initializer,
@@ -3684,55 +3693,67 @@ see <doc:Protocols#Optional-Protocol-Requirements>.
   compiler team. Update this section if they decide to make everything work
   properly for optional initializer requirements.
 -->
-- term `required`: Apply this modifier to a designated or convenience initializer
-of a class to indicate that every subclass must implement that initializer.
-The subclass's implementation of that initializer
-must also be marked with the `required` modifier.
-- term `static`: Apply this modifier to a member of a structure, class, enumeration, or protocol
-to indicate that the member is a member of the type,
-rather than a member of instances of that type.
-In the scope of a class declaration,
-writing the `static` modifier on a member declaration
-has the same effect as writing the `class` and `final` modifiers
-on that member declaration.
-However, constant type properties of a class are an exception:
-`static` has its normal, nonclass meaning there
-because you can't write `class` or `final` on those declarations.
-- term `unowned`: Apply this modifier to a stored variable, constant, or stored property
-to indicate that the variable or property has an unowned reference
-to the object stored as its value.
-If you try to access the variable or property
-after the object has been deallocated,
-a runtime error is raised.
-Like a weak reference,
-the type of the property or value must be a class type;
-unlike a weak reference,
-the type is non-optional.
-For an example and more information about the `unowned` modifier,
-see <doc:AutomaticReferenceCounting#Unowned-References>.
-- term `unowned(safe)`: An explicit spelling of `unowned`.
-- term `unowned(unsafe)`: Apply this modifier to a stored variable, constant, or stored property
-to indicate that the variable or property has an unowned reference
-to the object stored as its value.
-If you try to access the variable or property
-after the object has been deallocated,
-you'll access the memory at the location where the object used to be,
-which is a memory-unsafe operation.
-Like a weak reference,
-the type of the property or value must be a class type;
-unlike a weak reference,
-the type is non-optional.
-For an example and more information about the `unowned` modifier,
-see <doc:AutomaticReferenceCounting#Unowned-References>.
-- term `weak`: Apply this modifier to a stored variable or stored variable property
-to indicate that the variable or property has a weak reference to the
-object stored as its value. The type of the variable or property
-must be an optional class type.
-If you access the variable or property
-after the object has been deallocated,
-its value is `nil`.
-For an example and more information about the `weak` modifier,
-see <doc:AutomaticReferenceCounting#Weak-References>.
+
+- term `required`:
+  Apply this modifier to a designated or convenience initializer
+  of a class to indicate that every subclass must implement that initializer.
+  The subclass's implementation of that initializer
+  must also be marked with the `required` modifier.
+
+- term `static`:
+  Apply this modifier to a member of a structure, class, enumeration, or protocol
+  to indicate that the member is a member of the type,
+  rather than a member of instances of that type.
+  In the scope of a class declaration,
+  writing the `static` modifier on a member declaration
+  has the same effect as writing the `class` and `final` modifiers
+  on that member declaration.
+  However, constant type properties of a class are an exception:
+  `static` has its normal, nonclass meaning there
+  because you can't write `class` or `final` on those declarations.
+
+- term `unowned`:
+  Apply this modifier to a stored variable, constant, or stored property
+  to indicate that the variable or property has an unowned reference
+  to the object stored as its value.
+  If you try to access the variable or property
+  after the object has been deallocated,
+  a runtime error is raised.
+  Like a weak reference,
+  the type of the property or value must be a class type;
+  unlike a weak reference,
+  the type is non-optional.
+  For an example and more information about the `unowned` modifier,
+  see <doc:AutomaticReferenceCounting#Unowned-References>.
+
+- term `unowned(safe)`:
+  An explicit spelling of `unowned`.
+
+- term `unowned(unsafe)`:
+  Apply this modifier to a stored variable, constant, or stored property
+  to indicate that the variable or property has an unowned reference
+  to the object stored as its value.
+  If you try to access the variable or property
+  after the object has been deallocated,
+  you'll access the memory at the location where the object used to be,
+  which is a memory-unsafe operation.
+  Like a weak reference,
+  the type of the property or value must be a class type;
+  unlike a weak reference,
+  the type is non-optional.
+  For an example and more information about the `unowned` modifier,
+  see <doc:AutomaticReferenceCounting#Unowned-References>.
+
+- term `weak`:
+  Apply this modifier to a stored variable or stored variable property
+  to indicate that the variable or property has a weak reference to the
+  object stored as its value. The type of the variable or property
+  must be an optional class type.
+  If you access the variable or property
+  after the object has been deallocated,
+  its value is `nil`.
+  For an example and more information about the `weak` modifier,
+  see <doc:AutomaticReferenceCounting#Weak-References>.
 
 ### Access Control Levels
 
@@ -3741,22 +3762,31 @@ You can mark a declaration with one of the access-level modifiers below
 to specify the declaration's access level.
 Access control is discussed in detail in <doc:AccessControl>.
 
-- term `open`: Apply this modifier to a declaration to indicate the declaration can be accessed and subclassed
-by code in the same module as the declaration.
-Declarations marked with the `open` access-level modifier can also be accessed and subclassed
-by code in a module that imports the module that contains that declaration.
-- term `public`: Apply this modifier to a declaration to indicate the declaration can be accessed and subclassed
-by code in the same module as the declaration.
-Declarations marked with the `public` access-level modifier can also be accessed (but not subclassed)
-by code in a module that imports the module that contains that declaration.
-- term `internal`: Apply this modifier to a declaration to indicate the declaration can be accessed
-only by code in the same module as the declaration.
-By default,
-most declarations are implicitly marked with the `internal` access-level modifier.
-- term `fileprivate`: Apply this modifier to a declaration to indicate the declaration can be accessed
-only by code in the same source file as the declaration.
-- term `private`: Apply this modifier to a declaration to indicate the declaration can be accessed
-only by code within the declaration's immediate enclosing scope.
+- term `open`:
+  Apply this modifier to a declaration to indicate the declaration can be accessed and subclassed
+  by code in the same module as the declaration.
+  Declarations marked with the `open` access-level modifier can also be accessed and subclassed
+  by code in a module that imports the module that contains that declaration.
+
+- term `public`:
+  Apply this modifier to a declaration to indicate the declaration can be accessed and subclassed
+  by code in the same module as the declaration.
+  Declarations marked with the `public` access-level modifier can also be accessed (but not subclassed)
+  by code in a module that imports the module that contains that declaration.
+
+- term `internal`:
+  Apply this modifier to a declaration to indicate the declaration can be accessed
+  only by code in the same module as the declaration.
+  By default,
+  most declarations are implicitly marked with the `internal` access-level modifier.
+
+- term `fileprivate`:
+  Apply this modifier to a declaration to indicate the declaration can be accessed
+  only by code in the same source file as the declaration.
+
+- term `private`:
+  Apply this modifier to a declaration to indicate the declaration can be accessed
+  only by code within the declaration's immediate enclosing scope.
 
 For the purpose of access control,
 extensions to the same type that are in the same file

--- a/Sources/TSPL/TSPL.docc/TSPL.md
+++ b/Sources/TSPL/TSPL.docc/TSPL.md
@@ -11,7 +11,7 @@
 
 ## Topics
 
-### Guided Tour
+### Welcome to Swift
 
 - <doc:AboutSwift>
 - <doc:Compatibility>

--- a/Sources/TSPL/TSPL.docc/TSPL.md
+++ b/Sources/TSPL/TSPL.docc/TSPL.md
@@ -7,6 +7,7 @@
 @Options(scope: global) {
   @AutomaticSeeAlso(disabled)
   @AutomaticTitleHeading(disabled)
+  @AutomaticArticleSubheading(disabled)
 }
 
 ## Topics


### PR DESCRIPTION
Various minor changes:

- Fix a heading
- Disable the automatic "Overview" heading
- Fix formatting of term-definition lists
- Set a Git attribute for markdown files