### PR TITLE
Check that heading redirects exist in the remapping dictionary.

### DIFF
--- a/bin/redirects/GuidedTour/Compatibility.html
+++ b/bin/redirects/GuidedTour/Compatibility.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/GuidedTour/GuidedTour.html
+++ b/bin/redirects/GuidedTour/GuidedTour.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/LanguageGuide/AccessControl.html
+++ b/bin/redirects/LanguageGuide/AccessControl.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/LanguageGuide/AdvancedOperators.html
+++ b/bin/redirects/LanguageGuide/AdvancedOperators.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/LanguageGuide/AutomaticReferenceCounting.html
+++ b/bin/redirects/LanguageGuide/AutomaticReferenceCounting.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/LanguageGuide/BasicOperators.html
+++ b/bin/redirects/LanguageGuide/BasicOperators.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/LanguageGuide/ClassesAndStructures.html
+++ b/bin/redirects/LanguageGuide/ClassesAndStructures.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/LanguageGuide/Closures.html
+++ b/bin/redirects/LanguageGuide/Closures.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/LanguageGuide/CollectionTypes.html
+++ b/bin/redirects/LanguageGuide/CollectionTypes.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/LanguageGuide/Concurrency.html
+++ b/bin/redirects/LanguageGuide/Concurrency.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/LanguageGuide/ControlFlow.html
+++ b/bin/redirects/LanguageGuide/ControlFlow.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/LanguageGuide/Deinitialization.html
+++ b/bin/redirects/LanguageGuide/Deinitialization.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/LanguageGuide/Enumerations.html
+++ b/bin/redirects/LanguageGuide/Enumerations.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/LanguageGuide/ErrorHandling.html
+++ b/bin/redirects/LanguageGuide/ErrorHandling.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/LanguageGuide/Extensions.html
+++ b/bin/redirects/LanguageGuide/Extensions.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/LanguageGuide/Functions.html
+++ b/bin/redirects/LanguageGuide/Functions.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/LanguageGuide/Generics.html
+++ b/bin/redirects/LanguageGuide/Generics.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/LanguageGuide/Inheritance.html
+++ b/bin/redirects/LanguageGuide/Inheritance.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/LanguageGuide/Initialization.html
+++ b/bin/redirects/LanguageGuide/Initialization.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/LanguageGuide/MemorySafety.html
+++ b/bin/redirects/LanguageGuide/MemorySafety.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/LanguageGuide/Methods.html
+++ b/bin/redirects/LanguageGuide/Methods.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/LanguageGuide/NestedTypes.html
+++ b/bin/redirects/LanguageGuide/NestedTypes.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/LanguageGuide/OpaqueTypes.html
+++ b/bin/redirects/LanguageGuide/OpaqueTypes.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/LanguageGuide/OptionalChaining.html
+++ b/bin/redirects/LanguageGuide/OptionalChaining.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/LanguageGuide/Properties.html
+++ b/bin/redirects/LanguageGuide/Properties.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/LanguageGuide/Protocols.html
+++ b/bin/redirects/LanguageGuide/Protocols.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/LanguageGuide/StringsAndCharacters.html
+++ b/bin/redirects/LanguageGuide/StringsAndCharacters.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/LanguageGuide/Subscripts.html
+++ b/bin/redirects/LanguageGuide/Subscripts.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/LanguageGuide/TheBasics.html
+++ b/bin/redirects/LanguageGuide/TheBasics.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/LanguageGuide/TypeCasting.html
+++ b/bin/redirects/LanguageGuide/TypeCasting.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/ReferenceManual/AboutTheLanguageReference.html
+++ b/bin/redirects/ReferenceManual/AboutTheLanguageReference.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/ReferenceManual/Attributes.html
+++ b/bin/redirects/ReferenceManual/Attributes.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/ReferenceManual/Declarations.html
+++ b/bin/redirects/ReferenceManual/Declarations.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/ReferenceManual/Expressions.html
+++ b/bin/redirects/ReferenceManual/Expressions.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/ReferenceManual/GenericParametersAndArguments.html
+++ b/bin/redirects/ReferenceManual/GenericParametersAndArguments.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/ReferenceManual/LexicalStructure.html
+++ b/bin/redirects/ReferenceManual/LexicalStructure.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/ReferenceManual/Patterns.html
+++ b/bin/redirects/ReferenceManual/Patterns.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/ReferenceManual/Statements.html
+++ b/bin/redirects/ReferenceManual/Statements.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/ReferenceManual/Types.html
+++ b/bin/redirects/ReferenceManual/Types.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/ReferenceManual/zzSummaryOfTheGrammar.html
+++ b/bin/redirects/ReferenceManual/zzSummaryOfTheGrammar.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);

--- a/bin/redirects/RevisionHistory/RevisionHistory.html
+++ b/bin/redirects/RevisionHistory/RevisionHistory.html
@@ -84,11 +84,15 @@ if (hash == "") {
     const components = path.split("/");
     const part = components[components.length - 2];
     const chapter = components[components.length - 1];
-    const redirectPath = chapterRedirects[part + "/" + chapter];
-    newURL += redirectPath;
+    const newPath = part + "/" + chapter;
+    if (newPath in chapterRedirects) {
+        newURL += chapterRedirects[part + "/" + chapter];
+    }
 } else {
-    const redirectPath = headingRedirects[hash];
-    newURL += redirectPath;
+    if (hash in headingRedirects) {
+        const redirectPath = headingRedirects[hash];
+        newURL += redirectPath;
+    }
 }
 
 document.getElementById("redirect").setAttribute("href", newURL);


### PR DESCRIPTION
Fixes an issues with redirects from the legacy publishing pipeline where redirects from anchors that our mapping doesn't know about would result in redirects to URLs that contained an `undefined` path.

E.g.: 

`https://docs.swift.org/swift-book/ReferenceManual/Declarations.html#ID622` would redirect to `https://docs.swift.org/swift-book/documentation/the-swift-programming-language/undefined`. 

This fix checks the dictionary of mappings we know about before appending anything to the redirect URL.