### PR TITLE
Redirect URLs from the legacy build system.

### DIFF
--- a/bin/publish-book
+++ b/bin/publish-book
@@ -28,13 +28,70 @@ set -eu
 # any changes to the content.
 export DOCC_JSON_PRETTYPRINT="YES"
 
+output="./swift-book"
+
+# Start at the top level directory of the repository.
+cd "$(git rev-parse --show-toplevel)"
+
 # The published version of the book gets the swift.org header.
 cp -n TSPL.docc/header-publish.html TSPL.docc/header.html
 
 docc convert \
     --experimental-enable-custom-templates \
     --hosting-base-path swift-book \
-    --output-path "./swift-book" \
+    --output-path "$output" \
     TSPL.docc
 
 rm TSPL.docc/header.html
+
+
+# Copy the redirect page into every location where the legacy RST-based
+# pipeline created an HTML page, to keep links to those chapters and
+# sections working.
+
+mkdir "$output"/GuidedTour
+mkdir "$output"/LanguageGuide
+mkdir "$output"/ReferenceManual
+mkdir "$output"/RevisionHistory
+
+cp bin/redirect.html "$output"/GuidedTour/Compatibility.html
+cp bin/redirect.html "$output"/GuidedTour/GuidedTour.html
+cp bin/redirect.html "$output"/LanguageGuide/AccessControl.html
+cp bin/redirect.html "$output"/LanguageGuide/AdvancedOperators.html
+cp bin/redirect.html "$output"/LanguageGuide/AutomaticReferenceCounting.html
+cp bin/redirect.html "$output"/LanguageGuide/BasicOperators.html
+cp bin/redirect.html "$output"/LanguageGuide/ClassesAndStructures.html
+cp bin/redirect.html "$output"/LanguageGuide/Closures.html
+cp bin/redirect.html "$output"/LanguageGuide/CollectionTypes.html
+cp bin/redirect.html "$output"/LanguageGuide/Concurrency.html
+cp bin/redirect.html "$output"/LanguageGuide/ControlFlow.html
+cp bin/redirect.html "$output"/LanguageGuide/Deinitialization.html
+cp bin/redirect.html "$output"/LanguageGuide/Enumerations.html
+cp bin/redirect.html "$output"/LanguageGuide/ErrorHandling.html
+cp bin/redirect.html "$output"/LanguageGuide/Extensions.html
+cp bin/redirect.html "$output"/LanguageGuide/Functions.html
+cp bin/redirect.html "$output"/LanguageGuide/Generics.html
+cp bin/redirect.html "$output"/LanguageGuide/Inheritance.html
+cp bin/redirect.html "$output"/LanguageGuide/Initialization.html
+cp bin/redirect.html "$output"/LanguageGuide/MemorySafety.html
+cp bin/redirect.html "$output"/LanguageGuide/Methods.html
+cp bin/redirect.html "$output"/LanguageGuide/NestedTypes.html
+cp bin/redirect.html "$output"/LanguageGuide/OpaqueTypes.html
+cp bin/redirect.html "$output"/LanguageGuide/OptionalChaining.html
+cp bin/redirect.html "$output"/LanguageGuide/Properties.html
+cp bin/redirect.html "$output"/LanguageGuide/Protocols.html
+cp bin/redirect.html "$output"/LanguageGuide/StringsAndCharacters.html
+cp bin/redirect.html "$output"/LanguageGuide/Subscripts.html
+cp bin/redirect.html "$output"/LanguageGuide/TheBasics.html
+cp bin/redirect.html "$output"/LanguageGuide/TypeCasting.html
+cp bin/redirect.html "$output"/ReferenceManual/AboutTheLanguageReference.html
+cp bin/redirect.html "$output"/ReferenceManual/Attributes.html
+cp bin/redirect.html "$output"/ReferenceManual/Declarations.html
+cp bin/redirect.html "$output"/ReferenceManual/Expressions.html
+cp bin/redirect.html "$output"/ReferenceManual/GenericParametersAndArguments.html
+cp bin/redirect.html "$output"/ReferenceManual/LexicalStructure.html
+cp bin/redirect.html "$output"/ReferenceManual/Patterns.html
+cp bin/redirect.html "$output"/ReferenceManual/Statements.html
+cp bin/redirect.html "$output"/ReferenceManual/Types.html
+cp bin/redirect.html "$output"/ReferenceManual/zzSummaryOfTheGrammar.html
+cp bin/redirect.html "$output"/RevisionHistory/RevisionHistory.html

--- a/bin/publish-book
+++ b/bin/publish-book
@@ -45,53 +45,7 @@ docc convert \
 rm TSPL.docc/header.html
 
 
-# Copy the redirect page into every location where the legacy RST-based
+# Copy the redirect pages into every location where the legacy RST-based
 # pipeline created an HTML page, to keep links to those chapters and
 # sections working.
-
-mkdir "$output"/GuidedTour
-mkdir "$output"/LanguageGuide
-mkdir "$output"/ReferenceManual
-mkdir "$output"/RevisionHistory
-
-cp bin/redirect.html "$output"/GuidedTour/Compatibility.html
-cp bin/redirect.html "$output"/GuidedTour/GuidedTour.html
-cp bin/redirect.html "$output"/LanguageGuide/AccessControl.html
-cp bin/redirect.html "$output"/LanguageGuide/AdvancedOperators.html
-cp bin/redirect.html "$output"/LanguageGuide/AutomaticReferenceCounting.html
-cp bin/redirect.html "$output"/LanguageGuide/BasicOperators.html
-cp bin/redirect.html "$output"/LanguageGuide/ClassesAndStructures.html
-cp bin/redirect.html "$output"/LanguageGuide/Closures.html
-cp bin/redirect.html "$output"/LanguageGuide/CollectionTypes.html
-cp bin/redirect.html "$output"/LanguageGuide/Concurrency.html
-cp bin/redirect.html "$output"/LanguageGuide/ControlFlow.html
-cp bin/redirect.html "$output"/LanguageGuide/Deinitialization.html
-cp bin/redirect.html "$output"/LanguageGuide/Enumerations.html
-cp bin/redirect.html "$output"/LanguageGuide/ErrorHandling.html
-cp bin/redirect.html "$output"/LanguageGuide/Extensions.html
-cp bin/redirect.html "$output"/LanguageGuide/Functions.html
-cp bin/redirect.html "$output"/LanguageGuide/Generics.html
-cp bin/redirect.html "$output"/LanguageGuide/Inheritance.html
-cp bin/redirect.html "$output"/LanguageGuide/Initialization.html
-cp bin/redirect.html "$output"/LanguageGuide/MemorySafety.html
-cp bin/redirect.html "$output"/LanguageGuide/Methods.html
-cp bin/redirect.html "$output"/LanguageGuide/NestedTypes.html
-cp bin/redirect.html "$output"/LanguageGuide/OpaqueTypes.html
-cp bin/redirect.html "$output"/LanguageGuide/OptionalChaining.html
-cp bin/redirect.html "$output"/LanguageGuide/Properties.html
-cp bin/redirect.html "$output"/LanguageGuide/Protocols.html
-cp bin/redirect.html "$output"/LanguageGuide/StringsAndCharacters.html
-cp bin/redirect.html "$output"/LanguageGuide/Subscripts.html
-cp bin/redirect.html "$output"/LanguageGuide/TheBasics.html
-cp bin/redirect.html "$output"/LanguageGuide/TypeCasting.html
-cp bin/redirect.html "$output"/ReferenceManual/AboutTheLanguageReference.html
-cp bin/redirect.html "$output"/ReferenceManual/Attributes.html
-cp bin/redirect.html "$output"/ReferenceManual/Declarations.html
-cp bin/redirect.html "$output"/ReferenceManual/Expressions.html
-cp bin/redirect.html "$output"/ReferenceManual/GenericParametersAndArguments.html
-cp bin/redirect.html "$output"/ReferenceManual/LexicalStructure.html
-cp bin/redirect.html "$output"/ReferenceManual/Patterns.html
-cp bin/redirect.html "$output"/ReferenceManual/Statements.html
-cp bin/redirect.html "$output"/ReferenceManual/Types.html
-cp bin/redirect.html "$output"/ReferenceManual/zzSummaryOfTheGrammar.html
-cp bin/redirect.html "$output"/RevisionHistory/RevisionHistory.html
+cp -r bin/redirects/* "$output"

--- a/bin/redirect.html
+++ b/bin/redirect.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/GuidedTour/Compatibility.html
+++ b/bin/redirects/GuidedTour/Compatibility.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/compatibility">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/GuidedTour/GuidedTour.html
+++ b/bin/redirects/GuidedTour/GuidedTour.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/guidedtour">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/LanguageGuide/AccessControl.html
+++ b/bin/redirects/LanguageGuide/AccessControl.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/accesscontrol">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/LanguageGuide/AdvancedOperators.html
+++ b/bin/redirects/LanguageGuide/AdvancedOperators.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/advancedoperators">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/LanguageGuide/AutomaticReferenceCounting.html
+++ b/bin/redirects/LanguageGuide/AutomaticReferenceCounting.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/automaticreferencecounting">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/LanguageGuide/BasicOperators.html
+++ b/bin/redirects/LanguageGuide/BasicOperators.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/basicoperators">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/LanguageGuide/ClassesAndStructures.html
+++ b/bin/redirects/LanguageGuide/ClassesAndStructures.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/classesandstructures">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/LanguageGuide/Closures.html
+++ b/bin/redirects/LanguageGuide/Closures.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/closures">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/LanguageGuide/CollectionTypes.html
+++ b/bin/redirects/LanguageGuide/CollectionTypes.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/collectiontypes">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/LanguageGuide/Concurrency.html
+++ b/bin/redirects/LanguageGuide/Concurrency.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/concurrency">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/LanguageGuide/ControlFlow.html
+++ b/bin/redirects/LanguageGuide/ControlFlow.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/controlflow">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/LanguageGuide/Deinitialization.html
+++ b/bin/redirects/LanguageGuide/Deinitialization.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/deinitialization">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/LanguageGuide/Enumerations.html
+++ b/bin/redirects/LanguageGuide/Enumerations.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/enumerations">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/LanguageGuide/ErrorHandling.html
+++ b/bin/redirects/LanguageGuide/ErrorHandling.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/errorhandling">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/LanguageGuide/Extensions.html
+++ b/bin/redirects/LanguageGuide/Extensions.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/extensions">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/LanguageGuide/Functions.html
+++ b/bin/redirects/LanguageGuide/Functions.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/functions">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/LanguageGuide/Generics.html
+++ b/bin/redirects/LanguageGuide/Generics.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/generics">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/LanguageGuide/Inheritance.html
+++ b/bin/redirects/LanguageGuide/Inheritance.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/inheritance">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/LanguageGuide/Initialization.html
+++ b/bin/redirects/LanguageGuide/Initialization.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/initialization">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/LanguageGuide/MemorySafety.html
+++ b/bin/redirects/LanguageGuide/MemorySafety.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/memorysafety">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/LanguageGuide/Methods.html
+++ b/bin/redirects/LanguageGuide/Methods.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/methods">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/LanguageGuide/NestedTypes.html
+++ b/bin/redirects/LanguageGuide/NestedTypes.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/nestedtypes">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/LanguageGuide/OpaqueTypes.html
+++ b/bin/redirects/LanguageGuide/OpaqueTypes.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/opaquetypes">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/LanguageGuide/OptionalChaining.html
+++ b/bin/redirects/LanguageGuide/OptionalChaining.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/optionalchaining">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/LanguageGuide/Properties.html
+++ b/bin/redirects/LanguageGuide/Properties.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/properties">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/LanguageGuide/Protocols.html
+++ b/bin/redirects/LanguageGuide/Protocols.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/protocols">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/LanguageGuide/StringsAndCharacters.html
+++ b/bin/redirects/LanguageGuide/StringsAndCharacters.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/stringsandcharacters">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/LanguageGuide/Subscripts.html
+++ b/bin/redirects/LanguageGuide/Subscripts.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/subscripts">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/LanguageGuide/TheBasics.html
+++ b/bin/redirects/LanguageGuide/TheBasics.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/thebasics">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/LanguageGuide/TypeCasting.html
+++ b/bin/redirects/LanguageGuide/TypeCasting.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/typecasting">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/ReferenceManual/AboutTheLanguageReference.html
+++ b/bin/redirects/ReferenceManual/AboutTheLanguageReference.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/aboutthelanguagereference">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/ReferenceManual/Attributes.html
+++ b/bin/redirects/ReferenceManual/Attributes.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/attributes">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/ReferenceManual/Declarations.html
+++ b/bin/redirects/ReferenceManual/Declarations.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/declarations">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/ReferenceManual/Expressions.html
+++ b/bin/redirects/ReferenceManual/Expressions.html
@@ -1,7 +1,7 @@
 <html>
 <head>
     <title>The Swift Programming Language: Redirect</title>
-    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/">
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/expressions">
 <head>
 <body>
 <div>

--- a/bin/redirects/ReferenceManual/GenericParametersAndArguments.html
+++ b/bin/redirects/ReferenceManual/GenericParametersAndArguments.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/genericparametersandarguments">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/ReferenceManual/LexicalStructure.html
+++ b/bin/redirects/ReferenceManual/LexicalStructure.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/lexicalstructure">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/ReferenceManual/Patterns.html
+++ b/bin/redirects/ReferenceManual/Patterns.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/patterns">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/ReferenceManual/Statements.html
+++ b/bin/redirects/ReferenceManual/Statements.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/statements">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/ReferenceManual/Types.html
+++ b/bin/redirects/ReferenceManual/Types.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/types">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/ReferenceManual/zzSummaryOfTheGrammar.html
+++ b/bin/redirects/ReferenceManual/zzSummaryOfTheGrammar.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/summaryofthegrammar">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/RevisionHistory/RevisionHistory.html
+++ b/bin/redirects/RevisionHistory/RevisionHistory.html
@@ -1,0 +1,98 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/revisionhistory">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+const headingRedirects = {
+    "#ID461": "guidedtour#Simple-Values",
+    "#ID462": "guidedtour#Control-Flow",
+    "#ID463": "guidedtour#Functions-and-Closures",
+}
+
+const chapterRedirects = {
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/AboutSwift.html": "aboutswift",
+    "GuidedTour/Compatibility.html": "compatibility",
+    "GuidedTour/GuidedTour.html": "guidedtour",
+    "GuidedTour/GuidedTourPart.html": "guidedtour",
+
+    "LanguageGuide/AccessControl.html": "accesscontrol",
+    "LanguageGuide/AdvancedOperators.html": "advancedoperators",
+    "LanguageGuide/AutomaticReferenceCounting.html": "automaticreferencecounting",
+    "LanguageGuide/BasicOperators.html": "basicoperators",
+    "LanguageGuide/ClassesAndStructures.html": "classesandstructures",
+    "LanguageGuide/Closures.html": "closures",
+    "LanguageGuide/CollectionTypes.html": "collectiontypes",
+    "LanguageGuide/Concurrency.html": "concurrency",
+    "LanguageGuide/ControlFlow.html": "controlflow",
+    "LanguageGuide/Deinitialization.html": "deinitialization",
+    "LanguageGuide/Enumerations.html": "enumerations",
+    "LanguageGuide/ErrorHandling.html": "errorhandling",
+    "LanguageGuide/Extensions.html": "extensions",
+    "LanguageGuide/Functions.html": "functions",
+    "LanguageGuide/Generics.html": "generics",
+    "LanguageGuide/Inheritance.html": "inheritance",
+    "LanguageGuide/Initialization.html": "initialization",
+    "LanguageGuide/LanguageGuidePart.html": "languageguide",
+    "LanguageGuide/MemorySafety.html": "memorysafety",
+    "LanguageGuide/Methods.html": "methods",
+    "LanguageGuide/NestedTypes.html": "nestedtypes",
+    "LanguageGuide/OpaqueTypes.html": "opaquetypes",
+    "LanguageGuide/OptionalChaining.html": "optionalchaining",
+    "LanguageGuide/Properties.html": "properties",
+    "LanguageGuide/Protocols.html": "protocols",
+    "LanguageGuide/StringsAndCharacters.html": "stringsandcharacters",
+    "LanguageGuide/Subscripts.html": "subscripts",
+    "LanguageGuide/TheBasics.html": "thebasics",
+    "LanguageGuide/TypeCasting.html": "typecasting",
+
+    "ReferenceManual/AboutTheLanguageReference.html": "aboutthelanguagereference",
+    "ReferenceManual/Attributes.html": "attributes",
+    "ReferenceManual/Declarations.html": "declarations",
+    "ReferenceManual/Expressions.html": "expressions",
+    "ReferenceManual/GenericParametersAndArguments.html": "genericparametersandarguments",
+    "ReferenceManual/LexicalStructure.html": "lexicalstructure",
+    "ReferenceManual/Patterns.html": "patterns",
+    "ReferenceManual/ReferenceManualPart.html": "referencemanual",
+    "ReferenceManual/Statements.html": "statements",
+    "ReferenceManual/Types.html": "types",
+    "ReferenceManual/zzSummaryOfTheGrammar.html": "summaryofthegrammar",
+
+    "RevisionHistory/RevisionHistory.html": "revisionhistory",
+    "RevisionHistory/RevisionHistoryPart.html": "revisionhistory",
+}
+
+const path = window.location.pathname;
+const hash = window.location.hash;
+
+var newURL = baseURL;
+if (hash == "") {
+    const components = path.split("/");
+    const part = components[components.length - 2];
+    const chapter = components[components.length - 1];
+    const redirectPath = chapterRedirects[part + "/" + chapter];
+    newURL += redirectPath;
+} else {
+    const redirectPath = headingRedirects[hash];
+    newURL += redirectPath;
+}
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>


### PR DESCRIPTION
Add a build step that copies a redirect page to each path where the legacy build system created content.  This initial redirect page has JavaScript that handles links to chapters.  It also handles a few sections, which serve as a proof of concept, and which can be filled in with the remaining ~600 section identifiers.

Fixes: rdar://96321914