### PR TITLE
Fix release date error

### DIFF
--- a/TSPL.docc/RevisionHistory/RevisionHistory.md
+++ b/TSPL.docc/RevisionHistory/RevisionHistory.md
@@ -2,7 +2,7 @@
 
 Review the recent changes to this book.
 
-**2023-04-30**
+**2023-03-30**
 
 - Updated for Swift 5.8.
 - Added the <doc:ControlFlow#Deferred-Actions> section,


### PR DESCRIPTION
<!-- What's in this pull request? -->
I know that Swift 5.8 release date is Mar 30. But wrong date is displayed to swift-book revision history.
Please check this!
Thank you.

<!-- If this pull request fixes a bug tracked in GitHub issues, provide the link. -->


<!--
Before merging this pull request, you must run the continuous integration (CI) tests.
When you're ready to start a CI build,
write the following in a comment on the pull request:

    @swift-ci Please test.

For more information about triggering CI builds via @swift-ci, see:

    https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution!
-->
