### PR TITLE
Restore code voice for links to API symbols

### DIFF
--- a/Sources/TSPL/TSPL.docc/LanguageGuide/CollectionTypes.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/CollectionTypes.md
@@ -605,7 +605,7 @@ are also hashable by default.
 > by making them conform to the `Hashable` protocol
 > from the Swift standard library.
 > For information about implementing the required `hash(into:)` method,
-> see [Hashable](https://developer.apple.com/documentation/swift/hashable).
+> see [`Hashable`](https://developer.apple.com/documentation/swift/hashable).
 > For information about conforming to protocols, see <doc:Protocols>.
 
 ### Set Type Syntax

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Concurrency.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Concurrency.md
@@ -297,7 +297,7 @@ you'll get compile-time error instead of introducing a bug.
   and give you better guarantees and clearer errors
 -->
 
-> Note: The [Task.sleep(until:tolerance:clock:)](https://developer.apple.com/documentation/swift/task/sleep(until:tolerance:clock:)) method
+> Note: The [`Task.sleep(until:tolerance:clock:)`](https://developer.apple.com/documentation/swift/task/sleep(until:tolerance:clock:)) method
 > is useful when writing simple code
 > to learn how concurrency works.
 > This method does nothing,
@@ -388,10 +388,10 @@ when it's waiting for the next element to be available.
 -->
 
 In the same way that you can use your own types in a `for`-`in` loop
-by adding conformance to the [Sequence](https://developer.apple.com/documentation/swift/sequence) protocol,
+by adding conformance to the [`Sequence`](https://developer.apple.com/documentation/swift/sequence) protocol,
 you can use your own types in a `for`-`await`-`in` loop
 by adding conformance to the
-[AsyncSequence](https://developer.apple.com/documentation/swift/asyncsequence) protocol.
+[`AsyncSequence`](https://developer.apple.com/documentation/swift/asyncsequence) protocol.
 
 <!--
   TODO what happened to ``Series`` which was supposed to be a currency type?
@@ -571,7 +571,7 @@ await withTaskGroup(of: Data.self) { taskGroup in
 -->
 
 For more information about task groups,
-see [TaskGroup](https://developer.apple.com/documentation/swift/taskgroup).
+see [`TaskGroup`](https://developer.apple.com/documentation/swift/taskgroup).
 
 <!--
   OUTLINE
@@ -699,10 +699,10 @@ You have complete flexibility to manage unstructured tasks
 in whatever way your program needs,
 but you're also completely responsible for their correctness.
 To create an unstructured task that runs on the current actor,
-call the [Task.init(priority:operation:)](https://developer.apple.com/documentation/swift/task/3856790-init) initializer.
+call the [`Task.init(priority:operation:)`](https://developer.apple.com/documentation/swift/task/3856790-init) initializer.
 To create an unstructured task that's not part of the current actor,
 known more specifically as a *detached task*,
-call the [Task.detached(priority:operation:)](https://developer.apple.com/documentation/swift/task/3856786-detached) class method.
+call the [`Task.detached(priority:operation:)`](https://developer.apple.com/documentation/swift/task/3856786-detached) class method.
 Both of these operations return a task that you can interact with ---
 for example, to wait for its result or to cancel it.
 
@@ -715,7 +715,7 @@ let result = await handle.value
 ```
 
 For more information about managing detached tasks,
-see [Task](https://developer.apple.com/documentation/swift/task).
+see [`Task`](https://developer.apple.com/documentation/swift/task).
 
 <!--
   TODO Add some conceptual guidance about
@@ -738,16 +738,16 @@ that usually means one of the following:
 - Returning the partially completed work
 
 To check for cancellation,
-either call [Task.checkCancellation()](https://developer.apple.com/documentation/swift/task/3814826-checkcancellation),
+either call [`Task.checkCancellation()`](https://developer.apple.com/documentation/swift/task/3814826-checkcancellation),
 which throws `CancellationError` if the task has been canceled,
-or check the value of [Task.isCancelled](https://developer.apple.com/documentation/swift/task/3814832-iscancelled)
+or check the value of [`Task.isCancelled`](https://developer.apple.com/documentation/swift/task/3814832-iscancelled)
 and handle the cancellation in your own code.
 For example,
 a task that's downloading photos from a gallery
 might need to delete partial downloads and close network connections.
 
 To propagate cancellation manually,
-call [Task.cancel()](https://developer.apple.com/documentation/swift/task/3851218-cancel).
+call [`Task.cancel()`](https://developer.apple.com/documentation/swift/task/3851218-cancel).
 
 <!--
   OUTLINE
@@ -1040,7 +1040,7 @@ In general, there are three ways for a type to be sendable:
 -->
 
 For a detailed list of the semantic requirements,
-see the [Sendable](https://developer.apple.com/documentation/swift/sendable) protocol reference.
+see the [`Sendable`](https://developer.apple.com/documentation/swift/sendable) protocol reference.
 
 Some types are always sendable,
 like structures that have only sendable properties

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/ControlFlow.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/ControlFlow.md
@@ -274,7 +274,7 @@ The examples above use a `for`-`in` loop to iterate
 ranges, arrays, dictionaries, and strings.
 However, you can use this syntax to iterate *any* collection,
 including your own classes and collection types,
-as long as those types conform to the [Sequence](https://developer.apple.com/documentation/swift/sequence) protocol.
+as long as those types conform to the [`Sequence`](https://developer.apple.com/documentation/swift/sequence) protocol.
 
 <!--
   TODO: for (index, object) in enumerate(collection)

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/Enumerations.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/Enumerations.md
@@ -307,7 +307,7 @@ for beverage in Beverage.allCases {
 
 The syntax used in the examples above
 marks the enumeration as conforming to the
-[CaseIterable](https://developer.apple.com/documentation/swift/caseiterable) protocol.
+[`CaseIterable`](https://developer.apple.com/documentation/swift/caseiterable) protocol.
 For information about protocols, see <doc:Protocols>.
 
 ## Associated Values

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/StringsAndCharacters.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/StringsAndCharacters.md
@@ -1173,7 +1173,7 @@ welcome.removeSubrange(range)
 When you get a substring from a string ---
 for example, using a subscript or a method like `prefix(_:)` ---
 the result is an instance
-of [Substring](https://developer.apple.com/documentation/swift/substring),
+of [`Substring`](https://developer.apple.com/documentation/swift/substring),
 not another string.
 Substrings in Swift have most of the same methods as strings,
 which means you can work with substrings
@@ -1249,7 +1249,7 @@ The figure below shows these relationships:
 ![](stringSubstring)
 
 > Note: Both `String` and `Substring` conform to the
-> [StringProtocol](https://developer.apple.com/documentation/swift/stringprotocol) protocol,
+> [`StringProtocol`](https://developer.apple.com/documentation/swift/stringprotocol) protocol,
 > which means it's often convenient for string-manipulation functions
 > to accept a `StringProtocol` value.
 > You can call such functions with either a `String` or `Substring` value.

--- a/Sources/TSPL/TSPL.docc/LanguageGuide/TheBasics.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/TheBasics.md
@@ -1876,7 +1876,7 @@ without impacting performance in production.
 -->
 
 You write an assertion by calling the
-[assert(_:_:file:line:)](https://developer.apple.com/documentation/swift/1541112-assert) function
+[`assert(_:_:file:line:)`](https://developer.apple.com/documentation/swift/1541112-assert) function
 from the Swift standard library.
 You pass this function an expression that evaluates to `true` or `false`
 and a message to display if the result of the condition is `false`.
@@ -1934,7 +1934,7 @@ assert(age >= 0)
 
 If the code already checks the condition,
 you use the
-[assertionFailure(_:file:line:)](https://developer.apple.com/documentation/swift/1539616-assertionfailure) function
+[`assertionFailure(_:file:line:)`](https://developer.apple.com/documentation/swift/1539616-assertionfailure) function
 to indicate that an assertion has failed.
 For example:
 
@@ -1972,7 +1972,7 @@ For example, use a precondition to check that a subscript isn't out of bounds,
 or to check that a function has been passed a valid value.
 
 You write a precondition by calling the
-[precondition(_:_:file:line:)](https://developer.apple.com/documentation/swift/1540960-precondition) function.
+[`precondition(_:_:file:line:)`](https://developer.apple.com/documentation/swift/1540960-precondition) function.
 You pass this function an expression that evaluates to `true` or `false`
 and a message to display if the result of the condition is `false`.
 For example:
@@ -1994,7 +1994,7 @@ precondition(index > 0, "Index must be greater than zero.")
 -->
 
 You can also call the
-[preconditionFailure(_:file:line:)](https://developer.apple.com/documentation/swift/1539374-preconditionfailure) function
+[`preconditionFailure(_:file:line:)`](https://developer.apple.com/documentation/swift/1539374-preconditionfailure) function
 to indicate that a failure has occurred ---
 for example, if the default case of a switch was taken,
 but all valid input data should have been handled

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Attributes.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Attributes.md
@@ -326,7 +326,7 @@ dial.dynamicallyCall(withArguments: [4, 1, 1])
 
 The declaration of the `dynamicallyCall(withArguments:)` method
 must have a single parameter that conforms to the
-[ExpressibleByArrayLiteral](https://developer.apple.com/documentation/swift/expressiblebyarrayliteral)
+[`ExpressibleByArrayLiteral`](https://developer.apple.com/documentation/swift/expressiblebyarrayliteral)
 protocol---like `[Int]` in the example above.
 The return type can be any type.
 
@@ -381,13 +381,13 @@ print(repeatLabels(a: 1, b: 2, c: 3, b: 2, a: 1))
 
 The declaration of the `dynamicallyCall(withKeywordArguments:)` method
 must have a single parameter that conforms to the
-[ExpressibleByDictionaryLiteral](https://developer.apple.com/documentation/swift/expressiblebydictionaryliteral)
+[`ExpressibleByDictionaryLiteral`](https://developer.apple.com/documentation/swift/expressiblebydictionaryliteral)
 protocol,
 and the return type can be any type.
-The parameter's [Key](https://developer.apple.com/documentation/swift/expressiblebydictionaryliteral/2294108-key)
+The parameter's [`Key`](https://developer.apple.com/documentation/swift/expressiblebydictionaryliteral/2294108-key)
 must be
-[ExpressibleByStringLiteral](https://developer.apple.com/documentation/swift/expressiblebystringliteral).
-The previous example uses [KeyValuePairs](https://developer.apple.com/documentation/swift/keyvaluepairs)
+[`ExpressibleByStringLiteral`](https://developer.apple.com/documentation/swift/expressiblebystringliteral).
+The previous example uses [`KeyValuePairs`](https://developer.apple.com/documentation/swift/keyvaluepairs)
 as the parameter type
 so that callers can include duplicate parameter labels---
 `a` and `b` appear multiple times in the call to `repeat`.
@@ -447,11 +447,11 @@ the subscript that takes key path argument is used.
 
 An implementation of `subscript(dynamicMember:)`
 can accept key paths using an argument of type
-[KeyPath](https://developer.apple.com/documentation/swift/keypath),
-[WritableKeyPath](https://developer.apple.com/documentation/swift/writablekeypath),
-or [ReferenceWritableKeyPath](https://developer.apple.com/documentation/swift/referencewritablekeypath).
+[`KeyPath`](https://developer.apple.com/documentation/swift/keypath),
+[`WritableKeyPath`](https://developer.apple.com/documentation/swift/writablekeypath),
+or [`ReferenceWritableKeyPath`](https://developer.apple.com/documentation/swift/referencewritablekeypath).
 It can accept member names using an argument of a type that conforms to the
-[ExpressibleByStringLiteral](https://developer.apple.com/documentation/swift/expressiblebystringliteral) protocol ---
+[`ExpressibleByStringLiteral`](https://developer.apple.com/documentation/swift/expressiblebystringliteral) protocol ---
 in most cases, `String`.
 The subscript's return type can be any type.
 
@@ -1060,7 +1060,7 @@ For more information, see
 > can also change the runtime name for that declaration.
 > You use the runtime name when calling functions
 > that interact with the Objective-C runtime,
-> like [NSClassFromString](https://developer.apple.com/documentation/foundation/1395135-nsclassfromstring),
+> like [`NSClassFromString`](https://developer.apple.com/documentation/foundation/1395135-nsclassfromstring),
 > and when specifying class names in an app's Info.plist file.
 > If you specify a name by passing an argument,
 > that name is used as the name in Objective-C code
@@ -2034,7 +2034,7 @@ passing this class's name as the name of the delegate class.
 
 If you don't use this attribute,
 supply a `main.swift` file with code at the top level
-that calls the [UIApplicationMain(_:_:_:_:)](https://developer.apple.com/documentation/uikit/1622933-uiapplicationmain) function.
+that calls the [`UIApplicationMain(_:_:_:_:)`](https://developer.apple.com/documentation/uikit/1622933-uiapplicationmain) function.
 For example,
 if your app uses a custom subclass of `UIApplication`
 as its principal class,
@@ -2051,7 +2051,7 @@ Apply this attribute to a protocol type
 as part of a type declaration's list of adopted protocols
 to turn off enforcement of that protocol's requirements.
 
-The only supported protocol is [Sendable](https://developer.apple.com/documentation/swift/sendable).
+The only supported protocol is [`Sendable`](https://developer.apple.com/documentation/swift/sendable).
 
 ### usableFromInline
 
@@ -2106,9 +2106,9 @@ with the same name that are accessible from the same scope.
 
 For example,
 the Swift standard library includes both a top-level
-[min(_:_:)](https://developer.apple.com/documentation/swift/1538339-min/)
+[`min(_:_:)`](https://developer.apple.com/documentation/swift/1538339-min/)
 function and a
-[min()](https://developer.apple.com/documentation/swift/sequence/1641174-min)
+[`min()`](https://developer.apple.com/documentation/swift/sequence/1641174-min)
 method for sequences with comparable elements.
 The sequence method is declared with the `warn_unqualified_access` attribute
 to help reduce confusion
@@ -2202,7 +2202,7 @@ Apply this attribute to the type of a function
 to indicate that the function or closure is sendable.
 Applying this attribute to a function type
 has the same meaning as conforming a non–function type
-to the [Sendable](https://developer.apple.com/documentation/swift/sendable) protocol.
+to the [`Sendable`](https://developer.apple.com/documentation/swift/sendable) protocol.
 
 This attribute is inferred on functions and closures
 if the function or closure is used in a context

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Attributes.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Attributes.md
@@ -1060,7 +1060,7 @@ For more information, see
 > can also change the runtime name for that declaration.
 > You use the runtime name when calling functions
 > that interact with the Objective-C runtime,
-> like [`NSClassFromString`](https://developer.apple.com/documentation/foundation/1395135-nsclassfromstring),
+> like [`NSClassFromString(_:)`](https://developer.apple.com/documentation/foundation/1395135-nsclassfromstring),
 > and when specifying class names in an app's Info.plist file.
 > If you specify a name by passing an argument,
 > that name is used as the name in Objective-C code

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Expressions.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Expressions.md
@@ -1575,7 +1575,7 @@ in any order.
 
 At compile time, a key-path expression
 is replaced by an instance
-of the [KeyPath](https://developer.apple.com/documentation/swift/keypath) class.
+of the [`KeyPath`](https://developer.apple.com/documentation/swift/keypath) class.
 
 To access a value using a key path,
 pass the key path to the `subscript(keyPath:)` subscript,

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/LexicalStructure.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/LexicalStructure.md
@@ -929,7 +929,7 @@ have the same indentation requirements as regular multiline string literals.
 The default inferred type of a string literal is `String`.
 For more information about the `String` type,
 see <doc:StringsAndCharacters>
-and [String](https://developer.apple.com/documentation/swift/string).
+and [`String`](https://developer.apple.com/documentation/swift/string).
 
 String literals that are concatenated by the `+` operator
 are concatenated at compile time.

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Statements.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Statements.md
@@ -81,7 +81,7 @@ and a `continue` statement and is discussed in <doc:Statements#Break-Statement> 
 A `for`-`in` statement allows a block of code to be executed
 once for each item in a collection (or any type)
 that conforms to the
-[Sequence](https://developer.apple.com/documentation/swift/sequence) protocol.
+[`Sequence`](https://developer.apple.com/documentation/swift/sequence) protocol.
 
 A `for`-`in` statement has the following form:
 
@@ -94,7 +94,7 @@ for <#item#> in <#collection#> {
 The `makeIterator()` method is called on the *collection* expression
 to obtain a value of an iterator type---that is,
 a type that conforms to the
-[IteratorProtocol](https://developer.apple.com/documentation/swift/iteratorprotocol) protocol.
+[`IteratorProtocol`](https://developer.apple.com/documentation/swift/iteratorprotocol) protocol.
 The program begins executing a loop
 by calling the `next()` method on the iterator.
 If the value returned isn't `nil`,
@@ -458,7 +458,7 @@ added a new case to the enumeration
 that doesn't have a corresponding switch case.
 
 The following example switches over all three existing cases of
-the standard library's [Mirror.AncestorRepresentation](https://developer.apple.com/documentation/swift/mirror/ancestorrepresentation)
+the standard library's [`Mirror.AncestorRepresentation`](https://developer.apple.com/documentation/swift/mirror/ancestorrepresentation)
 enumeration.
 If you add additional cases in the future,
 the compiler generates a warning to indicate

--- a/Sources/TSPL/TSPL.docc/ReferenceManual/Types.md
+++ b/Sources/TSPL/TSPL.docc/ReferenceManual/Types.md
@@ -958,7 +958,7 @@ type(of: someInstance).printClassName()
 -->
 
 For more information,
-see [type(of:)](https://developer.apple.com/documentation/swift/2885064-type)
+see [`type(of:)`](https://developer.apple.com/documentation/swift/2885064-type)
 in the Swift standard library.
 
 Use an initializer expression to construct an instance of a type
@@ -1064,7 +1064,7 @@ which is defined by the language,
 `AnyObject` is defined by the Swift standard library.
 For more information, see
 <doc:Protocols#Class-Only-Protocols>
-and [AnyObject](https://developer.apple.com/documentation/swift/anyobject).
+and [`AnyObject`](https://developer.apple.com/documentation/swift/anyobject).
 
 > Grammar of an Any type:
 >
@@ -1183,7 +1183,7 @@ the `Self` type refers to the type
 introduced by the innermost type declaration.
 
 The `Self` type refers to the same type
-as the [type(of:)](https://developer.apple.com/documentation/swift/2885064-type)
+as the [`type(of:)`](https://developer.apple.com/documentation/swift/2885064-type)
 function in the Swift standard library.
 Writing `Self.someStaticMember` to access a member of the current type
 is the same as writing `type(of: self).someStaticMember`.


### PR DESCRIPTION
This was long during the RST export to markdown.  Found places to change by searching for "developer.apple.com/documentation" since all of the links are for standard library docs.  Verified that all API links have matching URLs by exporting a list of links from the current published version.

Fixes rdar://103197507