### PR TITLE
Match forum link in README and CONTRIBUTING

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ For more information, see [Contributing to The Swift Programming Language][contr
 [bugs]: https://github.com/apple/swift-book/issues
 [conduct]: https://www.swift.org/code-of-conduct
 [contributing]: /CONTRIBUTING.md
-[forum]: https://forums.swift.org/c/development/swift-docc/80
+[forum]: https://forums.swift.org/c/swift-documentation/92
 [tspl-style]: /Style.md
 
 ## Building


### PR DESCRIPTION
In the future, as part of formalizing the contribution process, we might end up with a separate forum category for these pitches — for now, they've been happening in the Swift Documentation category.