### PR TITLE
Match the prose order in code voice

### DIFF
--- a/TSPL.docc/LanguageGuide/Enumerations.md
+++ b/TSPL.docc/LanguageGuide/Enumerations.md
@@ -453,7 +453,7 @@ case .qrCode(let productCode):
 
 If all of the associated values for an enumeration case
 are extracted as constants, or if all are extracted as variables,
-you can place a single `var` or `let` annotation before the case name, for brevity:
+you can place a single `let` or `var` annotation before the case name, for brevity:
 
 ```swift
 switch productBarcode {


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR fixes a tiny text mistake in the sentence that you can find in the section [Associated Values](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/enumerations/#Associated-Values) of the chapter "Enumerations"

> If all of the associated values for an enumeration case are extracted as constants, or if all are extracted as variables, you can place a single `var` or `let` annotation before the case name, for brevity:

This PR swaps `var` and `let` annotation places in the sentence above.

<!-- If this pull request fixes a bug tracked in GitHub issues, provide the link. -->
Fixes https://github.com/apple/swift-book/issues/124


<!--
Before merging this pull request, you must run the continuous integration (CI) tests.
When you're ready to start a CI build,
write the following in a comment on the pull request:

    @swift-ci Please test.

For more information about triggering CI builds via @swift-ci, see:

    https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution!
-->
