### PR TITLE
Add appearance selection input to the footer

### DIFF
--- a/TSPL.docc/footer.html
+++ b/TSPL.docc/footer.html
@@ -53,11 +53,11 @@ See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
         outline: none;
         --toggle-color-fill: var(--color-button-background);
         font-size: 12px;
-        border: 1px solid var(--color-nav-link-color);
-        border-radius: var(--border-radius);
+        border: 1px solid #fff;
+        border-radius: 4px;
         display: inline-flex;
         padding: 1px;
-        margin-bottom:var(--content-margin-bottom)
+        margin-bottom: 1em;
     }
 
     .color-scheme-toggle input {
@@ -75,7 +75,6 @@ See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
     .color-scheme-toggle-label {
         border: 1px solid transparent;
         border-radius: var(--toggle-border-radius-inner, 2px);
-        color: var(--color-nav-link-color);
         display: inline-block;
         text-align: center;
         padding: 1px 6px;
@@ -88,7 +87,7 @@ See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
     }
 
     input:checked + .color-scheme-toggle-label {
-        background: var(--color-nav-link-color);
+        background: #fff;
         color: var(--color-nav-stuck)
     }
 

--- a/TSPL.docc/footer.html
+++ b/TSPL.docc/footer.html
@@ -48,6 +48,10 @@ See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
     </div>
   </div>
   <style type="text/css">
+    /*
+    Expanded SCSS from apple/swift-org-website commit a09c14493f812:
+    /assets/stylesheets/_screen.scss#L925
+    */
     .color-scheme-toggle {
         display: block;
         outline: none;
@@ -108,10 +112,12 @@ See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
     }
   </style>
   <script type="text/javascript">
+    // DocC uses this local storage key to persist appearance preferences.
     const appearanceKey = 'developer.setting.preferredColorScheme'
     window.addEventListener('DOMContentLoaded', _ => {
       let appearancePreference = localStorage.getItem(appearanceKey)
       if (appearancePreference) {
+        // Set a color scheme according to a saved preference.
         document.body.dataset.colorScheme = appearancePreference
         document.querySelector('custom-footer')
           .shadowRoot
@@ -125,6 +131,7 @@ See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
       }
     })
 
+    // Set a color scheme based on user choice and persist it.
     function doccAppearance(mode) {
       switch(mode) {
       case 'light':

--- a/TSPL.docc/footer.html
+++ b/TSPL.docc/footer.html
@@ -144,10 +144,7 @@ See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
         break
       case 'auto':
         localStorage.removeItem(appearanceKey)
-        document.body.dataset.colorScheme =
-          window.matchMedia('(prefers-color-scheme: dark)').matches
-            ? 'dark'
-            : 'light'
+        document.body.dataset.colorScheme = 'auto'
         break
       }
     }

--- a/TSPL.docc/footer.html
+++ b/TSPL.docc/footer.html
@@ -20,9 +20,121 @@ See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
         <a href="//www.apple.com/legal/privacy/en-ww/cookies/">Cookies</a>
       </p>
     </div>
-    <aside>
+    <div class="footer-other">
+      <form
+        class="color-scheme-toggle"
+        role="radiogroup"
+        tabindex="0"
+        id="color-scheme-toggle"
+      >
+        <legend class="visuallyhidden">Color scheme preference</legend>
+        <label for="scheme-light">
+          <input id="scheme-light" type="radio" class="visuallyhidden" name="color-scheme-preference" value="light" onchange="doccAppearance('light')">
+          <span class="color-scheme-toggle-label">Light</span>
+        </label>
+        <label for="scheme-dark">
+          <input id="scheme-dark" type="radio" class="visuallyhidden" name="color-scheme-preference" value="dark" onchange="doccAppearance('dark')">
+          <span class="color-scheme-toggle-label">Dark</span>
+        </label>
+        <label for="scheme-auto" id="scheme-auto-wrapper">
+          <input id="scheme-auto" type="radio" class="visuallyhidden" name="color-scheme-preference" value="auto" onchange="doccAppearance('auto')">
+          <span class="color-scheme-toggle-label">Auto</span>
+        </label>
+      </form>
+      <aside>
       <a href="/atom.xml" title="Subscribe to Site Updates"><i class="feed"></i></a>
       <a href="https://twitter.com/swiftlang" rel="nofollow" title="Follow @SwiftLang on Twitter"><i class="twitter"></i></a>
     </aside>
+    </div>
   </div>
+  <style type="text/css">
+    .color-scheme-toggle {
+        display: block;
+        outline: none;
+        --toggle-color-fill: var(--color-button-background);
+        font-size: 12px;
+        border: 1px solid var(--color-nav-link-color);
+        border-radius: var(--border-radius);
+        display: inline-flex;
+        padding: 1px;
+        margin-bottom:var(--content-margin-bottom)
+    }
+
+    .color-scheme-toggle input {
+        position: absolute;
+        clip: rect(1px, 1px, 1px, 1px);
+        clip-path: inset(0px 0px 99.9% 99.9%);
+        overflow: hidden;
+        height: 1px;
+        width: 1px;
+        padding: 0;
+        border: 0;
+        appearance:none
+    }
+
+    .color-scheme-toggle-label {
+        border: 1px solid transparent;
+        border-radius: var(--toggle-border-radius-inner, 2px);
+        color: var(--color-nav-link-color);
+        display: inline-block;
+        text-align: center;
+        padding: 1px 6px;
+        min-width: 42px;
+        box-sizing:border-box
+    }
+
+    .color-scheme-toggle-label:hover {
+        cursor:pointer
+    }
+
+    input:checked + .color-scheme-toggle-label {
+        background: var(--color-nav-link-color);
+        color: var(--color-nav-stuck)
+    }
+
+    [role="contentinfo"] {
+        display: flex;
+        justify-content:space-between
+    }
+
+    .visuallyhidden {
+        position: absolute;
+        clip: rect(1px, 1px, 1px, 1px);
+        clip-path: inset(0px 0px 99.9% 99.9%);
+        overflow: hidden;
+        height: 1px;
+        width: 1px;
+        padding: 0;
+        border:0
+    }
+  </style>
+  <script type="text/javascript">
+    const appearanceKey = 'developer.setting.preferredColorScheme'
+    window.addEventListener('DOMContentLoaded', _ => {
+      let appearancePreference = localStorage.getItem(appearanceKey)
+      if (appearancePreference) {
+        document.body.dataset.colorScheme = appearancePreference
+      }
+    })
+
+    function doccAppearance(mode) {
+      switch(mode) {
+      case 'light':
+        localStorage.setItem(appearanceKey, mode)
+        document.body.dataset.colorScheme = mode
+        break
+      case 'dark':
+        localStorage.setItem(appearanceKey, mode)
+        document.body.dataset.colorScheme = mode
+        break
+      case 'auto':
+        localStorage.removeItem(appearanceKey)
+        document.body.dataset.colorScheme =
+          window.matchMedia('(prefers-color-scheme: dark)').matches
+            ? 'dark'
+            : 'light'
+        break
+      }
+    }
+  </script>
 </footer>

--- a/TSPL.docc/footer.html
+++ b/TSPL.docc/footer.html
@@ -133,18 +133,16 @@ See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
     // Set a color scheme based on user choice and persist it.
     function doccAppearance(mode) {
+      document.body.dataset.colorScheme = mode
       switch(mode) {
       case 'light':
         localStorage.setItem(appearanceKey, mode)
-        document.body.dataset.colorScheme = mode
         break
       case 'dark':
         localStorage.setItem(appearanceKey, mode)
-        document.body.dataset.colorScheme = mode
         break
       case 'auto':
         localStorage.removeItem(appearanceKey)
-        document.body.dataset.colorScheme = 'auto'
         break
       }
     }

--- a/TSPL.docc/footer.html
+++ b/TSPL.docc/footer.html
@@ -88,7 +88,7 @@ See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
     input:checked + .color-scheme-toggle-label {
         background: #fff;
-        color: var(--color-nav-stuck)
+        color: rgba(42,42,42,0.9);
     }
 
     [role="contentinfo"] {
@@ -113,6 +113,15 @@ See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
       let appearancePreference = localStorage.getItem(appearanceKey)
       if (appearancePreference) {
         document.body.dataset.colorScheme = appearancePreference
+        document.querySelector('custom-footer')
+          .shadowRoot
+          .querySelector(`#scheme-${appearancePreference}`)
+          .checked = true
+      } else {
+        document.querySelector('custom-footer')
+          .shadowRoot
+          .querySelector(`#scheme-auto`)
+          .checked = true
       }
     })
 


### PR DESCRIPTION
Several people pointed out that they would like a site-specific toggle for light/dark mode for the book: https://forums.swift.org/t/light-mode-for-swift-5-8-docs/63364

This PR adds a toggle like the one in the footer on the main swift.org site. I manually expanded the SCSS to CSS to avoid adding a build-time dependency for it. 

I deployed a test/preview version here: https://krilnon.github.io/swift-book/documentation/the-swift-programming-language/