### PR TITLE
Ignore RST-to-markdown commit when blaming

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -4,11 +4,11 @@
 #
 # To use this file for a single blame operation,
 #
-#   git blame --ignore-revs-file .git_ignored_revs <somefile>
+#   git blame --ignore-revs-file .git-blame-ignore-revs <somefile>
 #
 # To use this file for all blame operations, run the following command:
 #
-#   git config --local blame.ignoredRevsFile .git_ignored_revs
+#   git config --local blame.ignoredRevsFile .git-blame-ignore-revs
 #
 # For more information, see the git-blame(1) man page's discussion of
 # the --ignore-revs-file option, and the git-config(1) man page's

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -8,7 +8,7 @@
 #
 # To use this file for all blame operations, run the following command:
 #
-#   git config --local blame.ignoredRevsFile .git-blame-ignore-revs
+#   git config --local blame.ignoreRevsFile .git-blame-ignore-revs
 #
 # For more information, see the git-blame(1) man page's discussion of
 # the --ignore-revs-file option, and the git-config(1) man page's

--- a/.git_ignored_revs
+++ b/.git_ignored_revs
@@ -1,0 +1,2 @@
+# Convert RST to markdown.
+96f0925407c6bd9eadd9d58d253bad3e1ef7a9f2

--- a/.git_ignored_revs
+++ b/.git_ignored_revs
@@ -1,2 +1,18 @@
+# This file is a list of commits that made uninteresting formatting
+# changes, which should be ignored by git-blame, so that it can instead
+# display more the relevant history and attribution information.
+#
+# To use this file for a single blame operation,
+#
+#   git blame --ignore-revs-file .git_ignored_revs <somefile>
+#
+# To use this file for all blame operations, run the following command:
+#
+#   git config --local blame.ignoredRevsFile .git_ignored_revs
+#
+# For more information, see the git-blame(1) man page's discussion of
+# the --ignore-revs-file option, and the git-config(1) man page's
+# discussion of the blame.ignoreRevsFile option.
+
 # Convert RST to markdown.
 96f0925407c6bd9eadd9d58d253bad3e1ef7a9f2


### PR DESCRIPTION
For comparison, here are links to the tour's blame view with and without this setting.

Without: https://github.com/apple/swift-book/blame/main/TSPL.docc/GuidedTour/GuidedTour.md

With: https://github.com/amartini51/swift-book/blame/ignored_revs/Sources/TSPL/TSPL.docc/GuidedTour/GuidedTour.md

Without this setting, almost half of the lines of the tour are attributed to commit 96f092540, the RST-to-markdown conversion.  With it, we get much more useful blame information:

```
% git blame GuidedTour.md | cut -d' ' -f 1 | sort | uniq -c | sort -n | tail
   8 a79e857ab
  10 c3e2f1463
  10 dfde955ed
  10 fe966592c
  11 41be57f94
  13 ee49b93bc
  15 cee94fdde
  30 940f17d35
 174 8e84be0fc
1770 96f092540

% git blame --ignore-revs-file .git-blame-ignore-revs GuidedTour.md | cut -d' ' -f 1 | sort | uniq -c | sort -n | tail
  34 ?0b8780e1
  36 ?91f5caa3
  37 ?8a84bcd0
  41 ?4df08a42
  56 ?1ead879d
  63 ?a6b8b6dd
  72 ?63fd3c59
 112 ?e3db956b
 174 8e84be0fc
 603 96f092540
```