### PR TITLE
Add a forward reference about extensions

### DIFF
--- a/TSPL.docc/LanguageGuide/Inheritance.md
+++ b/TSPL.docc/LanguageGuide/Inheritance.md
@@ -510,7 +510,7 @@ Any attempt to override a final method, property, or subscript in a subclass
 is reported as a compile-time error.
 Methods, properties, or subscripts that you add to a class in an extension
 can also be marked as final within the extension's definition.
-For more information about extensions, see <doc:Extensions>.
+For more information, see <doc:Extensions>.
 
 <!--
   - test: `finalPreventsOverriding`

--- a/TSPL.docc/LanguageGuide/Inheritance.md
+++ b/TSPL.docc/LanguageGuide/Inheritance.md
@@ -510,6 +510,7 @@ Any attempt to override a final method, property, or subscript in a subclass
 is reported as a compile-time error.
 Methods, properties, or subscripts that you add to a class in an extension
 can also be marked as final within the extension's definition.
+For more information about extensions, see <doc:Extensions>.
 
 <!--
   - test: `finalPreventsOverriding`


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR inserts a sentence that explains an extra link about `extension` in the section [Preventing Overrides](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/inheritance#Preventing-Overrides) of the chapter "Inheritance".
"Extension" is mentioned here for the first time. Therefore, it is appropriate to attach a link to it.

To be honest, it is not the first time. You might already find some examples in the Swift Tour, and the chapter "The Basics".
Nonetheless, this time it is mentioned without the link in advance of the chapter "Extensions".
As such, it would be better to have a link.