### PR TITLE
Discuss 'defer' in the guide, outside of error handling

### DIFF
--- a/TSPL.docc/LanguageGuide/ControlFlow.md
+++ b/TSPL.docc/LanguageGuide/ControlFlow.md
@@ -1854,14 +1854,14 @@ if score < 10 {
   - test: `defer-with-if`
 
   ```swifttest
-  -> var score = 3
+  -> var score = 1
   -> if score < 10 {
   ->     defer {
   ->         print(score)
   ->     }
   ->     score += 5
   -> }
-  <- 8
+  <- 6
   ```
 -->
 
@@ -1948,7 +1948,7 @@ if score < 10 {
   ->     }
   ->     score += 5
   -> }
-  <- 8
+  <- 6
   ```
 -->
 


### PR DESCRIPTION
The corresponding discussion in the reference was updated in https://github.com/apple/swift-book/pull/30.

Fixes rdar://34173603
