### PR TITLE
Add custom header for staging copy and build script

### DIFF
--- a/Sources/TSPL/TSPL.docc/TSPL.md
+++ b/Sources/TSPL/TSPL.docc/TSPL.md
@@ -1,7 +1,7 @@
-# ``TSPL``
+# The Swift Programming Language
 
 @Metadata {
-  @DisplayName("The Swift Programming Language")
+  @TechnologyRoot
 }
 
 @Options(scope: global) {

--- a/Sources/TSPL/TSPL.docc/TSPL.md
+++ b/Sources/TSPL/TSPL.docc/TSPL.md
@@ -1,7 +1,7 @@
-# The Swift Programming Language
+# ``TSPL``
 
 @Metadata {
-  @TechnologyRoot
+  @DisplayName("The Swift Programming Language")
 }
 
 @Options(scope: global) {

--- a/Sources/TSPL/TSPL.docc/header.html
+++ b/Sources/TSPL/TSPL.docc/header.html
@@ -1,12 +1,13 @@
 <!--
-  This source file is part of the Swift.org open source project
+This source file is part of the Swift.org open source project
 
-  Copyright (c) 2022 Apple Inc. and the Swift project authors
-  Licensed under Apache License v2.0 with Runtime Library Exception
+Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
 
-  See https://swift.org/LICENSE.txt for license information
-  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+See https://swift.org/LICENSE.txt for license information
+See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 -->
+
 <header id="header" role="banner">
     <div class="container">
         <aside style="border-radius: 20px; border: 2px solid goldenrod; background: rgba(230, 241, 69, 0.625); padding: 5px; margin: 5px;">

--- a/Sources/TSPL/TSPL.docc/header.html
+++ b/Sources/TSPL/TSPL.docc/header.html
@@ -15,8 +15,8 @@
             This is the development version of <em>The Swift Programming Language</em> book.
         </p>
         <p>
-            For the current shipping book, see <a href="https://docs.swift.org/swift-book/">swift.org</a>.
-            To contribute to its development, see the <a href="https://www.swift.org/documentation-workgroup/">Swift Documentation Workgroup</a>.
+            For the current shipping book, see <a href="https://docs.swift.org/swift-book/">Swift.org</a>.
+            To contribute to this documentation, see the <a href="https://github.com/apple/swift-book">swift-book project</a> on GitHub.
         </p>
         </aside>
     </div>

--- a/Sources/TSPL/TSPL.docc/header.html
+++ b/Sources/TSPL/TSPL.docc/header.html
@@ -1,0 +1,23 @@
+<!--
+  This source file is part of the Swift.org open source project
+
+  Copyright (c) 2022 Apple Inc. and the Swift project authors
+  Licensed under Apache License v2.0 with Runtime Library Exception
+
+  See https://swift.org/LICENSE.txt for license information
+  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+<header id="header" role="banner">
+    <div class="container">
+        <aside style="border-radius: 20px; border: 2px solid goldenrod; background: rgba(230, 241, 69, 0.625); padding: 5px; margin: 5px;">
+        <h3>Important</h3>
+        <p>
+            This is the development version of <em>The Swift Programming Language</em> book.
+        </p>
+        <p>
+            For the current shipping book, see <a href="https://docs.swift.org/swift-book/">swift.org</a>.
+            To contribute to its development, see the <a href="https://www.swift.org/documentation-workgroup/">Swift Documentation Workgroup</a>.
+        </p>
+        </aside>
+    </div>
+</header>

--- a/bin/update-book-preview
+++ b/bin/update-book-preview
@@ -1,5 +1,5 @@
-#!/bin/bash
-#
+#! /bin/bash
+
 # This source file is part of the Swift.org open source project
 #
 # Copyright (c) 2022 Apple Inc. and the Swift project authors
@@ -7,64 +7,64 @@
 #
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for Swift project authors
-#
-# Updates the GitHub Pages documentation site thats published from the 'docs'
+
+# Updates the GitHub Pages documentation site that's published from the 'docs'
 # subdirectory in the 'gh-pages' branch of this repository.
 #
 # This script should be run by someone with commit access to the 'gh-pages' branch
 # at a regular frequency so that the documentation content on the GitHub Pages site
 # is up-to-date with the content in this repo.
+
+# To use top-of-tree DocC, set environment variables like the following:
 #
+#     DOCC_EXEC=~/git/DocC/.build/arm64-apple-macosx/debug/docc
+#     DOCC_HTML_DIR=~/git/DocC-Renderer/dist/
 
 set -eu
 
-# A `realpath` alternative using the default C implementation.
-filepath() {
-  [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
-}
+REMOTE=${1:-origin}
+CURRENT_COMMIT_HASH="$(git rev-parse --short HEAD)"
 
-SWIFT_BOOK_ROOT="$(dirname $(dirname $(filepath $0)))"
+# Start at the top level directory of the repository.
+cd "$(git rev-parse --show-toplevel)"
 
-# Set current directory to the repository root
-cd "$SWIFT_BOOK_ROOT"
+# Check out the 'gh-pages' branch in a subdirectory.
+git worktree add --checkout gh-pages "$REMOTE"/gh-pages
 
-# Use git worktree to checkout the gh-pages branch of this repository in a gh-pages sub-directory
-git fetch
-git worktree add --checkout gh-pages origin/gh-pages
-
-# Pretty print DocC JSON output so that it can be consistently diffed between commits
+# Pretty print DocC JSON output, so that it has a stable ordering and
+# can be diffed.  This lets us determine whether rebuilding resulted in
+# any changes to the content.
 export DOCC_JSON_PRETTYPRINT="YES"
 
-# Generate documentation for TSPL and output it
-# to the /docs subdirectory in the gh-pages worktree directory.
+# Build documentation, writing output in the gh-pages/docs subdirectory.
 export SWIFTPM_ENABLE_COMMAND_PLUGINS=1
 swift package \
-    --allow-writing-to-directory "$SWIFT_BOOK_ROOT/gh-pages/docs" \
+    --allow-writing-to-directory "./gh-pages/docs" \
     generate-documentation \
     --target TSPL \
     --disable-indexing \
     --transform-for-static-hosting \
     --experimental-enable-custom-templates \
     --hosting-base-path swift-book \
-    --output-path "$SWIFT_BOOK_ROOT/gh-pages/docs"
-
-# Save the current commit we've just built documentation from in a variable
-CURRENT_COMMIT_HASH=`git rev-parse --short HEAD`
+    --output-path "./gh-pages/docs"
 
 # Commit and push our changes to the gh-pages branch
-cd gh-pages
+pushd gh-pages
 git add docs
 
-if [ -n "$(git status --porcelain)" ]; then
-    echo "Documentation changes found. Commiting the changes to the 'gh-pages' branch and pushing to origin."
+if [[ -n "$(git status --porcelain)" ]]
+then
+    echo "Found documentation changes."
+    echo "Committing the changes to the 'gh-pages' branch and pushing to $REMOTE."
     git commit -m "Update GitHub Pages documentation site to '$CURRENT_COMMIT_HASH'."
-    git push origin HEAD:gh-pages
+    echo
+    git push "$REMOTE" HEAD:gh-pages
 else
   # No changes found, nothing to commit.
   echo "No documentation changes found."
 fi
 
+popd
+
 # Delete the git worktree we created
-cd ..
-exit
 git worktree remove gh-pages

--- a/bin/update-book-preview
+++ b/bin/update-book-preview
@@ -43,13 +43,11 @@ git worktree add --checkout gh-pages "$REMOTE"/gh-pages
 export DOCC_JSON_PRETTYPRINT="YES"
 
 # Build documentation, writing output in the gh-pages/docs subdirectory.
-export SWIFTPM_ENABLE_COMMAND_PLUGINS=1
 swift package \
     --allow-writing-to-directory "./gh-pages/docs" \
     generate-documentation \
     --target TSPL \
     --disable-indexing \
-    --transform-for-static-hosting \
     --experimental-enable-custom-templates \
     --hosting-base-path swift-book \
     --output-path "./gh-pages/docs"

--- a/bin/update-book-preview
+++ b/bin/update-book-preview
@@ -14,8 +14,14 @@
 # This script should be run by someone with commit access to the 'gh-pages' branch
 # at a regular frequency so that the documentation content on the GitHub Pages site
 # is up-to-date with the content in this repo.
-
-# To use top-of-tree DocC, set environment variables like the following:
+#
+# To use top-of-tree DocC, clone the following repositories:
+#
+#     https://github.com/apple/swift-docc
+#     https://github.com/apple/swift-docc-render
+#
+# Then set environment variables to paths in their working directories,
+# like the following, before running this script:
 #
 #     DOCC_EXEC=~/git/DocC/.build/arm64-apple-macosx/debug/docc
 #     DOCC_HTML_DIR=~/git/DocC-Renderer/dist/

--- a/bin/update-book-preview
+++ b/bin/update-book-preview
@@ -1,0 +1,70 @@
+#!/bin/bash
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2022 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+#
+# Updates the GitHub Pages documentation site thats published from the 'docs'
+# subdirectory in the 'gh-pages' branch of this repository.
+#
+# This script should be run by someone with commit access to the 'gh-pages' branch
+# at a regular frequency so that the documentation content on the GitHub Pages site
+# is up-to-date with the content in this repo.
+#
+
+set -eu
+
+# A `realpath` alternative using the default C implementation.
+filepath() {
+  [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+
+SWIFT_BOOK_ROOT="$(dirname $(dirname $(filepath $0)))"
+
+# Set current directory to the repository root
+cd "$SWIFT_BOOK_ROOT"
+
+# Use git worktree to checkout the gh-pages branch of this repository in a gh-pages sub-directory
+git fetch
+git worktree add --checkout gh-pages origin/gh-pages
+
+# Pretty print DocC JSON output so that it can be consistently diffed between commits
+export DOCC_JSON_PRETTYPRINT="YES"
+
+# Generate documentation for TSPL and output it
+# to the /docs subdirectory in the gh-pages worktree directory.
+export SWIFTPM_ENABLE_COMMAND_PLUGINS=1
+swift package \
+    --allow-writing-to-directory "$SWIFT_BOOK_ROOT/gh-pages/docs" \
+    generate-documentation \
+    --target TSPL \
+    --disable-indexing \
+    --transform-for-static-hosting \
+    --experimental-enable-custom-templates \
+    --hosting-base-path swift-book \
+    --output-path "$SWIFT_BOOK_ROOT/gh-pages/docs"
+
+# Save the current commit we've just built documentation from in a variable
+CURRENT_COMMIT_HASH=`git rev-parse --short HEAD`
+
+# Commit and push our changes to the gh-pages branch
+cd gh-pages
+git add docs
+
+if [ -n "$(git status --porcelain)" ]; then
+    echo "Documentation changes found. Commiting the changes to the 'gh-pages' branch and pushing to origin."
+    git commit -m "Update GitHub Pages documentation site to '$CURRENT_COMMIT_HASH'."
+    git push origin HEAD:gh-pages
+else
+  # No changes found, nothing to commit.
+  echo "No documentation changes found."
+fi
+
+# Delete the git worktree we created
+cd ..
+exit
+git worktree remove gh-pages

--- a/bin/update-book-preview
+++ b/bin/update-book-preview
@@ -60,11 +60,9 @@ then
     echo
     git push "$REMOTE" HEAD:gh-pages
 else
-  # No changes found, nothing to commit.
-  echo "No documentation changes found."
+    echo "No documentation changes found."
 fi
 
 popd
 
-# Delete the git worktree we created
 git worktree remove gh-pages


### PR DESCRIPTION
As discussed in some of the docs workgroup meetings, it's useful for us to have a staging copy of the book.

Fixes https://github.com/apple/swift-book/issues/34
