### PR TITLE
Update URLs that now redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains a version of *The Swift Programming Language*
 that you can build using Swift-DocC.
 
-The version of *The Swift Programming Language* published on [docs.swift.org](https://docs.swift.org/swift-book/)
+The version of *The Swift Programming Language* published on [docs.swift.org](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/)
 is currently built using a legacy toolchain,
 not from this repository or its content.
 The goal is to replace that version with a version built from this repository,

--- a/TSPL.docc/header-staging.html
+++ b/TSPL.docc/header-staging.html
@@ -16,7 +16,7 @@ See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
             This is the development version of <em>The Swift Programming Language</em> book.
         </p>
         <p>
-            For the current shipping book, see <a href="https://docs.swift.org/swift-book/">Swift.org</a>.
+            For the current shipping book, see <a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/">Swift.org</a>.
             To contribute to this documentation, see the <a href="https://github.com/apple/swift-book">swift-book project</a> on GitHub.
         </p>
         </aside>


### PR DESCRIPTION
<!-- What's in this pull request? -->
There are several links to the previous url where the Swift book was published, this PR here just gets rid of the main offender in the README. i'm hesitant to touch the other links, so i'll just drop this search for posterity: https://github.com/search?q=repo%3Aapple%2Fswift-book%20https%3A%2F%2Fdocs.swift.org%2Fswift-book%2F&type=code

<!-- If this pull request fixes a bug tracked in GitHub issues, provide the link. -->
as per https://github.com/apple/swift-book/issues/72

<!--
Before merging this pull request, you must run the continuous integration (CI) tests.
When you're ready to start a CI build,
write the following in a comment on the pull request:

    @swift-ci Please test.

For more information about triggering CI builds via @swift-ci, see:

    https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution!
-->
