### PR TITLE
Correct the date for Swift 5.7 to FCS.

### DIFF
--- a/Sources/TSPL/TSPL.docc/RevisionHistory/RevisionHistory.md
+++ b/Sources/TSPL/TSPL.docc/RevisionHistory/RevisionHistory.md
@@ -2,7 +2,7 @@
 
 Review the recent changes to this book.
 
-**2022-06-06**
+**2022-09-12**
 
 - Updated for Swift 5.7.
 - Added the <doc:Concurrency#Sendable-Types> section,


### PR DESCRIPTION
We exported TSPL from RST to markdown after a beta of Swift 5.7 shipped, so the revision history at the time of export reflected the date when a prerelease version of TSPL shipped alongside that beta.  TSPL was published for Swift 5.7 FCS using the legacy RST version, where this date was updated after the markdown export.  This commit reflects the same change here, in the markdown version.