### PR TITLE
Add discussion of 'if' and 'switch' expressions [SE-0380]

### DIFF
--- a/TSPL.docc/GuidedTour/GuidedTour.md
+++ b/TSPL.docc/GuidedTour/GuidedTour.md
@@ -379,7 +379,7 @@ this means that code such as `if score { ... }` is an error,
 not an implicit comparison to zero.
 
 You can write `if` or `switch`
-after the equals sign (`=`) of an assignment
+after the equal sign (`=`) of an assignment
 or after `return`,
 to choose a value based on the condition.
 

--- a/TSPL.docc/GuidedTour/GuidedTour.md
+++ b/TSPL.docc/GuidedTour/GuidedTour.md
@@ -381,6 +381,21 @@ the conditional must be a Boolean expression ---
 this means that code such as `if score { ... }` is an error,
 not an implicit comparison to zero.
 
+You can write `if` or `switch`
+after the equals sign (`=`) of an assignment
+or after `return`,
+to choose a value based on the condition.
+
+```swift
+let scoreDecoration = if teamScore > 10 {
+    "🎉"
+} else {
+    ""
+}
+print("Score:", teamScore, scoreDecoration)
+// Prints "Score: 11 🎉"
+```
+
 You can use `if` and `let` together
 to work with values that might be missing.
 These values are represented as optionals.

--- a/TSPL.docc/GuidedTour/GuidedTour.md
+++ b/TSPL.docc/GuidedTour/GuidedTour.md
@@ -221,8 +221,6 @@ A comma is allowed after the last element.
   Occupations is a reference to Firefly,
   specifically to Mal's joke about Jayne's job on the ship.
 
-
-
   Can't find the specific episode,
   but it shows up in several lists of Firefly "best of" quotes:
 
@@ -309,7 +307,6 @@ you need to specify the type.
 let emptyArray: [String] = []
 let emptyDictionary: [String: Float] = [:]
 ```
-
 
 <!--
   - test: `guided-tour`

--- a/TSPL.docc/LanguageGuide/ClassesAndStructures.md
+++ b/TSPL.docc/LanguageGuide/ClassesAndStructures.md
@@ -639,8 +639,8 @@ if tenEighty === alsoTenEighty {
   ```
 -->
 
-Note that *identical to* (represented by three equals signs, or `===`)
-doesn't mean the same thing as *equal to* (represented by two equals signs, or `==`).
+Note that *identical to* (represented by three equal signs, or `===`)
+doesn't mean the same thing as *equal to* (represented by two equal signs, or `==`).
 *Identical to* means that
 two constants or variables of class type refer to exactly the same class instance.
 *Equal to* means that

--- a/TSPL.docc/LanguageGuide/ControlFlow.md
+++ b/TSPL.docc/LanguageGuide/ControlFlow.md
@@ -817,6 +817,39 @@ each branch of the `if` expression
 produces of the three possible values for `weatherAdvice`,
 and the assignment uses that value.
 
+All of the branches of an `if` expression
+need to contain values of the same type.
+Because Swift checks the type of each branch separately,
+values like `nil` that can be used with multiple types
+prevent Swift from determining the `if` expression's type automatically.
+Instead, you need to specify the type explicitly ---
+for example:
+
+```swift
+let freezeWarning: String? = if temperatureInCelsius <= 0 {
+    "It's below freezing. Watch for ice!"
+} else {
+    nil
+}
+```
+
+In the code above,
+one branch of the `if` statement has a string value
+and the other branch has a `nil` value.
+The `nil` value could be used as a value for any optional type,
+so you have to explicitly write that `freezeWarning` is an optional string.
+An alternate way to provide this type information
+is to provide an explicit type for `nil`,
+instead of providing an explicit type for `freezeWarning`:
+
+```swift
+let freezeWarning = if temperatureInCelsius <= 0 {
+    "It's below freezing. Watch for ice!"
+} else {
+    nil as String?
+}
+```
+
 An `if` expression that checks for conditions
 that are invalid or that it can't handle
 can throw an error

--- a/TSPL.docc/LanguageGuide/ControlFlow.md
+++ b/TSPL.docc/LanguageGuide/ControlFlow.md
@@ -1285,6 +1285,37 @@ and `distance` is an integer in both patterns ---
 which means that the code in the body of the `case`
 can always access a value for `distance`.
 
+
+### If and Switch Expressions
+
+```swift
+let temperatureInCelsius = 25
+
+let weatherAdvice = if temperatureInCelsius <= 0 {
+    "It's very cold. Consider wearing a scarf."
+} else if temperatureInCelsius >= 30 {
+    "It's really warm. Don't forget to wear sunscreen."
+} else {
+    "It's not that cold. Wear a t-shirt."
+}
+
+print(weatherAdvice)
+// Prints "It's not that cold. Wear a t-shirt."
+```
+
+```swift
+let yetAnotherPoint = (1, -1)
+switch yetAnotherPoint {
+case let (x, y) where x == y:
+    print("(\(x), \(y)) is on the line x == y")
+case let (x, y) where x == -y:
+    print("(\(x), \(y)) is on the line x == -y")
+case let (x, y):
+    print("(\(x), \(y)) is just some arbitrary point")
+}
+// Prints "(1, -1) is on the line x == -y"
+```
+
 ## Control Transfer Statements
 
 *Control transfer statements* change the order in which your code is executed,

--- a/TSPL.docc/LanguageGuide/ControlFlow.md
+++ b/TSPL.docc/LanguageGuide/ControlFlow.md
@@ -788,7 +788,7 @@ which is printed after the `if` statement.
 
 Using the alternate syntax,
 known as an `if` expression,
-you could write this code more concisely:
+you can write this code more concisely:
 
 ```swift
 let weatherAdvice = if temperatureInCelsius <= 0 {

--- a/TSPL.docc/LanguageGuide/ControlFlow.md
+++ b/TSPL.docc/LanguageGuide/ControlFlow.md
@@ -929,13 +929,13 @@ a single lowercase character called `someCharacter`:
 let someCharacter: Character = "z"
 switch someCharacter {
 case "a":
-    print("The first letter of the alphabet")
+    print("The first letter of the Latin alphabet")
 case "z":
-    print("The last letter of the alphabet")
+    print("The last letter of the Latin alphabet")
 default:
     print("Some other character")
 }
-// Prints "The last letter of the alphabet"
+// Prints "The last letter of the Latin alphabet"
 ```
 
 <!--
@@ -945,13 +945,13 @@ default:
   -> let someCharacter: Character = "z"
   -> switch someCharacter {
         case "a":
-           print("The first letter of the alphabet")
+           print("The first letter of the Latin alphabet")
         case "z":
-           print("The last letter of the alphabet")
+           print("The last letter of the Latin alphabet")
         default:
            print("Some other character")
      }
-  <- The last letter of the alphabet
+  <- The last letter of the Latin alphabet
   ```
 -->
 
@@ -971,15 +971,15 @@ Like `if` statements,
 let anotherCharacter: Character = "a"
 let message = switch anotherCharacter {
 case "a":
-    "The first letter of the alphabet"
+    "The first letter of the Latin alphabet"
 case "z":
-    "The last letter of the alphabet"
+    "The last letter of the Latin alphabet"
 default:
     "Some other character"
 }
 
 print(message)
-// Prints "The first letter of the alphabet"
+// Prints "The first letter of the Latin alphabet"
 ```
 
 In this example,

--- a/TSPL.docc/LanguageGuide/ControlFlow.md
+++ b/TSPL.docc/LanguageGuide/ControlFlow.md
@@ -672,9 +672,9 @@ temperatureInFahrenheit = 40
 if temperatureInFahrenheit <= 32 {
     print("It's very cold. Consider wearing a scarf.")
 } else {
-    print("It's not that cold. Wear a t-shirt.")
+    print("It's not that cold. Wear a T-shirt.")
 }
-// Prints "It's not that cold. Wear a t-shirt."
+// Prints "It's not that cold. Wear a T-shirt."
 ```
 
 <!--
@@ -685,9 +685,9 @@ if temperatureInFahrenheit <= 32 {
   -> if temperatureInFahrenheit <= 32 {
         print("It's very cold. Consider wearing a scarf.")
      } else {
-        print("It's not that cold. Wear a t-shirt.")
+        print("It's not that cold. Wear a T-shirt.")
      }
-  <- It's not that cold. Wear a t-shirt.
+  <- It's not that cold. Wear a T-shirt.
   ```
 -->
 
@@ -706,7 +706,7 @@ if temperatureInFahrenheit <= 32 {
 } else if temperatureInFahrenheit >= 86 {
     print("It's really warm. Don't forget to wear sunscreen.")
 } else {
-    print("It's not that cold. Wear a t-shirt.")
+    print("It's not that cold. Wear a T-shirt.")
 }
 // Prints "It's really warm. Don't forget to wear sunscreen."
 ```
@@ -721,7 +721,7 @@ if temperatureInFahrenheit <= 32 {
      } else if temperatureInFahrenheit >= 86 {
         print("It's really warm. Don't forget to wear sunscreen.")
      } else {
-        print("It's not that cold. Wear a t-shirt.")
+        print("It's not that cold. Wear a T-shirt.")
      }
   <- It's really warm. Don't forget to wear sunscreen.
   ```
@@ -773,11 +773,11 @@ if temperatureInCelsius <= 0 {
 } else if temperatureInCelsius >= 30 {
     weatherAdvice = "It's really warm. Don't forget to wear sunscreen."
 } else {
-    weatherAdvice = "It's not that cold. Wear a t-shirt."
+    weatherAdvice = "It's not that cold. Wear a T-shirt."
 }
 
 print(weatherAdvice)
-// Prints "It's not that cold. Wear a t-shirt."
+// Prints "It's not that cold. Wear a T-shirt."
 ```
 
 Here, each of the branches sets a value for the `weatherAdvice` constant,
@@ -794,11 +794,11 @@ let weatherAdvice = if temperatureInCelsius <= 0 {
 } else if temperatureInCelsius >= 30 {
     "It's really warm. Don't forget to wear sunscreen."
 } else {
-    "It's not that cold. Wear a t-shirt."
+    "It's not that cold. Wear a T-shirt."
 }
 
 print(weatherAdvice)
-// Prints "It's not that cold. Wear a t-shirt."
+// Prints "It's not that cold. Wear a T-shirt."
 ```
 
 In this `if` expression version of the code,

--- a/TSPL.docc/LanguageGuide/ControlFlow.md
+++ b/TSPL.docc/LanguageGuide/ControlFlow.md
@@ -819,12 +819,33 @@ each branch of the `if` expression
 produces of the three possible values for `weatherAdvice`,
 and the assignment uses that value.
 
+An `if` expression that checks for conditions
+that are invalid or that it can't handle
+can throw an error
+or call a function like `fatalError(_:file:line:)` that never returns.
+For example:
+
+```swift
+let weatherAdvice = if temperatureInCelsius > 100 {
+    throw TemperatureError.boiling
+} else {
+    "It's a reasonable temperature."
+}
+```
+
+In this example,
+the `if` expression checks whether the forecast temperature
+is hotter than 100° C, the temperature that water boils at.
+A temperature this hot causes the `if` expression to throw a `.boiling` error
+instead of returning a textual summary.
+Even though this `if` expression can throw an error,
+you don't write `try` before it.
+For information about working with errors, see <doc:ErrorHandling>.
+
 You can use `if` expressions
 on the right-hand side of an assignment,
 as shown in the example above,
 and as the value that a function or closure returns.
-
-<!--- XXX exception to the "one expression" rule -->
 
 ### Switch
 
@@ -929,7 +950,22 @@ print(message)
 // Prints "The first letter of the alphabet"
 ```
 
-<!-- XXX walkthru -->
+In this example,
+each case in the `switch` expression
+contains the value for `message`
+to be used when that case matches `anotherCharacter`.
+Because `switch` is always exhaustive,
+there will always be a value to assign.
+
+As with `if` expressions,
+you can throw an error
+or call a function like `fatalError(_:file:line:)` that never returns
+instead of providing a value for a given case.
+You can use `switch` expressions
+on the right-hand side of an assignment,
+as shown in the example above,
+and as the value that a function or closure returns.
+
 
 #### No Implicit Fallthrough
 

--- a/TSPL.docc/LanguageGuide/ControlFlow.md
+++ b/TSPL.docc/LanguageGuide/ControlFlow.md
@@ -764,8 +764,6 @@ that you can use to set a value based on certain conditions.
 For example,
 consider the following code that uses `if` statements:
 
-```
-
 ```swift
 let temperatureInCelsius = 25
 let weatherAdvice: String

--- a/TSPL.docc/LanguageGuide/ControlFlow.md
+++ b/TSPL.docc/LanguageGuide/ControlFlow.md
@@ -801,7 +801,7 @@ print(weatherAdvice)
 // Prints "It's not that cold. Wear a T-shirt."
 ```
 
-In this `if` expression version of the code,
+In this `if` expression version,
 each branch contains a single value.
 If a branch's condition is true,
 then that branch's value is used as the value for the whole `if` expression
@@ -812,10 +812,10 @@ and that the `if` expression always produces a value,
 regardless of which conditions are true.
 
 Because the syntax for the assignment starts outside the `if` expression,
-there's no need to repeat `weatherAdvice =` inside each branch ---
-instead,
+there's no need to repeat `weatherAdvice =` inside each branch.
+Instead,
 each branch of the `if` expression
-produces of the three possible values for `weatherAdvice`,
+produces one of the three possible values for `weatherAdvice`,
 and the assignment uses that value.
 
 All of the branches of an `if` expression
@@ -867,7 +867,7 @@ let weatherAdvice = if temperatureInCelsius > 100 {
 
 In this example,
 the `if` expression checks whether the forecast temperature
-is hotter than 100° C, the temperature that water boils at.
+is hotter than 100° C --- the boiling point of water.
 A temperature this hot causes the `if` expression to throw a `.boiling` error
 instead of returning a textual summary.
 Even though this `if` expression can throw an error,

--- a/TSPL.docc/LanguageGuide/ControlFlow.md
+++ b/TSPL.docc/LanguageGuide/ControlFlow.md
@@ -759,10 +759,10 @@ if temperatureInFahrenheit <= 32 {
 Because the temperature is neither too cold nor too warm to trigger the `if` or `else if` conditions,
 no message is printed.
 
-Swift provides another version of `if` statements
-that you can use to set a value based on certain conditions.
+Swift provides a shorthand spelling of `if`
+that you can use when setting values.
 For example,
-consider the following code that uses `if` statements:
+consider the following code:
 
 ```swift
 let temperatureInCelsius = 25
@@ -803,11 +803,12 @@ print(weatherAdvice)
 
 In this `if` expression version of the code,
 each branch contains a single value.
-If that branch's condition is true,
-then its value is used as the value for the whole `if` expression
+If a branch's condition is true,
+then that branch's value is used as the value for the whole `if` expression
 in the assignment of `weatherAdvice`.
 Every `if` branch has a corresponding `else if` branch or `else` branch,
-ensuring that one of the branches always produces a value,
+ensuring that one of the branches always matches
+and that the `if` expression always produces a value,
 regardless of which conditions are true.
 
 Because the syntax for the assignment starts outside the `if` expression,
@@ -820,7 +821,7 @@ and the assignment uses that value.
 All of the branches of an `if` expression
 need to contain values of the same type.
 Because Swift checks the type of each branch separately,
-values like `nil` that can be used with multiple types
+values like `nil` that can be used with more than one type
 prevent Swift from determining the `if` expression's type automatically.
 Instead, you need to specify the type explicitly ---
 for example:
@@ -834,10 +835,12 @@ let freezeWarning: String? = if temperatureInCelsius <= 0 {
 ```
 
 In the code above,
-one branch of the `if` statement has a string value
+one branch of the `if` expression has a string value
 and the other branch has a `nil` value.
 The `nil` value could be used as a value for any optional type,
-so you have to explicitly write that `freezeWarning` is an optional string.
+so you have to explicitly write that `freezeWarning` is an optional string,
+as described in <doc:TheBasics#Type-Annotations>.
+
 An alternate way to provide this type information
 is to provide an explicit type for `nil`,
 instead of providing an explicit type for `freezeWarning`:
@@ -850,10 +853,8 @@ let freezeWarning = if temperatureInCelsius <= 0 {
 }
 ```
 
-An `if` expression that checks for conditions
-that are invalid or that it can't handle
-can throw an error
-or call a function like `fatalError(_:file:line:)` that never returns.
+An `if` expression can respond to unexpected failures by throwing an error
+or calling a function like `fatalError(_:file:line:)` that never returns.
 For example:
 
 ```swift
@@ -873,10 +874,10 @@ Even though this `if` expression can throw an error,
 you don't write `try` before it.
 For information about working with errors, see <doc:ErrorHandling>.
 
-You can use `if` expressions
+In addition to using `if` expressions
 on the right-hand side of an assignment,
-as shown in the example above,
-and as the value that a function or closure returns.
+as shown in the examples above,
+you can also use them as the value that a function or closure returns.
 
 ### Switch
 
@@ -986,7 +987,7 @@ each case in the `switch` expression
 contains the value for `message`
 to be used when that case matches `anotherCharacter`.
 Because `switch` is always exhaustive,
-there will always be a value to assign.
+there is always a value to assign.
 
 As with `if` expressions,
 you can throw an error

--- a/TSPL.docc/LanguageGuide/ControlFlow.md
+++ b/TSPL.docc/LanguageGuide/ControlFlow.md
@@ -997,7 +997,6 @@ on the right-hand side of an assignment,
 as shown in the example above,
 and as the value that a function or closure returns.
 
-
 #### No Implicit Fallthrough
 
 In contrast with `switch` statements in C and Objective-C,

--- a/TSPL.docc/LanguageGuide/ControlFlow.md
+++ b/TSPL.docc/LanguageGuide/ControlFlow.md
@@ -759,6 +759,73 @@ if temperatureInFahrenheit <= 32 {
 Because the temperature is neither too cold nor too warm to trigger the `if` or `else if` conditions,
 no message is printed.
 
+Swift provides another version of `if` statements
+that you can use to set a value based on certain conditions.
+For example,
+consider the following code that uses `if` statements:
+
+```
+
+```swift
+let temperatureInCelsius = 25
+let weatherAdvice: String
+
+if temperatureInCelsius <= 0 {
+    weatherAdvice = "It's very cold. Consider wearing a scarf."
+} else if temperatureInCelsius >= 30 {
+    weatherAdvice = "It's really warm. Don't forget to wear sunscreen."
+} else {
+    weatherAdvice = "It's not that cold. Wear a t-shirt."
+}
+
+print(weatherAdvice)
+// Prints "It's not that cold. Wear a t-shirt."
+```
+
+Here, each of the branches sets a value for the `weatherAdvice` constant,
+which is printed after the `if` statement.
+<!-- XXX have we shown deferred initialization like in an earlier chapter? -->
+
+Using the alternate syntax,
+known as an `if` expression,
+you could write this code more concisely:
+
+```swift
+let weatherAdvice = if temperatureInCelsius <= 0 {
+    "It's very cold. Consider wearing a scarf."
+} else if temperatureInCelsius >= 30 {
+    "It's really warm. Don't forget to wear sunscreen."
+} else {
+    "It's not that cold. Wear a t-shirt."
+}
+
+print(weatherAdvice)
+// Prints "It's not that cold. Wear a t-shirt."
+```
+
+In this `if` expression version of the code,
+each branch contains a single value.
+If that branch's condition is true,
+then its value is used as the value for the whole `if` expression
+in the assignment of `weatherAdvice`.
+Every `if` branch has a corresponding `else if` branch or `else` branch,
+ensuring that one of the branches always produces a value,
+regardless of which conditions are true.
+
+Because the syntax for the assignment starts outside the `if` expression,
+there's no need to repeat `weatherAdvice =` inside each branch ---
+instead,
+each branch of the `if` expression
+produces of the three possible values for `weatherAdvice`,
+and the assignment uses that value.
+
+You can use `if` expressions
+on the right-hand side of an assignment,
+as shown in the example above,
+and as the value that a function or closure returns.
+
+<!--- XXX exception to the "one expression" rule -->
+
 ### Switch
 
 A `switch` statement considers a value
@@ -843,6 +910,26 @@ not just every alphabetic character,
 this `switch` statement uses a `default` case
 to match all characters other than `a` and `z`.
 This provision ensures that the `switch` statement is exhaustive.
+
+Like `if` statements,
+`switch` statements also have an expression form:
+
+```swift
+let anotherCharacter: Character = "a"
+let message = switch anotherCharacter {
+case "a":
+    "The first letter of the alphabet"
+case "z":
+    "The last letter of the alphabet"
+default:
+    "Some other character"
+}
+
+print(message)
+// Prints "The first letter of the alphabet"
+```
+
+<!-- XXX walkthru -->
 
 #### No Implicit Fallthrough
 
@@ -1284,37 +1371,6 @@ Both patterns include a binding for `distance`
 and `distance` is an integer in both patterns ---
 which means that the code in the body of the `case`
 can always access a value for `distance`.
-
-
-### If and Switch Expressions
-
-```swift
-let temperatureInCelsius = 25
-
-let weatherAdvice = if temperatureInCelsius <= 0 {
-    "It's very cold. Consider wearing a scarf."
-} else if temperatureInCelsius >= 30 {
-    "It's really warm. Don't forget to wear sunscreen."
-} else {
-    "It's not that cold. Wear a t-shirt."
-}
-
-print(weatherAdvice)
-// Prints "It's not that cold. Wear a t-shirt."
-```
-
-```swift
-let yetAnotherPoint = (1, -1)
-switch yetAnotherPoint {
-case let (x, y) where x == y:
-    print("(\(x), \(y)) is on the line x == y")
-case let (x, y) where x == -y:
-    print("(\(x), \(y)) is on the line x == -y")
-case let (x, y):
-    print("(\(x), \(y)) is just some arbitrary point")
-}
-// Prints "(1, -1) is on the line x == -y"
-```
 
 ## Control Transfer Statements
 

--- a/TSPL.docc/ReferenceManual/Declarations.md
+++ b/TSPL.docc/ReferenceManual/Declarations.md
@@ -1055,7 +1055,7 @@ For example, the variadic parameter `Int...` is treated as `[Int]`.
 For an example that uses a variadic parameter,
 see <doc:Functions#Variadic-Parameters>.
 
-A parameter with an equals sign (`=`) and an expression after its type
+A parameter with an equal sign (`=`) and an expression after its type
 is understood to have a default value of the given expression.
 The given expression is evaluated when the function is called.
 If the parameter is omitted when calling the function,

--- a/TSPL.docc/ReferenceManual/Expressions.md
+++ b/TSPL.docc/ReferenceManual/Expressions.md
@@ -947,60 +947,48 @@ default:
 ```
 
 A conditional expression
-has the same behavior and syntax as an if statement or switch statement,
-with the following differences:
+has the same behavior and syntax as an `if` statement or a `switch` statement,
+except for the differences listed below.
 
-- A conditional expression appears only in the following contexts:
+A conditional expression appears only in the following contexts:
 
-    - As the value assigned to a variable.
+  - As the value assigned to a variable.
+  - As the initial value in a variable or constant declaration.
+  - As the error thrown by a `throw` expression.
+  - As the value returned by a function, closure, or property getter.
 
-    - As the initial value in a variable or constant declaration.
+The branches of a conditional expression are exhaustive,
+ensuring that the expression always produces a value
+regardless of the condition.
+This means each `if` branch needs a corresponding `else` branch.
 
-    - As the error thrown by a `throw` expression.
+Each branch contains either a single expression,
+which is used as the value for the conditional expression
+when that branch's conditional is true,
+a `throw` statement,
+or a call to a function that never returns.
 
-    - As the value returned by a function, closure, or property getter.
+Each branch must produce a value of the same type.
+Because type checking of each branch is independent,
+conditional expressions that that include a `nil` literal
+or different kinds of literals typically need type context,
+like an explicit type annotation.
 
-- Each branch contains either a single expression,
-  which is used as the value for the conditional expression
-  when that branch's conditional is true,
-  a `throw` statement,
-  or a call to a function that never returns.
-  <!--
-  You can't add precondition() to a branch before the expression.
-  -->
+```swift
+let number: Double = if someCondition { 10 } else {12.34 }
+```
 
-- Each `if` branch has a corresponding `else` branch.
+A conditional expression can't appear inside a result builder.
 
-- Each branch produces a value of the same type.
-  Type checking of each branch happens independently.
+<!--
+XXX  TR: The SE proposal says the above,
+but then also says this, which appears to contradict:
 
-  <!--
-  XXX If you use literals of different types on different branches
-  or you include a nil literal,
-  you need to provide type context so those will type check.
-  -->
-
-- A conditional expression can't appear inside a result builder.
-
-  <!--
-  XXX  But the SE proposal also says:
-  The variable declaration form of an if will be allowed in result builders.
-  -->
+The variable declaration form of an if will be allowed in result builders.
+-->
 
 Don't put a conditional expression in a `try` expression,
 even if one of the branches of a conditional expression is throwing.
-
-<!--
-XXX The SE proposal says this isn't required,
-but in my testing I see it's actually an error.
-
-In the case where a branch throws,
-either because a call in the expression throws
-(which requires a try)
-or with an explicit throw,
-there is no requirement to mark the overall expression
-with an additional try (e.g. before the if).
--->
 
 > Grammar of a conditional expression:
 >

--- a/TSPL.docc/ReferenceManual/Expressions.md
+++ b/TSPL.docc/ReferenceManual/Expressions.md
@@ -956,6 +956,7 @@ A conditional expression appears only in the following contexts:
   - As the initial value in a variable or constant declaration.
   - As the error thrown by a `throw` expression.
   - As the value returned by a function, closure, or property getter.
+  - As the value inside a branch of a conditional expression.
 
 The branches of a conditional expression are exhaustive,
 ensuring that the expression always produces a value
@@ -978,14 +979,13 @@ like an explicit type annotation.
 let number: Double = if someCondition { 10 } else {12.34 }
 ```
 
-A conditional expression can't appear inside a result builder.
-
-<!--
-XXX  TR: The SE proposal says the above,
-but then also says this, which appears to contradict:
-
-The variable declaration form of an if will be allowed in result builders.
--->
+Inside a result builder,
+conditional expressions can appear
+only as the initial value of a variable or constant.
+This behavior means when you write `if` or `switch` in a result builder,
+outside of a variable or constant declaration,
+that code is understood as a branch statement
+and one of the result builder's methods transforms that code.
 
 Don't put a conditional expression in a `try` expression,
 even if one of the branches of a conditional expression is throwing.
@@ -996,7 +996,7 @@ even if one of the branches of a conditional expression is throwing.
 >
 > *if-expression-tail* → **`else`** *if-expression*
 >
-> *if-expression-tail* → **`else`** *condition-list* **`{`** *statement* **`}`** *if-expression-tail*
+> *if-expression-tail* → **`else`** **`{`** *statement* **`}`** *if-expression-tail*
 >
 >
 >

--- a/TSPL.docc/ReferenceManual/Expressions.md
+++ b/TSPL.docc/ReferenceManual/Expressions.md
@@ -921,6 +921,41 @@ to make use of the implementation in their superclass.
 >
 > *superclass-initializer-expression* → **`super`** **`.`** **`init`**
 
+### Conditional Expression
+
+A *conditional expression* XXX
+
+A conditional expression can appear only in the following contexts:
+
+- As the value assigned to a variable.
+- As the initial value in a variable or constant declaration.
+- As the value returned by a function, closure, or property getter.
+
+<!--
+OUTLINE
+
+- each branch must be a single expression -- except for branches that throw or trap
+- each branch must produce a value of the same type -- and must typecheck independently
+- an 'if' must have an 'else' -- does a 'switch' have to have a default?
+- conditional expressions can't be used inside a result builder
+-->
+
+> Grammar of a conditional expression:
+>
+> *if-expression* → **`if`** *condition-list* **`{`** expression **`}`** *if-expression-tail*
+> *if-expression-tail* → **`else`** *condition-list* **`{`** expression **`}`** *if-expression-tail*
+> *if-expression-tail* → **`else`** *if-expression*
+>
+>
+>
+> *switch-expression* → **`switch`** *expression* **`{`** *switch-expression-cases* **`}`**
+>
+> *switch-expression-cases* → *switch-expression-case* *switch-expression-cases*_?_
+>
+> *switch-expression-case* → *case-label* *expression*
+>
+> *switch-expression-case* → *default-label* *expression*
+
 ### Closure Expression
 
 A *closure expression* creates a closure,

--- a/TSPL.docc/ReferenceManual/Expressions.md
+++ b/TSPL.docc/ReferenceManual/Expressions.md
@@ -936,7 +936,7 @@ OUTLINE
 
 - each branch must be a single expression -- except for branches that throw or trap
 - each branch must produce a value of the same type -- and must typecheck independently
-- an 'if' must have an 'else' -- does a 'switch' have to have a default?
+- an 'if' must have an 'else' -- 'switch' must be exhaustive
 - conditional expressions can't be used inside a result builder
 -->
 

--- a/TSPL.docc/ReferenceManual/Expressions.md
+++ b/TSPL.docc/ReferenceManual/Expressions.md
@@ -969,7 +969,18 @@ with the following differences:
 - Each branch must produce a value of the same type.
   Type checking of each branch happens independently.
 
+  <!--
+  XXX If you use literals of different types on different branches
+  or you include a nil literal,
+  you need to provide type context so those will type check.
+  -->
+
 - A conditional expression can't appear inside a result builder.
+
+  <!--
+  XXX  But the SE proposal also says:
+  The variable declaration form of an if will be allowed in result builders.
+  -->
 
 > Grammar of a conditional expression:
 >

--- a/TSPL.docc/ReferenceManual/Expressions.md
+++ b/TSPL.docc/ReferenceManual/Expressions.md
@@ -950,23 +950,28 @@ A conditional expression
 has the same behavior and syntax as an if statement or switch statement,
 with the following differences:
 
-- A conditional expression can appear only in the following contexts:
+- A conditional expression appears only in the following contexts:
 
     - As the value assigned to a variable.
 
     - As the initial value in a variable or constant declaration.
 
+    - As the error thrown by a `throw` expression.
+
     - As the value returned by a function, closure, or property getter.
 
-- Each branch must contain a single expression,
+- Each branch contains either a single expression,
   which is used as the value for the conditional expression
-  when that branch's conditional is true.
+  when that branch's conditional is true,
+  a `throw` statement,
+  or a call to a function that never returns.
+  <!--
+  You can't add precondition() to a branch before the expression.
+  -->
 
-  <!-- XXX can also include throw or fatalError() and so on -->
+- Each `if` branch has a corresponding `else` branch.
 
-- An `if` branch must have a corresponding `else` branch.
-
-- Each branch must produce a value of the same type.
+- Each branch produces a value of the same type.
   Type checking of each branch happens independently.
 
   <!--
@@ -982,11 +987,28 @@ with the following differences:
   The variable declaration form of an if will be allowed in result builders.
   -->
 
+Don't put a conditional expression in a `try` expression,
+even if one of the branches of a conditional expression is throwing.
+
+<!--
+XXX The SE proposal says this isn't required,
+but in my testing I see it's actually an error.
+
+In the case where a branch throws,
+either because a call in the expression throws
+(which requires a try)
+or with an explicit throw,
+there is no requirement to mark the overall expression
+with an additional try (e.g. before the if).
+-->
+
 > Grammar of a conditional expression:
 >
-> *if-expression* → **`if`** *condition-list* **`{`** expression **`}`** *if-expression-tail*
-> *if-expression-tail* → **`else`** *condition-list* **`{`** expression **`}`** *if-expression-tail*
+> *if-expression* → **`if`** *condition-list* **`{`** *statement* **`}`** *if-expression-tail*
+>
 > *if-expression-tail* → **`else`** *if-expression*
+>
+> *if-expression-tail* → **`else`** *condition-list* **`{`** *statement* **`}`** *if-expression-tail*
 >
 >
 >
@@ -994,9 +1016,9 @@ with the following differences:
 >
 > *switch-expression-cases* → *switch-expression-case* *switch-expression-cases*_?_
 >
-> *switch-expression-case* → *case-label* *expression*
+> *switch-expression-case* → *case-label* *statement*
 >
-> *switch-expression-case* → *default-label* *expression*
+> *switch-expression-case* → *default-label* *statement*
 
 ### Closure Expression
 

--- a/TSPL.docc/ReferenceManual/Expressions.md
+++ b/TSPL.docc/ReferenceManual/Expressions.md
@@ -923,22 +923,53 @@ to make use of the implementation in their superclass.
 
 ### Conditional Expression
 
-A *conditional expression* XXX
+A *conditional expression* evaluates to one of several given values
+based on the value of a condition.
+It has one the following forms:
 
-A conditional expression can appear only in the following contexts:
+```swift
+if <#condition 1#> {
+   <#expression used if condition 1 is true#>
+} else if <#condition 2#> {
+   <#expression used if condition 2 is true#>
+} else {
+   <#expression used if both conditions are false#>
+}
 
-- As the value assigned to a variable.
-- As the initial value in a variable or constant declaration.
-- As the value returned by a function, closure, or property getter.
+switch <#expression#> {
+case <#pattern 1#>:
+    <#expression 1#>
+case <#pattern 2#> where <#condition#>:
+    <#expression 2#>
+default:
+    <#expression 3#>
+}
+```
 
-<!--
-OUTLINE
+A conditional expression
+has the same behavior and syntax as an if statement or switch statement,
+with the following differences:
 
-- each branch must be a single expression -- except for branches that throw or trap
-- each branch must produce a value of the same type -- and must typecheck independently
-- an 'if' must have an 'else' -- 'switch' must be exhaustive
-- conditional expressions can't be used inside a result builder
--->
+- A conditional expression can appear only in the following contexts:
+
+    - As the value assigned to a variable.
+
+    - As the initial value in a variable or constant declaration.
+
+    - As the value returned by a function, closure, or property getter.
+
+- Each branch must contain a single expression,
+  which is used as the value for the conditional expression
+  when that branch's conditional is true.
+
+  <!-- XXX can also include throw or fatalError() and so on -->
+
+- An `if` branch must have a corresponding `else` branch.
+
+- Each branch must produce a value of the same type.
+  Type checking of each branch happens independently.
+
+- A conditional expression can't appear inside a result builder.
 
 > Grammar of a conditional expression:
 >

--- a/TSPL.docc/ReferenceManual/Expressions.md
+++ b/TSPL.docc/ReferenceManual/Expressions.md
@@ -973,12 +973,16 @@ or a call to a function that never returns.
 
 Each branch must produce a value of the same type.
 Because type checking of each branch is independent,
-conditional expressions that that include a `nil` literal
-or different kinds of literals typically need type context,
-like an explicit type annotation.
+you sometimes need to add type context,
+like when branches include different kinds of literals,
+or when a branch's value is `nil`.
+To provide this type context,
+add a type annotation to the variable that the result is assigned to,
+or add an `as` cast to the branches' values.
 
 ```swift
-let number: Double = if someCondition { 10 } else {12.34 }
+let number: Double = if someCondition { 10 } else { 12.34 }
+let number = if someCondition { 10 as Double } else { 12.34 }
 ```
 
 Inside a result builder,

--- a/TSPL.docc/ReferenceManual/Expressions.md
+++ b/TSPL.docc/ReferenceManual/Expressions.md
@@ -950,7 +950,7 @@ default:
 
 A conditional expression
 has the same behavior and syntax as an `if` statement or a `switch` statement,
-except for the differences listed below.
+except for the differences that the paragraphs below describe.
 
 A conditional expression appears only in the following contexts:
 

--- a/TSPL.docc/ReferenceManual/Expressions.md
+++ b/TSPL.docc/ReferenceManual/Expressions.md
@@ -554,6 +554,8 @@ to make prefix expressions, infix expressions, and postfix expressions.
 >
 > *primary-expression* → *superclass-expression*
 >
+> *primary-expression* → *conditional-expression*
+>
 > *primary-expression* → *closure-expression*
 >
 > *primary-expression* → *parenthesized-expression*
@@ -991,6 +993,10 @@ Don't put a conditional expression in a `try` expression,
 even if one of the branches of a conditional expression is throwing.
 
 > Grammar of a conditional expression:
+>
+> *conditional-expression* → *if-expression* | *switch-expression*
+>
+>
 >
 > *if-expression* → **`if`** *condition-list* **`{`** *statement* **`}`** *if-expression-tail*
 >

--- a/TSPL.docc/ReferenceManual/Expressions.md
+++ b/TSPL.docc/ReferenceManual/Expressions.md
@@ -973,10 +973,10 @@ or a call to a function that never returns.
 
 Each branch must produce a value of the same type.
 Because type checking of each branch is independent,
-you sometimes need to add type context,
+you sometimes need to specify the value's type explicitly,
 like when branches include different kinds of literals,
 or when a branch's value is `nil`.
-To provide this type context,
+When you need to provide this information,
 add a type annotation to the variable that the result is assigned to,
 or add an `as` cast to the branches' values.
 
@@ -988,8 +988,8 @@ let number = if someCondition { 10 as Double } else { 12.34 }
 Inside a result builder,
 conditional expressions can appear
 only as the initial value of a variable or constant.
-This behavior means when you write `if` or `switch` in a result builder,
-outside of a variable or constant declaration,
+This behavior means when you write `if` or `switch` in a result builder ---
+outside of a variable or constant declaration ---
 that code is understood as a branch statement
 and one of the result builder's methods transforms that code.
 

--- a/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
+++ b/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
@@ -565,6 +565,8 @@ make the same change here also.
 >
 > *primary-expression* → *superclass-expression*
 >
+> *primary-expression* → *conditional-expression*
+>
 > *primary-expression* → *closure-expression*
 >
 > *primary-expression* → *parenthesized-expression*
@@ -641,11 +643,15 @@ make the same change here also.
 
 > Grammar of a conditional expression:
 >
+> *conditional-expression* → *if-expression* | *switch-expression*
+>
+>
+>
 > *if-expression* → **`if`** *condition-list* **`{`** *statement* **`}`** *if-expression-tail*
 >
 > *if-expression-tail* → **`else`** *if-expression*
 >
-> *if-expression-tail* → **`else`** *condition-list* **`{`** *statement* **`}`** *if-expression-tail*
+> *if-expression-tail* → **`else`** **`{`** *statement* **`}`** *if-expression-tail*
 >
 >
 >

--- a/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
+++ b/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
@@ -639,6 +639,24 @@ make the same change here also.
 >
 > *superclass-initializer-expression* → **`super`** **`.`** **`init`**
 
+> Grammar of a conditional expression:
+>
+> *if-expression* → **`if`** *condition-list* **`{`** *statement* **`}`** *if-expression-tail*
+>
+> *if-expression-tail* → **`else`** *if-expression*
+>
+> *if-expression-tail* → **`else`** *condition-list* **`{`** *statement* **`}`** *if-expression-tail*
+>
+>
+>
+> *switch-expression* → **`switch`** *expression* **`{`** *switch-expression-cases* **`}`**
+>
+> *switch-expression-cases* → *switch-expression-case* *switch-expression-cases*_?_
+>
+> *switch-expression-case* → *case-label* *statement*
+>
+> *switch-expression-case* → *default-label* *statement*
+
 > Grammar of a closure expression:
 >
 > *closure-expression* → **`{`** *attributes*_?_ *closure-signature*_?_ *statements*_?_ **`}`**


### PR DESCRIPTION
Added a brief example of this syntax in the tour.

Added examples of this syntax alongside the existing `if` and `switch` statements in the guide.  I opted to explain it inline, rather than adding a new "If/Switch Expressions" section, because I think that will age better.  Today, this syntax is salient because it's new, but after a few years it will just be part of the language — and in the latter context, integrating it gives a better learning path.

Added a new "Conditional Expressions" section to the reference, which leans heavily on the existing "Conditional Statements" section but calls out the differences in behavior and requirements, and which describes the formal grammar of `conditional-expression`.

Fixes: rdar://104936324
