### PR TITLE
Fix markup for backtick in code voice

### DIFF
--- a/Sources/TSPL/TSPL.docc/ReferenceManual/LexicalStructure.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/LexicalStructure.md
@@ -122,9 +122,9 @@ are reserved for the Swift compiler and standard library.
 To use a reserved word as an identifier,
 put a backtick (\`) before and after it.
 For example, `class` isn't a valid identifier,
-but \``class`\` is valid.
+but `` `class` `` is valid.
 The backticks aren't considered part of the identifier;
-\``x`\` and `x` have the same meaning.
+`` `x` `` and `x` have the same meaning.
 
 Inside a closure with no explicit parameter names,
 the parameters are implicitly named `$0`, `$1`, `$2`, and so on.

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/LexicalStructure.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/LexicalStructure.md
@@ -430,7 +430,7 @@ The following tokens are reserved as punctuation
 and can't be used as custom operators:
 `(`, `)`, `{`, `}`, `[`, `]`,
 `.`, `,`, `:`, `;`, `=`, `@`, `#`,
-`&` (as a prefix operator), `->`, `\\``,
+`&` (as a prefix operator), `->`, `` ` ``,
 `?`, and `!` (as a postfix operator).
 
 ## Literals

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/LexicalStructure.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/LexicalStructure.md
@@ -126,6 +126,14 @@ but `` `class` `` is valid.
 The backticks aren't considered part of the identifier;
 `` `x` `` and `x` have the same meaning.
 
+<!--
+The paragraph above produces a link-resolution warning
+because of a known issue with ` in code voice.
+
+https://github.com/apple/swift-book/issues/71
+https://github.com/apple/swift-markdown/issues/93
+-->
+
 Inside a closure with no explicit parameter names,
 the parameters are implicitly named `$0`, `$1`, `$2`, and so on.
 These names are valid identifiers within the scope of the closure.
@@ -141,6 +149,15 @@ of the <doc:Attributes> chapter.
   The cross reference above includes both the section and chapter because,
   even though "propertyWrapper" is the title of the section,
   the section name isn't title case so it doesn't necessarily look like a title.
+-->
+
+<!--
+The formal grammar below for 'identifier'
+produces a link-resolution warning
+because of a known issue with ` in code voice.
+
+https://github.com/apple/swift-book/issues/71
+https://github.com/apple/swift-markdown/issues/93
 -->
 
 > Grammar of an identifier:


### PR DESCRIPTION
This markup is the only way to create a code-voice backtick in markdown, even though it creates a warning due to DocC's meaning of double backticks to delimit code voice.  See also that known issue: <https://github.com/apple/swift-book/issues/71> & <https://github.com/apple/swift-markdown/issues/93>

The current markup for the 'code' and 'x' example in Lexical structure does render the backticks, but the backticks are in plain font instead of code voice, which isn't correct.

Fixes rdar://102988329