### PR TITLE
Fix incorrect (one-space) indentation.

### DIFF
--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Attributes.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Attributes.md
@@ -1281,13 +1281,13 @@ as the original wrapped property.
 ```swift
 @propertyWrapper
 struct WrapperWithProjection {
- var wrappedValue: Int
- var projectedValue: SomeProjection {
-     return SomeProjection(wrapper: self)
- }
+    var wrappedValue: Int
+    var projectedValue: SomeProjection {
+        return SomeProjection(wrapper: self)
+    }
 }
 struct SomeProjection {
- var wrapper: WrapperWithProjection
+    var wrapper: WrapperWithProjection
 }
 
 struct SomeStruct {
@@ -1305,13 +1305,13 @@ s.$x.wrapper  // WrapperWithProjection value
   ```swifttest
   -> @propertyWrapper
   -> struct WrapperWithProjection {
-      var wrappedValue: Int
-      var projectedValue: SomeProjection {
-          return SomeProjection(wrapper: self)
-      }
+         var wrappedValue: Int
+         var projectedValue: SomeProjection {
+             return SomeProjection(wrapper: self)
+         }
   }
   -> struct SomeProjection {
-      var wrapper: WrapperWithProjection
+         var wrapper: WrapperWithProjection
   }
   ---
   -> struct SomeStruct {


### PR DESCRIPTION
This probably got overlooked by the searches when fixing https://github.com/apple/swift-book/pull/53 because it's a one-space indentation.  It wasn't a leftover from the Swift 1 era of intentional three-space indentations — this was just a markup error in source that didn't cause issues under the legacy RST publication pipeline because that pipeline reindented everything anyhow.

Fixes rdar://103197773