### PR TITLE
Specify code listings are in Swift

### DIFF
--- a/Sources/TSPL/TSPL.docc/Info.plist
+++ b/Sources/TSPL/TSPL.docc/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>org.swift.tspl</string>
 	<key>CDDefaultCodeListingLanguage</key>
-	<string>markdown</string>
+	<string>swift</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleIconFile</key>

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Concurrency.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Concurrency.md
@@ -557,7 +557,7 @@ the explicit parent-child relationships between tasks
 lets Swift handle some behaviors like propagating cancellation for you,
 and lets Swift detect some errors at compile time.
 
-```
+```swift
 await withTaskGroup(of: Data.self) { taskGroup in
     let photoNames = await listPhotos(inGallery: "Summer Vacation")
     for name in photoNames {
@@ -706,7 +706,7 @@ call the [Task.detached(priority:operation:)](https://developer.apple.com/docume
 Both of these operations return a task that you can interact with ---
 for example, to wait for its result or to cancel it.
 
-```
+```swift
 let newPhoto = // ... some photo data ...
 let handle = Task {
     return await add(newPhoto, toGalleryNamed: "Spring Adventures")
@@ -840,7 +840,7 @@ When you access a property or method of an actor,
 you use `await` to mark the potential suspension point.
 For example:
 
-```
+```swift
 let logger = TemperatureLogger(label: "Outdoors", measurement: 25)
 print(await logger.max)
 // Prints "25"
@@ -858,7 +858,7 @@ when accessing the actor's properties.
 For example,
 here's a method that updates a `TemperatureLogger` with a new temperature:
 
-```
+```swift
 extension TemperatureLogger {
     func update(with measurement: Int) {
         measurements.append(measurement)
@@ -906,7 +906,7 @@ like you would with an instance of a class,
 you'll get a compile-time error.
 For example:
 
-```
+```swift
 print(logger.max)  // Error
 ```
 


### PR DESCRIPTION
Did a quick check, and it looks like these were the only code listings missing their syntax highlighting.  Before:

```% cmark --to xml **.md | grep --only-matching '<code_block[^>]*>' | sort -u
<code_block info="swift" xml:space="preserve">
<code_block xml:space="preserve">
```

After:

```
% cmark --to xml **.md | grep --only-matching '<code_block[^>]*>' | sort -u
<code_block info="swift" xml:space="preserve">
```

Fixes rdar://103217537