### PR TITLE
Don't escape backslashes in code voice

### DIFF
--- a/TSPL.docc/LanguageGuide/StringsAndCharacters.md
+++ b/TSPL.docc/LanguageGuide/StringsAndCharacters.md
@@ -229,7 +229,7 @@ String literals can include the following special characters:
 - The escaped special characters `\0` (null character), `\\` (backslash),
   `\t` (horizontal tab), `\n` (line feed), `\r` (carriage return),
   `\"` (double quotation mark) and `\'` (single quotation mark)
-- An arbitrary Unicode scalar value, written as `\\u{`*n*`}`,
+- An arbitrary Unicode scalar value, written as `\u{`*n*`}`,
   where *n* is a 1--8 digit hexadecimal number
   (Unicode is discussed in <doc:StringsAndCharacters#Unicode> below)
 

--- a/TSPL.docc/ReferenceManual/LexicalStructure.md
+++ b/TSPL.docc/ReferenceManual/LexicalStructure.md
@@ -786,7 +786,7 @@ using the following escape sequences:
 - Carriage return (`\r`)
 - Double quotation mark (`\"`)
 - Single quotation mark (`\'`)
-- Unicode scalar (`\\u{`*n*`}`),
+- Unicode scalar (`\u{`*n*`}`),
   where *n* is a hexadecimal number
   that has one to eight digits
 


### PR DESCRIPTION
Per the [CommonMark spec](spec), you don't escape backslashes when they appear in in code voice.  This was probably a bug in the RST-to-markdown export.

Searched the Render JSON output from DoC to confirm that the remaining escaped backslashes are only in places where TSPL is discussing how to escape a backslash in code, and we actually want to see two backslashes in the output.

Fixes rdar://107326096

[spec]: https://spec.commonmark.org/0.30/#backslash-escapes
