### PR TITLE
Input em-dashes with space on both sides

### DIFF
--- a/Sources/TSPL/TSPL.docc/LanguageGuide/CollectionTypes.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/CollectionTypes.md
@@ -898,7 +898,7 @@ or determining whether two sets contain all, some, or none of the same values.
 
 ### Fundamental Set Operations
 
-The illustration below depicts two sets---`a` and `b`---
+The illustration below depicts two sets --- `a` and `b` ---
 with the results of various set operations represented by the shaded regions.
 
 ![](setVennDiagram)
@@ -957,7 +957,7 @@ oddDigits.symmetricDifference(singleDigitPrimeNumbers).sorted()
 
 ### Set Membership and Equality
 
-The illustration below depicts three sets---`a`, `b` and `c`---
+The illustration below depicts three sets --- `a`, `b` and `c` ---
 with overlapping regions representing elements shared among sets.
 Set `a` is a *superset* of set `b`,
 because `a` contains all elements in `b`.

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Attributes.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Attributes.md
@@ -327,7 +327,7 @@ dial.dynamicallyCall(withArguments: [4, 1, 1])
 The declaration of the `dynamicallyCall(withArguments:)` method
 must have a single parameter that conforms to the
 [ExpressibleByArrayLiteral](https://developer.apple.com/documentation/swift/expressiblebyarrayliteral)
-protocol---like `[Int]` in the example above.
+protocol --- like `[Int]` in the example above.
 The return type can be any type.
 
 You can include labels in a dynamic method call
@@ -389,7 +389,7 @@ must be
 [ExpressibleByStringLiteral](https://developer.apple.com/documentation/swift/expressiblebystringliteral).
 The previous example uses [KeyValuePairs](https://developer.apple.com/documentation/swift/keyvaluepairs)
 as the parameter type
-so that callers can include duplicate parameter labels---
+so that callers can include duplicate parameter labels ---
 `a` and `b` appear multiple times in the call to `repeat`.
 
 If you implement both `dynamicallyCall` methods,
@@ -945,7 +945,7 @@ as discussed in <doc:Declarations#Top-Level-Code>.
 
 Apply this attribute to a stored variable property of a class.
 This attribute causes the property's setter to be synthesized with a *copy*
-of the property's value---returned by the `copyWithZone(_:)` method---instead of the
+of the property's value --- returned by the `copyWithZone(_:)` method --- instead of the
 value of the property itself.
 The type of the property must conform to the `NSCopying` protocol.
 
@@ -969,7 +969,7 @@ Applying this attribute also implies the `objc` attribute.
 
 ### objc
 
-Apply this attribute to any declaration that can be represented in Objective-C---
+Apply this attribute to any declaration that can be represented in Objective-C ---
 for example, nonnested classes, protocols,
 nongeneric enumerations (constrained to integer raw-value types),
 properties and methods (including getters and setters) of classes,

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Declarations.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Declarations.md
@@ -799,8 +799,8 @@ A function definition can appear inside another function declaration.
 This kind of function is known as a *nested function*.
 
 A nested function is nonescaping if it captures
-a value that's guaranteed to never escape---
-such as an in-out parameter---
+a value that's guaranteed to never escape ---
+such as an in-out parameter ---
 or passed as a nonescaping function argument.
 Otherwise, the nested function is an escaping function.
 
@@ -1529,7 +1529,7 @@ An *enumeration declaration* introduces a named enumeration type into your progr
 
 Enumeration declarations have two basic forms and are declared using the `enum` keyword.
 The body of an enumeration declared using either form contains
-zero or more values---called *enumeration cases*---
+zero or more values --- called *enumeration cases* ---
 and any number of declarations,
 including computed properties,
 instance methods, type methods, initializers, type aliases,
@@ -2208,8 +2208,8 @@ and only to members of protocols that are marked
 with the `objc` attribute. As a result, only class types can adopt and conform
 to a protocol that contains optional member requirements.
 For more information about how to use the `optional` declaration modifier
-and for guidance about how to access optional protocol members---
-for example, when you're not sure whether a conforming type implements them---
+and for guidance about how to access optional protocol members ---
+for example, when you're not sure whether a conforming type implements them ---
 see <doc:Protocols#Optional-Protocol-Requirements>.
 
 <!--
@@ -2825,8 +2825,8 @@ deinit {
 
 A deinitializer is called automatically when there are no longer any references
 to a class object, just before the class object is deallocated.
-A deinitializer can be declared only in the body of a class declaration---
-but not in an extension of a class---
+A deinitializer can be declared only in the body of a class declaration ---
+but not in an extension of a class ---
 and each class can have at most one.
 
 A subclass inherits its superclass's deinitializer,
@@ -3673,8 +3673,8 @@ to implement those members.You can apply the `optional` modifier only to protoco
 with the `objc` attribute. As a result, only class types can adopt and conform
 to a protocol that contains optional member requirements.
 For more information about how to use the `optional` modifier
-and for guidance about how to access optional protocol members---
-for example, when you're not sure whether a conforming type implements them---
+and for guidance about how to access optional protocol members ---
+for example, when you're not sure whether a conforming type implements them ---
 see <doc:Protocols#Optional-Protocol-Requirements>.
 
 <!--

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Patterns.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Patterns.md
@@ -392,12 +392,12 @@ is <#type#>
 ```
 
 The `is` pattern matches a value if the type of that value at runtime is the same as
-the type specified in the right-hand side of the `is` pattern---or a subclass of that type.
+the type specified in the right-hand side of the `is` pattern --- or a subclass of that type.
 The `is` pattern behaves like the `is` operator in that they both perform a type cast
 but discard the returned type.
 
 The `as` pattern matches a value if the type of that value at runtime is the same as
-the type specified in the right-hand side of the `as` pattern---or a subclass of that type.
+the type specified in the right-hand side of the `as` pattern --- or a subclass of that type.
 If the match succeeds,
 the type of the matched value is cast to the *pattern* specified in the right-hand side
 of the `as` pattern.

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Statements.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Statements.md
@@ -92,7 +92,7 @@ for <#item#> in <#collection#> {
 ```
 
 The `makeIterator()` method is called on the *collection* expression
-to obtain a value of an iterator type---that is,
+to obtain a value of an iterator type --- that is,
 a type that conforms to the
 [IteratorProtocol](https://developer.apple.com/documentation/swift/iteratorprotocol) protocol.
 The program begins executing a loop
@@ -384,7 +384,7 @@ which must appear at the end of the `switch` statement.
 Although the actual execution order of pattern-matching operations,
 and in particular the evaluation order of patterns in cases, is unspecified,
 pattern matching in a `switch` statement behaves
-as if the evaluation is performed in source order---that is,
+as if the evaluation is performed in source order --- that is,
 the order in which they appear in source code.
 As a result, if multiple cases contain patterns that evaluate to the same value,
 and thus can match the value of the control expression,
@@ -430,7 +430,7 @@ you can include a default case to satisfy the requirement.
 #### Switching Over Future Enumeration Cases
 
 A *nonfrozen enumeration* is a special kind of enumeration
-that may gain new enumeration cases in the future---
+that may gain new enumeration cases in the future ---
 even after you compile and ship an app.
 Switching over a nonfrozen enumeration requires extra consideration.
 When a library's authors mark an enumeration as nonfrozen,

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Types.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Types.md
@@ -11,8 +11,8 @@ In addition to user-defined named types,
 the Swift standard library defines many commonly used named types,
 including those that represent arrays, dictionaries, and optional values.
 
-Data types that are normally considered basic or primitive in other languages---
-such as types that represent numbers, characters, and strings---
+Data types that are normally considered basic or primitive in other languages ---
+such as types that represent numbers, characters, and strings ---
 are actually named types,
 defined and implemented in the Swift standard library using structures.
 Because they're named types,
@@ -1244,7 +1244,7 @@ That is,
 the type of `x` in `var x: Int = 0` is inferred by first checking the type of `0`
 and then passing this type information up to the root (the variable `x`).
 
-In Swift, type information can also flow in the opposite direction---from the root down to the leaves.
+In Swift, type information can also flow in the opposite direction --- from the root down to the leaves.
 In the following example, for instance,
 the explicit type annotation (`: Float`) on the constant `eFloat`
 causes the numeric literal `2.71828` to have an inferred type of `Float` instead of `Double`.


### PR DESCRIPTION
This matches the rest of the em-dashes in the book.  In most cases, because an em-dash is a clause boundary, it ends up at the end of the line with semantic line breaks.  The previous RST-based publication pipeline included a step to close up em-dashes, so these few exceptions didn't cause issues.

DocC doesn't close up em-dashes, and the current instruction from editorial is to set em-dashes open because the San Francisco font otherwise sets things too close together.  When setting this content in another font that doesn't have that issue, like Helvetica, we'd need to teach DocC to close up the em-dashes throughout.

Fixes rdar://102987894