### PR TITLE
remove comma for correlative conjunction

### DIFF
--- a/Sources/TSPL/TSPL.docc/LanguageGuide/StringsAndCharacters.md
+++ b/Sources/TSPL/TSPL.docc/LanguageGuide/StringsAndCharacters.md
@@ -353,7 +353,7 @@ Here are three more double quotes: """
 
 To create an empty `String` value as the starting point
 for building a longer string,
-either assign an empty string literal to a variable,
+either assign an empty string literal to a variable
 or initialize a new `String` instance with initializer syntax:
 
 ```swift


### PR DESCRIPTION
Hello, I'm Bomi and learning a swift.
While studying, I found a sentence that would be better to modify so I suggest it.

I think the comma should be removed from this sentence so the conjunctions are not separated from each other.
Because `Either...or` is a correlative pair of conjunction.

I couldn't seen using commas in sentences of this chapter include correlative conjunction. I guess it would be better to change it for the uniformity.

Please review, Thanks! 💙