### PR TITLE
Generate a tags file for navigation while editing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 /.build
 /Package.resolved
 /TSPL.docc/header.html
+/TSPL.docc/tags
 /swift-book

--- a/bin/make_tags
+++ b/bin/make_tags
@@ -1,10 +1,10 @@
 #! /usr/bin/env python3
 
 # This source file is part of the Swift.org open source project
-# 
+#
 # Copyright (c) 2023 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
-# 
+#
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 

--- a/bin/make_tags
+++ b/bin/make_tags
@@ -1,5 +1,13 @@
 #! /usr/bin/env python3
 
+# This source file is part of the Swift.org open source project
+# 
+# Copyright (c) 2023 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+# 
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+
 """
 Generates a tags file for navigation in editors by DocC links and within
 the formal grammar.

--- a/bin/make_tags
+++ b/bin/make_tags
@@ -4,12 +4,7 @@
 Generates a tags file for navigation in editors by DocC links and within
 the formal grammar.
 
-Output uses the POSIX ctags syntax, but needs a post-processing step to
-sort it.
-
-Run this script as:
-
-    bin/make_tags | sort > TSPL.docc/tags
+Output uses the POSIX ctags syntax.
 
 To use these tags, configure your editor to include a-z, A-Z, pound (#),
 hyphen (-), and colon (:), as valid characters in a tag.
@@ -23,6 +18,7 @@ HEADING_REGEX = re.compile(r'^#+ ')
 GRAMMAR_REGEX = re.compile(r'^> \*[a-z-]*\* → ')
 
 chapter = None
+tags = []
 
 os.chdir('TSPL.docc')
 for root, dirs, files in os.walk('.'):
@@ -40,14 +36,18 @@ for root, dirs, files in os.walk('.'):
                     chapter = line.lstrip('# ').replace(' ', '')
                     tag = 'doc:' + chapter
                     search =  '/^' + line + '/'
-                    print(tag + '\t' + path + '\t' + search)
+                    tags.append(tag + '\t' + path + '\t' + search + '\n')
                 elif HEADING_REGEX.match(line):
                     heading = line.lstrip('# ').replace(' ', '-')
                     tag = 'doc:' + chapter + '#' + heading
                     search =  '/^' + line + '/'
-                    print(tag + '\t' + path + '\t' + search)
+                    tags.append(tag + '\t' + path + '\t' + search + '\n')
                 elif GRAMMAR_REGEX.match(line):
                     tag, _ = line.split('→')
                     tag = tag.lstrip('*> ').rstrip('* ')
                     search = '/*' + tag + '* →/'
-                    print(tag + '\t' + path + '\t' + search)
+                    tags.append(tag + '\t' + path + '\t' + search + '\n')
+
+tags.sort()
+with open('tags', 'w', encoding='utf8') as tags_file:
+    tags_file.writelines(tags)

--- a/bin/make_tags
+++ b/bin/make_tags
@@ -35,17 +35,17 @@ for root, dirs, files in os.walk('.'):
                 if CHAPTER_REGEX.match(line):
                     chapter = line.lstrip('# ').replace(' ', '')
                     tag = 'doc:' + chapter
-                    search =  '/^' + line + '/'
+                    search =  '/^' + line.replace('/', '\\/') + '/'
                     tags.append(tag + '\t' + path + '\t' + search + '\n')
                 elif HEADING_REGEX.match(line):
                     heading = line.lstrip('# ').replace(' ', '-')
                     tag = 'doc:' + chapter + '#' + heading
-                    search =  '/^' + line + '/'
+                    search =  '/^' + line.replace('/', '\\/') + '/'
                     tags.append(tag + '\t' + path + '\t' + search + '\n')
                 elif GRAMMAR_REGEX.match(line):
                     tag, _ = line.split('→')
                     tag = tag.lstrip('*> ').rstrip('* ')
-                    search = '/*' + tag + '* →/'
+                    search = '/*' + tag.replace('/', '\\/') + '* →/'
                     tags.append(tag + '\t' + path + '\t' + search + '\n')
 
 tags.sort()

--- a/bin/make_tags
+++ b/bin/make_tags
@@ -9,10 +9,9 @@
 # See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 """
-Generates a tags file for navigation in editors by DocC links and within
-the formal grammar.
-
-Output uses the POSIX ctags syntax.
+Generates a tags file, using the POSIX ctags syntax, for navigation while
+editing.  The tags file provides "jump to definition" information about DocC
+links to headings and syntactic categories in the formal grammar.
 
 To use these tags, configure your editor to include a-z, A-Z, pound (#),
 hyphen (-), and colon (:), as valid characters in a tag.

--- a/bin/make_tags
+++ b/bin/make_tags
@@ -1,0 +1,53 @@
+#! /usr/bin/env python3
+
+"""
+Generates a tags file for navigation in editors by DocC links and within
+the formal grammar.
+
+Output uses the POSIX ctags syntax, but needs a post-processing step to
+sort it.
+
+Run this script as:
+
+    bin/make_tags | sort > TSPL.docc/tags
+
+To use these tags, configure your editor to include a-z, A-Z, pound (#),
+hyphen (-), and colon (:), as valid characters in a tag.
+"""
+
+import os
+import re
+
+CHAPTER_REGEX = re.compile(r'^# ')
+HEADING_REGEX = re.compile(r'^#+ ')
+GRAMMAR_REGEX = re.compile(r'^> \*[a-z-]*\* → ')
+
+chapter = None
+
+os.chdir('TSPL.docc')
+for root, dirs, files in os.walk('.'):
+    for file in files:
+        if not file.endswith('.md'):
+            continue
+        if file == 'SummaryOfTheGrammar.md':
+            continue
+        path = os.path.join(root, file)
+        with open(path, encoding='utf8') as f:
+            chapter = None
+            for line in f:
+                line = line.rstrip()
+                if CHAPTER_REGEX.match(line):
+                    chapter = line.lstrip('# ').replace(' ', '')
+                    tag = 'doc:' + chapter
+                    search =  '/^' + line + '/'
+                    print(tag + '\t' + path + '\t' + search)
+                elif HEADING_REGEX.match(line):
+                    heading = line.lstrip('# ').replace(' ', '-')
+                    tag = 'doc:' + chapter + '#' + heading
+                    search =  '/^' + line + '/'
+                    print(tag + '\t' + path + '\t' + search)
+                elif GRAMMAR_REGEX.match(line):
+                    tag, _ = line.split('→')
+                    tag = tag.lstrip('*> ').rstrip('* ')
+                    search = '/*' + tag + '* →/'
+                    print(tag + '\t' + path + '\t' + search)

--- a/bin/make_tags.swift
+++ b/bin/make_tags.swift
@@ -1,0 +1,53 @@
+#! /usr/bin/env python3
+
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+/*
+Generates a tags file, using the POSIX ctags syntax, for navigation while
+editing.  The tags file provides "jump to definition" information about DocC
+links to headings and syntactic categories in the formal grammar.
+
+To use these tags, configure your editor to include a-z, A-Z, pound (#),
+hyphen (-), and colon (:), as valid characters in a tag.
+*/
+
+import Foundation
+
+let chapterRegex = try Regex("^# (.*)")
+let headingRegex = try Regex("^#+ ")
+let grammarRegex = try Regex(#"^> \*[a-z-]*\* → "#)
+
+var chapter: String? = nil
+var tags: [String] = []
+
+let basePath = "TSPL.docc/"
+let fileManager = FileManager()
+let fileEnumerator = fileManager.enumerator(atPath: basePath)!
+for case let path as String in fileEnumerator {
+    guard path.hasSuffix(".md") else { continue }
+    guard path != "ReferenceManual/SummaryOfTheGrammar.md" else { continue }
+    print(path)
+
+    let fileContents = try String(contentsOfFile: basePath + path, encoding: .utf8)
+    chapter = nil
+    for line in fileContents.split(separator: "\n") {
+        if let match = line.firstMatch(of: chapterRegex) {
+            let chapter = match.0
+            let tag = "doc:" + chapter
+            let search =  "/^" + line.replacingOccurances(of: "/", with: "\\/") + "/"
+            tags.append(tag + "\t" + path + "\t" + search + "\n")
+        } else if let match = line.firstMatch(of: headingRegex) {
+
+        } else if let match = line.firstMatch(of: grammarRegex) {
+
+        }
+    }
+}
+
+print(tags)


### PR DESCRIPTION
The output uses using the POSIX ctags syntax, and enables "jump to definition" for DocC links and for syntactic categories in the formal grammar.  From testing with a few different editors, here's what I saw:

- In Vim, you have to configure `setlocal iskeyword+=#,:,-` to allow those characters as part a tag.  Then both links and grammar works.  Classic `vi` supports tag files, but doesn't have `iskeyword`, so other `vi`-like editors might not be able to follow tags.
- In BBedit, links work without configuration changes.  I wasn't able to get grammar to work, likely because it doesn't consider `-` as part of a tag.
- Emacs has support for tags files, but it seems to need a module or configuration change to handle the ctags syntax instead of its preferred etags syntax.
- Xcode uses its own indexing for navigation, not a tags file.

Marking this as a draft for now.  I'd like to consider rewriting the script in Swift.