### PR TITLE
Show multiline string with indentation in the tour

### DIFF
--- a/TSPL.docc/GuidedTour/GuidedTour.md
+++ b/TSPL.docc/GuidedTour/GuidedTour.md
@@ -171,9 +171,13 @@ For example:
 
 ```swift
 let quotation = """
-I said "I have \(apples) apples."
-And then I said "I have \(apples + oranges) pieces of fruit."
-"""
+        Even though there's whitespace to the left,
+        the actual lines aren't indented.
+            Except for this line.
+        Double quotes (") can appear without being escaped.
+
+        I still have \(apples + oranges) pieces of fruit.
+        """
 ```
 
 <!--

--- a/TSPL.docc/LanguageGuide/StringsAndCharacters.md
+++ b/TSPL.docc/LanguageGuide/StringsAndCharacters.md
@@ -198,10 +198,8 @@ that whitespace *is* included.
 ![](multilineStringWhitespace)
 
 <!--
-  Using an image here is a little clearer,
-  since it can call out which spaces "count",
-  but it also works around
-  <rdar://problem/32463195> Multiline string literals lose (meaningful) indentation
+  Using an image here is a little clearer than a code listing,
+  since it can call out which spaces "count".
 -->
 
 <!--

--- a/TSPL.docc/ReferenceManual/Expressions.md
+++ b/TSPL.docc/ReferenceManual/Expressions.md
@@ -2918,15 +2918,6 @@ let numbers = [10, 20, 33, 43, 50]
   ```
 -->
 
-<!--
-  The indentation gets lost for the .filter lines above
-  even if I start them with -> instead of three spaces
-  because that's how swift-format re-indents them.
-  This is probably not the same issue as
-  <rdar://problem/32463195> for multiline string literals,
-  but they're likely related.
--->
-
 Between `#if`, `#endif`, and other compilation directives,
 the conditional compilation block can contain
 an implicit member expression


### PR DESCRIPTION
A bug in the legacy publication pipeline used to make this code listing render without the indentation, preventing us from using it.  That's no longer the case under DocC, so let's put back the richer example.

Fixes rdar://34530402