### PR TITLE
Restore numbered lists

### DIFF
--- a/Sources/TSPL/TSPL.docc/GuidedTour/GuidedTour.md
+++ b/Sources/TSPL/TSPL.docc/GuidedTour/GuidedTour.md
@@ -1294,9 +1294,9 @@ You can provide an explicit name in parentheses after `set`.
 Notice that the initializer for the `EquilateralTriangle` class
 has three different steps:
 
-- Setting the value of properties that the subclass declares.
-- Calling the superclass's initializer.
-- Changing the value of properties defined by the superclass.
+1. Setting the value of properties that the subclass declares.
+2. Calling the superclass's initializer.
+3. Changing the value of properties defined by the superclass.
    Any additional setup work that uses methods, getters, or setters
    can also be done at this point.
 

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/AdvancedOperators.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/AdvancedOperators.md
@@ -202,9 +202,9 @@ whereas shifting it to the right by one position halves its value.
 
 The bit-shifting behavior for unsigned integers is as follows:
 
-- Existing bits are moved to the left or right by the requested number of places.
-- Any bits that are moved beyond the bounds of the integer's storage are discarded.
-- Zeros are inserted in the spaces left behind
+1. Existing bits are moved to the left or right by the requested number of places.
+2. Any bits that are moved beyond the bounds of the integer's storage are discarded.
+3. Zeros are inserted in the spaces left behind
    after the original bits are moved to the left or right.
 
 This approach is known as a *logical shift*.

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Concurrency.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Concurrency.md
@@ -883,11 +883,11 @@ the temperature logger is in a temporary inconsistent state.
 Preventing multiple tasks from interacting with the same instance simultaneously
 prevents problems like the following sequence of events:
 
-- Your code calls the `update(with:)` method.
+1. Your code calls the `update(with:)` method.
    It updates the `measurements` array first.
-- Before your code can update `max`,
+2. Before your code can update `max`,
    code elsewhere reads the maximum value and the array of temperatures.
-- Your code finishes its update by changing `max`.
+3. Your code finishes its update by changing `max`.
 
 In this case,
 the code running elsewhere would read incorrect information

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Generics.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Generics.md
@@ -320,11 +320,11 @@ The illustration below shows the push and pop behavior for a stack:
 
 ![](stackPushPop)
 
-- There are currently three values on the stack.
-- A fourth value is pushed onto the top of the stack.
-- The stack now holds four values, with the most recent one at the top.
-- The top item in the stack is popped.
-- After popping a value, the stack once again holds three values.
+1. There are currently three values on the stack.
+2. A fourth value is pushed onto the top of the stack.
+3. The stack now holds four values, with the most recent one at the top.
+4. The top item in the stack is popped.
+5. After popping a value, the stack once again holds three values.
 
 Here's how to write a nongeneric version of a stack,
 in this case for a stack of `Int` values:

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Declarations.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Declarations.md
@@ -884,11 +884,11 @@ repeatGreeting("Hello, world!", count: 2) //  count is labeled, greeting is not
 
 In-out parameters are passed as follows:
 
-- When the function is called,
+1. When the function is called,
    the value of the argument is copied.
-- In the body of the function,
+2. In the body of the function,
    the copy is modified.
-- When the function returns,
+3. When the function returns,
    the copy's value is assigned to the original argument.
 
 This behavior is known as *copy-in copy-out*

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Statements.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Statements.md
@@ -123,9 +123,9 @@ while <#condition#> {
 
 A `while` statement is executed as follows:
 
-- The *condition* is evaluated.If `true`, execution continues to step 2.
+1. The *condition* is evaluated.If `true`, execution continues to step 2.
    If `false`, the program is finished executing the `while` statement.
-- The program executes the *statements*, and execution returns to step 1.
+2. The program executes the *statements*, and execution returns to step 1.
 
 Because the value of the *condition* is evaluated before the *statements* are executed,
 the *statements* in a `while` statement can be executed zero or more times.
@@ -166,9 +166,9 @@ repeat {
 
 A `repeat`-`while` statement is executed as follows:
 
-- The program executes the *statements*,
+1. The program executes the *statements*,
    and execution continues to step 2.
-- The *condition* is evaluated.If `true`, execution returns to step 1.
+2. The *condition* is evaluated.If `true`, execution returns to step 1.
    If `false`, the program is finished executing the `repeat`-`while` statement.
 
 Because the value of the *condition* is evaluated after the *statements* are executed,


### PR DESCRIPTION
This got incorrectly converted from a numbered list to a bulleted list during the RST export to markdown.

<img width="1903" alt="Screenshot 2022-12-05 at 10 09 56 AM" src="https://user-images.githubusercontent.com/15617351/205712984-dcf3c93b-d2b6-4a89-bbb1-679302f8e4fc.png">

Fixes rdar://102987273