### PR TITLE
Manually put the beta banner back

### DIFF
--- a/TSPL.docc/GuidedTour/AboutSwift.md
+++ b/TSPL.docc/GuidedTour/AboutSwift.md
@@ -48,6 +48,12 @@ and it continues to evolve with new features and capabilities.
 Our goals for Swift are ambitious.
 We can’t wait to see what you create with it.
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/GuidedTour/AboutSwift.md
+++ b/TSPL.docc/GuidedTour/AboutSwift.md
@@ -52,7 +52,7 @@ We can’t wait to see what you create with it.
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/GuidedTour/AboutSwift.md
+++ b/TSPL.docc/GuidedTour/AboutSwift.md
@@ -48,7 +48,7 @@ and it continues to evolve with new features and capabilities.
 Our goals for Swift are ambitious.
 We can’t wait to see what you create with it.
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/GuidedTour/Compatibility.md
+++ b/TSPL.docc/GuidedTour/Compatibility.md
@@ -49,7 +49,7 @@ that's divided into multiple frameworks,
 you can migrate your code from Swift 4 to Swift 5.8
 one framework at a time.
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/GuidedTour/Compatibility.md
+++ b/TSPL.docc/GuidedTour/Compatibility.md
@@ -53,7 +53,7 @@ one framework at a time.
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/GuidedTour/Compatibility.md
+++ b/TSPL.docc/GuidedTour/Compatibility.md
@@ -49,6 +49,12 @@ that's divided into multiple frameworks,
 you can migrate your code from Swift 4 to Swift 5.8
 one framework at a time.
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/GuidedTour/GuidedTour.md
+++ b/TSPL.docc/GuidedTour/GuidedTour.md
@@ -2361,7 +2361,7 @@ is the same as writing `<T> ... where T: Equatable`.
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/GuidedTour/GuidedTour.md
+++ b/TSPL.docc/GuidedTour/GuidedTour.md
@@ -2357,6 +2357,12 @@ anyCommonElements([1, 2, 3], [3])
 Writing `<T: Equatable>`
 is the same as writing `<T> ... where T: Equatable`.
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/GuidedTour/GuidedTour.md
+++ b/TSPL.docc/GuidedTour/GuidedTour.md
@@ -2357,7 +2357,7 @@ anyCommonElements([1, 2, 3], [3])
 Writing `<T: Equatable>`
 is the same as writing `<T> ... where T: Equatable`.
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/LanguageGuide/AccessControl.md
+++ b/TSPL.docc/LanguageGuide/AccessControl.md
@@ -1483,6 +1483,12 @@ but a public type alias can't alias an internal, file-private, or private type.
   ```
 -->
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/AccessControl.md
+++ b/TSPL.docc/LanguageGuide/AccessControl.md
@@ -1487,7 +1487,7 @@ but a public type alias can't alias an internal, file-private, or private type.
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/LanguageGuide/AccessControl.md
+++ b/TSPL.docc/LanguageGuide/AccessControl.md
@@ -1483,7 +1483,7 @@ but a public type alias can't alias an internal, file-private, or private type.
   ```
 -->
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/LanguageGuide/AdvancedOperators.md
+++ b/TSPL.docc/LanguageGuide/AdvancedOperators.md
@@ -1561,7 +1561,7 @@ see <doc:Attributes#resultBuilder>.
   TODO: generic operators
 -->
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/LanguageGuide/AdvancedOperators.md
+++ b/TSPL.docc/LanguageGuide/AdvancedOperators.md
@@ -1565,7 +1565,7 @@ see <doc:Attributes#resultBuilder>.
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/LanguageGuide/AdvancedOperators.md
+++ b/TSPL.docc/LanguageGuide/AdvancedOperators.md
@@ -1561,6 +1561,12 @@ see <doc:Attributes#resultBuilder>.
   TODO: generic operators
 -->
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/AutomaticReferenceCounting.md
+++ b/TSPL.docc/LanguageGuide/AutomaticReferenceCounting.md
@@ -1512,7 +1512,7 @@ paragraph = nil
 For more information about capture lists,
 see <doc:Expressions#Capture-Lists>.
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/LanguageGuide/AutomaticReferenceCounting.md
+++ b/TSPL.docc/LanguageGuide/AutomaticReferenceCounting.md
@@ -1512,6 +1512,12 @@ paragraph = nil
 For more information about capture lists,
 see <doc:Expressions#Capture-Lists>.
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/AutomaticReferenceCounting.md
+++ b/TSPL.docc/LanguageGuide/AutomaticReferenceCounting.md
@@ -1516,7 +1516,7 @@ see <doc:Expressions#Capture-Lists>.
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/LanguageGuide/BasicOperators.md
+++ b/TSPL.docc/LanguageGuide/BasicOperators.md
@@ -1235,7 +1235,7 @@ use parentheses where they help to make your intentions clear.
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/LanguageGuide/BasicOperators.md
+++ b/TSPL.docc/LanguageGuide/BasicOperators.md
@@ -1231,6 +1231,12 @@ but the overall intention is clearer to the reader.
 Readability is always preferred over brevity;
 use parentheses where they help to make your intentions clear.
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/BasicOperators.md
+++ b/TSPL.docc/LanguageGuide/BasicOperators.md
@@ -1231,7 +1231,7 @@ but the overall intention is clearer to the reader.
 Readability is always preferred over brevity;
 use parentheses where they help to make your intentions clear.
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/LanguageGuide/ClassesAndStructures.md
+++ b/TSPL.docc/LanguageGuide/ClassesAndStructures.md
@@ -714,7 +714,7 @@ see [Manual Memory Management](https://developer.apple.com/documentation/swift/s
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/LanguageGuide/ClassesAndStructures.md
+++ b/TSPL.docc/LanguageGuide/ClassesAndStructures.md
@@ -710,7 +710,7 @@ see [Manual Memory Management](https://developer.apple.com/documentation/swift/s
   QUESTION: what's the deal with tuples and reference types / value types?
 -->
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/LanguageGuide/ClassesAndStructures.md
+++ b/TSPL.docc/LanguageGuide/ClassesAndStructures.md
@@ -710,6 +710,12 @@ see [Manual Memory Management](https://developer.apple.com/documentation/swift/s
   QUESTION: what's the deal with tuples and reference types / value types?
 -->
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/Closures.md
+++ b/TSPL.docc/LanguageGuide/Closures.md
@@ -1332,6 +1332,12 @@ As a result,
 the value of the `customerProvider` argument
 must be allowed to escape the function's scope.
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/Closures.md
+++ b/TSPL.docc/LanguageGuide/Closures.md
@@ -1336,7 +1336,7 @@ must be allowed to escape the function's scope.
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/LanguageGuide/Closures.md
+++ b/TSPL.docc/LanguageGuide/Closures.md
@@ -1332,7 +1332,7 @@ As a result,
 the value of the `customerProvider` argument
 must be allowed to escape the function's scope.
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/LanguageGuide/CollectionTypes.md
+++ b/TSPL.docc/LanguageGuide/CollectionTypes.md
@@ -1473,7 +1473,7 @@ use the `sorted()` method on its `keys` or `values` property.
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/LanguageGuide/CollectionTypes.md
+++ b/TSPL.docc/LanguageGuide/CollectionTypes.md
@@ -1469,7 +1469,7 @@ Swift's `Dictionary` type doesn't have a defined ordering.
 To iterate over the keys or values of a dictionary in a specific order,
 use the `sorted()` method on its `keys` or `values` property.
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/LanguageGuide/CollectionTypes.md
+++ b/TSPL.docc/LanguageGuide/CollectionTypes.md
@@ -1469,6 +1469,12 @@ Swift's `Dictionary` type doesn't have a defined ordering.
 To iterate over the keys or values of a dictionary in a specific order,
 use the `sorted()` method on its `keys` or `values` property.
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/Concurrency.md
+++ b/TSPL.docc/LanguageGuide/Concurrency.md
@@ -1174,6 +1174,12 @@ struct TemperatureReading {
   but maybe link to them?
 -->
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/Concurrency.md
+++ b/TSPL.docc/LanguageGuide/Concurrency.md
@@ -1174,7 +1174,7 @@ struct TemperatureReading {
   but maybe link to them?
 -->
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/LanguageGuide/Concurrency.md
+++ b/TSPL.docc/LanguageGuide/Concurrency.md
@@ -1178,7 +1178,7 @@ struct TemperatureReading {
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/LanguageGuide/ControlFlow.md
+++ b/TSPL.docc/LanguageGuide/ControlFlow.md
@@ -1974,7 +1974,7 @@ when the check contains only fallback code.
   You can use it with if-let, and other Boolean conditions, using a comma
 -->
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/LanguageGuide/ControlFlow.md
+++ b/TSPL.docc/LanguageGuide/ControlFlow.md
@@ -1978,7 +1978,7 @@ when the check contains only fallback code.
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/LanguageGuide/ControlFlow.md
+++ b/TSPL.docc/LanguageGuide/ControlFlow.md
@@ -1974,6 +1974,12 @@ when the check contains only fallback code.
   You can use it with if-let, and other Boolean conditions, using a comma
 -->
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/Deinitialization.md
+++ b/TSPL.docc/LanguageGuide/Deinitialization.md
@@ -242,6 +242,12 @@ and so it's deallocated in order to free up its memory.
 Just before this happens, its deinitializer is called automatically,
 and its coins are returned to the bank.
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/Deinitialization.md
+++ b/TSPL.docc/LanguageGuide/Deinitialization.md
@@ -242,7 +242,7 @@ and so it's deallocated in order to free up its memory.
 Just before this happens, its deinitializer is called automatically,
 and its coins are returned to the bank.
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/LanguageGuide/Deinitialization.md
+++ b/TSPL.docc/LanguageGuide/Deinitialization.md
@@ -246,7 +246,7 @@ and its coins are returned to the bank.
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/LanguageGuide/Enumerations.md
+++ b/TSPL.docc/LanguageGuide/Enumerations.md
@@ -830,7 +830,7 @@ by evaluating the expression on the left-hand side,
 evaluating the expression on the right-hand side,
 and then adding them or multiplying them.
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/LanguageGuide/Enumerations.md
+++ b/TSPL.docc/LanguageGuide/Enumerations.md
@@ -830,6 +830,12 @@ by evaluating the expression on the left-hand side,
 evaluating the expression on the right-hand side,
 and then adding them or multiplying them.
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/Enumerations.md
+++ b/TSPL.docc/LanguageGuide/Enumerations.md
@@ -834,7 +834,7 @@ and then adding them or multiplying them.
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/LanguageGuide/ErrorHandling.md
+++ b/TSPL.docc/LanguageGuide/ErrorHandling.md
@@ -773,6 +773,12 @@ has a corresponding call to `close(_:)`.
 > Note: You can use a `defer` statement
 > even when no error handling code is involved.
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/ErrorHandling.md
+++ b/TSPL.docc/LanguageGuide/ErrorHandling.md
@@ -773,7 +773,7 @@ has a corresponding call to `close(_:)`.
 > Note: You can use a `defer` statement
 > even when no error handling code is involved.
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/LanguageGuide/ErrorHandling.md
+++ b/TSPL.docc/LanguageGuide/ErrorHandling.md
@@ -777,7 +777,7 @@ has a corresponding call to `close(_:)`.
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/LanguageGuide/Extensions.md
+++ b/TSPL.docc/LanguageGuide/Extensions.md
@@ -682,7 +682,7 @@ and prints an appropriate description.
 > can be written in shorthand form inside the `switch` statement,
 > such as `.negative` rather than `Int.Kind.negative`.
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/LanguageGuide/Extensions.md
+++ b/TSPL.docc/LanguageGuide/Extensions.md
@@ -682,6 +682,12 @@ and prints an appropriate description.
 > can be written in shorthand form inside the `switch` statement,
 > such as `.negative` rather than `Int.Kind.negative`.
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/Extensions.md
+++ b/TSPL.docc/LanguageGuide/Extensions.md
@@ -686,7 +686,7 @@ and prints an appropriate description.
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/LanguageGuide/Functions.md
+++ b/TSPL.docc/LanguageGuide/Functions.md
@@ -1299,6 +1299,12 @@ print("zero!")
   ```
 -->
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/Functions.md
+++ b/TSPL.docc/LanguageGuide/Functions.md
@@ -1303,7 +1303,7 @@ print("zero!")
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/LanguageGuide/Functions.md
+++ b/TSPL.docc/LanguageGuide/Functions.md
@@ -1299,7 +1299,7 @@ print("zero!")
   ```
 -->
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/LanguageGuide/Generics.md
+++ b/TSPL.docc/LanguageGuide/Generics.md
@@ -1968,7 +1968,7 @@ is a sequence of integers.
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/LanguageGuide/Generics.md
+++ b/TSPL.docc/LanguageGuide/Generics.md
@@ -1964,6 +1964,12 @@ is a sequence of integers.
   TODO: Describe how Optional<Wrapped> works
 -->
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/Generics.md
+++ b/TSPL.docc/LanguageGuide/Generics.md
@@ -1964,7 +1964,7 @@ is a sequence of integers.
   TODO: Describe how Optional<Wrapped> works
 -->
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/LanguageGuide/Inheritance.md
+++ b/TSPL.docc/LanguageGuide/Inheritance.md
@@ -606,7 +606,7 @@ Any attempt to subclass a final class is reported as a compile-time error.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 -->
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/LanguageGuide/Inheritance.md
+++ b/TSPL.docc/LanguageGuide/Inheritance.md
@@ -606,6 +606,12 @@ Any attempt to subclass a final class is reported as a compile-time error.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 -->
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/Inheritance.md
+++ b/TSPL.docc/LanguageGuide/Inheritance.md
@@ -610,7 +610,7 @@ Any attempt to subclass a final class is reported as a compile-time error.
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/LanguageGuide/Initialization.md
+++ b/TSPL.docc/LanguageGuide/Initialization.md
@@ -2954,7 +2954,7 @@ print(board.squareIsBlackAt(row: 7, column: 7))
   ```
 -->
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/LanguageGuide/Initialization.md
+++ b/TSPL.docc/LanguageGuide/Initialization.md
@@ -2958,7 +2958,7 @@ print(board.squareIsBlackAt(row: 7, column: 7))
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/LanguageGuide/Initialization.md
+++ b/TSPL.docc/LanguageGuide/Initialization.md
@@ -2954,6 +2954,12 @@ print(board.squareIsBlackAt(row: 7, column: 7))
   ```
 -->
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/MemorySafety.md
+++ b/TSPL.docc/LanguageGuide/MemorySafety.md
@@ -742,6 +742,12 @@ it doesn't allow the access.
   on performance and memory usage.
 -->
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/MemorySafety.md
+++ b/TSPL.docc/LanguageGuide/MemorySafety.md
@@ -746,7 +746,7 @@ it doesn't allow the access.
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/LanguageGuide/MemorySafety.md
+++ b/TSPL.docc/LanguageGuide/MemorySafety.md
@@ -742,7 +742,7 @@ it doesn't allow the access.
   on performance and memory usage.
 -->
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/LanguageGuide/Methods.md
+++ b/TSPL.docc/LanguageGuide/Methods.md
@@ -654,7 +654,7 @@ if player.tracker.advance(to: 6) {
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/LanguageGuide/Methods.md
+++ b/TSPL.docc/LanguageGuide/Methods.md
@@ -650,6 +650,12 @@ if player.tracker.advance(to: 6) {
   (see Doug's comments from the 2014-03-12 release notes)
 -->
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/Methods.md
+++ b/TSPL.docc/LanguageGuide/Methods.md
@@ -650,7 +650,7 @@ if player.tracker.advance(to: 6) {
   (see Doug's comments from the 2014-03-12 release notes)
 -->
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/LanguageGuide/NestedTypes.md
+++ b/TSPL.docc/LanguageGuide/NestedTypes.md
@@ -191,6 +191,12 @@ For the example above,
 this enables the names of `Suit`, `Rank`, and `Values` to be kept deliberately short,
 because their names are naturally qualified by the context in which they're defined.
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/NestedTypes.md
+++ b/TSPL.docc/LanguageGuide/NestedTypes.md
@@ -191,7 +191,7 @@ For the example above,
 this enables the names of `Suit`, `Rank`, and `Values` to be kept deliberately short,
 because their names are naturally qualified by the context in which they're defined.
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/LanguageGuide/NestedTypes.md
+++ b/TSPL.docc/LanguageGuide/NestedTypes.md
@@ -195,7 +195,7 @@ because their names are naturally qualified by the context in which they're defi
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/LanguageGuide/OpaqueTypes.md
+++ b/TSPL.docc/LanguageGuide/OpaqueTypes.md
@@ -784,6 +784,12 @@ which means that the type of `twelve` is also inferred to be `Int`.
   }
 -->
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/OpaqueTypes.md
+++ b/TSPL.docc/LanguageGuide/OpaqueTypes.md
@@ -788,7 +788,7 @@ which means that the type of `twelve` is also inferred to be `Int`.
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/LanguageGuide/OpaqueTypes.md
+++ b/TSPL.docc/LanguageGuide/OpaqueTypes.md
@@ -784,7 +784,7 @@ which means that the type of `twelve` is also inferred to be `Int`.
   }
 -->
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/LanguageGuide/OptionalChaining.md
+++ b/TSPL.docc/LanguageGuide/OptionalChaining.md
@@ -883,6 +883,12 @@ if let beginsWithThe =
   the sugar for optional protocol requirements works.
 -->
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/OptionalChaining.md
+++ b/TSPL.docc/LanguageGuide/OptionalChaining.md
@@ -887,7 +887,7 @@ if let beginsWithThe =
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/LanguageGuide/OptionalChaining.md
+++ b/TSPL.docc/LanguageGuide/OptionalChaining.md
@@ -883,7 +883,7 @@ if let beginsWithThe =
   the sugar for optional protocol requirements works.
 -->
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/LanguageGuide/Properties.md
+++ b/TSPL.docc/LanguageGuide/Properties.md
@@ -2060,6 +2060,12 @@ print(AudioChannel.maxInputLevelForAllChannels)
   ```
 -->
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/Properties.md
+++ b/TSPL.docc/LanguageGuide/Properties.md
@@ -2064,7 +2064,7 @@ print(AudioChannel.maxInputLevelForAllChannels)
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/LanguageGuide/Properties.md
+++ b/TSPL.docc/LanguageGuide/Properties.md
@@ -2060,7 +2060,7 @@ print(AudioChannel.maxInputLevelForAllChannels)
   ```
 -->
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/LanguageGuide/Protocols.md
+++ b/TSPL.docc/LanguageGuide/Protocols.md
@@ -2674,7 +2674,7 @@ print(differentNumbers.allEqual())
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/LanguageGuide/Protocols.md
+++ b/TSPL.docc/LanguageGuide/Protocols.md
@@ -2670,6 +2670,12 @@ print(differentNumbers.allEqual())
   Checking for (and calling) optional implementations via optional binding and closures
 -->
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/Protocols.md
+++ b/TSPL.docc/LanguageGuide/Protocols.md
@@ -2670,7 +2670,7 @@ print(differentNumbers.allEqual())
   Checking for (and calling) optional implementations via optional binding and closures
 -->
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/LanguageGuide/StringsAndCharacters.md
+++ b/TSPL.docc/LanguageGuide/StringsAndCharacters.md
@@ -1791,7 +1791,7 @@ for scalar in dogString.unicodeScalars {
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/LanguageGuide/StringsAndCharacters.md
+++ b/TSPL.docc/LanguageGuide/StringsAndCharacters.md
@@ -1787,7 +1787,7 @@ for scalar in dogString.unicodeScalars {
   ```
 -->
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/LanguageGuide/StringsAndCharacters.md
+++ b/TSPL.docc/LanguageGuide/StringsAndCharacters.md
@@ -1787,6 +1787,12 @@ for scalar in dogString.unicodeScalars {
   ```
 -->
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/Subscripts.md
+++ b/TSPL.docc/LanguageGuide/Subscripts.md
@@ -426,7 +426,7 @@ print(mars)
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/LanguageGuide/Subscripts.md
+++ b/TSPL.docc/LanguageGuide/Subscripts.md
@@ -422,6 +422,12 @@ print(mars)
   ```
 -->
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/Subscripts.md
+++ b/TSPL.docc/LanguageGuide/Subscripts.md
@@ -422,7 +422,7 @@ print(mars)
   ```
 -->
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/LanguageGuide/TheBasics.md
+++ b/TSPL.docc/LanguageGuide/TheBasics.md
@@ -2038,6 +2038,12 @@ by one of the switch's other cases.
   but doesn't stop at assertions.
 -->
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/TheBasics.md
+++ b/TSPL.docc/LanguageGuide/TheBasics.md
@@ -2042,7 +2042,7 @@ by one of the switch's other cases.
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/LanguageGuide/TheBasics.md
+++ b/TSPL.docc/LanguageGuide/TheBasics.md
@@ -2038,7 +2038,7 @@ by one of the switch's other cases.
   but doesn't stop at assertions.
 -->
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/LanguageGuide/TypeCasting.md
+++ b/TSPL.docc/LanguageGuide/TypeCasting.md
@@ -522,7 +522,7 @@ for thing in things {
   ```
 -->
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/LanguageGuide/TypeCasting.md
+++ b/TSPL.docc/LanguageGuide/TypeCasting.md
@@ -526,7 +526,7 @@ for thing in things {
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/LanguageGuide/TypeCasting.md
+++ b/TSPL.docc/LanguageGuide/TypeCasting.md
@@ -522,6 +522,12 @@ for thing in things {
   ```
 -->
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/ReferenceManual/AboutTheLanguageReference.md
+++ b/TSPL.docc/ReferenceManual/AboutTheLanguageReference.md
@@ -53,7 +53,7 @@ where the alternatives are spelled out explicitly:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/ReferenceManual/AboutTheLanguageReference.md
+++ b/TSPL.docc/ReferenceManual/AboutTheLanguageReference.md
@@ -49,6 +49,12 @@ where the alternatives are spelled out explicitly:
 >
 > *getter-setter-block* → **`{`** *setter-clause* *getter-clause* **`}`**
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/ReferenceManual/AboutTheLanguageReference.md
+++ b/TSPL.docc/ReferenceManual/AboutTheLanguageReference.md
@@ -49,7 +49,7 @@ where the alternatives are spelled out explicitly:
 >
 > *getter-setter-block* → **`{`** *setter-clause* *getter-clause* **`}`**
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/ReferenceManual/Attributes.md
+++ b/TSPL.docc/ReferenceManual/Attributes.md
@@ -2259,7 +2259,7 @@ see <doc:Statements#Switching-Over-Future-Enumeration-Cases>.
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/ReferenceManual/Attributes.md
+++ b/TSPL.docc/ReferenceManual/Attributes.md
@@ -2255,7 +2255,7 @@ see <doc:Statements#Switching-Over-Future-Enumeration-Cases>.
 >
 > *balanced-token* → Any punctuation except  **`(`**,  **`)`**,  **`[`**,  **`]`**,  **`{`**, or  **`}`**
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/ReferenceManual/Attributes.md
+++ b/TSPL.docc/ReferenceManual/Attributes.md
@@ -2255,6 +2255,12 @@ see <doc:Statements#Switching-Over-Future-Enumeration-Cases>.
 >
 > *balanced-token* → Any punctuation except  **`(`**,  **`)`**,  **`[`**,  **`]`**,  **`{`**, or  **`}`**
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/ReferenceManual/Declarations.md
+++ b/TSPL.docc/ReferenceManual/Declarations.md
@@ -3839,7 +3839,7 @@ as discussed in <doc:AccessControl#Getters-and-Setters>.
 >
 > *actor-isolation-modifier* → **`nonisolated`**
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/ReferenceManual/Declarations.md
+++ b/TSPL.docc/ReferenceManual/Declarations.md
@@ -3843,7 +3843,7 @@ as discussed in <doc:AccessControl#Getters-and-Setters>.
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/ReferenceManual/Declarations.md
+++ b/TSPL.docc/ReferenceManual/Declarations.md
@@ -3839,6 +3839,12 @@ as discussed in <doc:AccessControl#Getters-and-Setters>.
 >
 > *actor-isolation-modifier* → **`nonisolated`**
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/ReferenceManual/Expressions.md
+++ b/TSPL.docc/ReferenceManual/Expressions.md
@@ -3266,6 +3266,12 @@ someDictionary["a"]?[0] = someFunctionWithSideEffects()
 >
 > *optional-chaining-expression* → *postfix-expression* **`?`**
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/ReferenceManual/Expressions.md
+++ b/TSPL.docc/ReferenceManual/Expressions.md
@@ -3266,7 +3266,7 @@ someDictionary["a"]?[0] = someFunctionWithSideEffects()
 >
 > *optional-chaining-expression* → *postfix-expression* **`?`**
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/ReferenceManual/Expressions.md
+++ b/TSPL.docc/ReferenceManual/Expressions.md
@@ -3270,7 +3270,7 @@ someDictionary["a"]?[0] = someFunctionWithSideEffects()
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/ReferenceManual/GenericParametersAndArguments.md
+++ b/TSPL.docc/ReferenceManual/GenericParametersAndArguments.md
@@ -304,6 +304,12 @@ of a generic function or initializer.
 >
 > *generic-argument* → *type*
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/ReferenceManual/GenericParametersAndArguments.md
+++ b/TSPL.docc/ReferenceManual/GenericParametersAndArguments.md
@@ -304,7 +304,7 @@ of a generic function or initializer.
 >
 > *generic-argument* → *type*
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/ReferenceManual/GenericParametersAndArguments.md
+++ b/TSPL.docc/ReferenceManual/GenericParametersAndArguments.md
@@ -308,7 +308,7 @@ of a generic function or initializer.
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/ReferenceManual/LexicalStructure.md
+++ b/TSPL.docc/ReferenceManual/LexicalStructure.md
@@ -1405,7 +1405,7 @@ see <doc:AdvancedOperators#Operator-Methods>.
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/ReferenceManual/LexicalStructure.md
+++ b/TSPL.docc/ReferenceManual/LexicalStructure.md
@@ -1401,6 +1401,12 @@ see <doc:AdvancedOperators#Operator-Methods>.
 >
 > *postfix-operator* → *operator*
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/ReferenceManual/LexicalStructure.md
+++ b/TSPL.docc/ReferenceManual/LexicalStructure.md
@@ -1401,7 +1401,7 @@ see <doc:AdvancedOperators#Operator-Methods>.
 >
 > *postfix-operator* → *operator*
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/ReferenceManual/Patterns.md
+++ b/TSPL.docc/ReferenceManual/Patterns.md
@@ -500,6 +500,12 @@ default:
 >
 > *expression-pattern* → *expression*
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/ReferenceManual/Patterns.md
+++ b/TSPL.docc/ReferenceManual/Patterns.md
@@ -504,7 +504,7 @@ default:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/ReferenceManual/Patterns.md
+++ b/TSPL.docc/ReferenceManual/Patterns.md
@@ -500,7 +500,7 @@ default:
 >
 > *expression-pattern* → *expression*
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/ReferenceManual/Statements.md
+++ b/TSPL.docc/ReferenceManual/Statements.md
@@ -1558,7 +1558,7 @@ It has the same meaning as the `*` argument in an availability condition.
   ```
 -->
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/ReferenceManual/Statements.md
+++ b/TSPL.docc/ReferenceManual/Statements.md
@@ -1562,7 +1562,7 @@ It has the same meaning as the `*` argument in an availability condition.
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/ReferenceManual/Statements.md
+++ b/TSPL.docc/ReferenceManual/Statements.md
@@ -1558,6 +1558,12 @@ It has the same meaning as the `*` argument in an availability condition.
   ```
 -->
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
+++ b/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
@@ -1659,7 +1659,7 @@ make the same change here also.
 >
 > *generic-argument* → *type*
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
+++ b/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
@@ -1663,7 +1663,7 @@ make the same change here also.
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
+++ b/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
@@ -1659,6 +1659,12 @@ make the same change here also.
 >
 > *generic-argument* → *type*
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/ReferenceManual/Types.md
+++ b/TSPL.docc/ReferenceManual/Types.md
@@ -1273,7 +1273,7 @@ the expression or one of its subexpressions.
   is allowed and when types must be fully typed.
 -->
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/ReferenceManual/Types.md
+++ b/TSPL.docc/ReferenceManual/Types.md
@@ -1273,6 +1273,12 @@ the expression or one of its subexpressions.
   is allowed and when types must be fully typed.
 -->
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/ReferenceManual/Types.md
+++ b/TSPL.docc/ReferenceManual/Types.md
@@ -1277,7 +1277,7 @@ the expression or one of its subexpressions.
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project

--- a/TSPL.docc/RevisionHistory/RevisionHistory.md
+++ b/TSPL.docc/RevisionHistory/RevisionHistory.md
@@ -791,7 +791,7 @@ Review the recent changes to this book.
   for the <doc:BasicOperators#Half-Open-Range-Operator>.
 - Added an example of <doc:Generics#Extending-a-Generic-Type>.
 
-> BETA SOFTWARE:
+> Beta Software:
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >

--- a/TSPL.docc/RevisionHistory/RevisionHistory.md
+++ b/TSPL.docc/RevisionHistory/RevisionHistory.md
@@ -791,6 +791,12 @@ Review the recent changes to this book.
   for the <doc:BasicOperators#Half-Open-Range-Operator>.
 - Added an example of <doc:Generics#Extending-a-Generic-Type>.
 
+> BETA SOFTWARE:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/RevisionHistory/RevisionHistory.md
+++ b/TSPL.docc/RevisionHistory/RevisionHistory.md
@@ -795,7 +795,7 @@ Review the recent changes to this book.
 >
 > This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
 >
-> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/)
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
 
 <!--
 This source file is part of the Swift.org open source project


### PR DESCRIPTION
The legacy publication pipeline conditionally included this text in the template, but DocC doesn't support that (see rdar://105292753).  Adding it manually for now, as a workaround.