### PR TITLE
Various minor changes

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -16,3 +16,6 @@
 
 # Convert RST to markdown.
 96f0925407c6bd9eadd9d58d253bad3e1ef7a9f2
+
+# Convert the formal grammar to markdown.
+4039ee0ef4e69d2cf6460861f9444a499503db16

--- a/.git-order-file
+++ b/.git-order-file
@@ -1,0 +1,65 @@
+# This file lists the chapters of TSPL, in the order they appear in the
+# book.  When reviewing changes, the diff can be easier to read when it
+# appears in this order.
+#
+# To use this file for single command, run a command like the following:
+#
+#     git log -O .git-order-file
+#     git diff -O .git-order-file
+#
+# To use it for all diffs, run the following command:
+#
+#     git config --local diff.orderFile .git-order-file
+#
+# For more information, see the git-log(1) and git-diff(1) man pages'
+# discussions of the -O option, and the git-config(1) man page's
+# discussion of diff.orderFile option.
+
+TSPL.docc/GuidedTour/AboutSwift.md
+TSPL.docc/GuidedTour/Compatibility.md
+TSPL.docc/GuidedTour/GuidedTour.md
+
+TSPL.docc/LanguageGuide/TheBasics.md
+TSPL.docc/LanguageGuide/BasicOperators.md
+TSPL.docc/LanguageGuide/StringsAndCharacters.md
+TSPL.docc/LanguageGuide/CollectionTypes.md
+TSPL.docc/LanguageGuide/ControlFlow.md
+TSPL.docc/LanguageGuide/Functions.md
+TSPL.docc/LanguageGuide/Closures.md
+TSPL.docc/LanguageGuide/Enumerations.md
+TSPL.docc/LanguageGuide/ClassesAndStructures.md
+TSPL.docc/LanguageGuide/Properties.md
+TSPL.docc/LanguageGuide/Methods.md
+TSPL.docc/LanguageGuide/Subscripts.md
+TSPL.docc/LanguageGuide/Inheritance.md
+TSPL.docc/LanguageGuide/Initialization.md
+TSPL.docc/LanguageGuide/Deinitialization.md
+TSPL.docc/LanguageGuide/OptionalChaining.md
+TSPL.docc/LanguageGuide/ErrorHandling.md
+TSPL.docc/LanguageGuide/Concurrency.md
+TSPL.docc/LanguageGuide/Macros.md
+TSPL.docc/LanguageGuide/TypeCasting.md
+TSPL.docc/LanguageGuide/NestedTypes.md
+TSPL.docc/LanguageGuide/Extensions.md
+TSPL.docc/LanguageGuide/Protocols.md
+TSPL.docc/LanguageGuide/Generics.md
+TSPL.docc/LanguageGuide/OpaqueTypes.md
+TSPL.docc/LanguageGuide/AutomaticReferenceCounting.md
+TSPL.docc/LanguageGuide/MemorySafety.md
+TSPL.docc/LanguageGuide/AccessControl.md
+TSPL.docc/LanguageGuide/AdvancedOperators.md
+
+TSPL.docc/ReferenceManual/AboutTheLanguageReference.md
+TSPL.docc/ReferenceManual/LexicalStructure.md
+TSPL.docc/ReferenceManual/Types.md
+TSPL.docc/ReferenceManual/Expressions.md
+TSPL.docc/ReferenceManual/Statements.md
+TSPL.docc/ReferenceManual/Declarations.md
+TSPL.docc/ReferenceManual/Attributes.md
+TSPL.docc/ReferenceManual/Patterns.md
+TSPL.docc/ReferenceManual/GenericParametersAndArguments.md
+TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
+
+TSPL.docc/RevisionHistory/RevisionHistory.md
+
+# Files that don't match a pattern listed above appear at the end.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,4 +2,4 @@
 Replace this paragraph with your rationale and a brief summary of what changed.
 
 <!-- If this pull request fixes a bug tracked in GitHub issues, provide the link. -->
-Fixes https://github.com/apple/swift-book/issues/####
+Fixes: https://github.com/apple/swift-book/issues/####

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,18 +3,3 @@ Replace this paragraph with your rationale and a brief summary of what changed.
 
 <!-- If this pull request fixes a bug tracked in GitHub issues, provide the link. -->
 Fixes https://github.com/apple/swift-book/issues/####
-
-
-<!--
-Before merging this pull request, you must run the continuous integration (CI) tests.
-When you're ready to start a CI build,
-write the following in a comment on the pull request:
-
-    @swift-ci Please test.
-
-For more information about triggering CI builds via @swift-ci, see:
-
-    https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci
-
-Thank you for your contribution!
--->

--- a/TSPL.docc/GuidedTour/AboutSwift.md
+++ b/TSPL.docc/GuidedTour/AboutSwift.md
@@ -48,6 +48,12 @@ and it continues to evolve with new features and capabilities.
 Our goals for Swift are ambitious.
 We can’t wait to see what you create with it.
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/GuidedTour/Compatibility.md
+++ b/TSPL.docc/GuidedTour/Compatibility.md
@@ -49,6 +49,12 @@ that's divided into multiple frameworks,
 you can migrate your code from Swift 4 to Swift 5.8
 one framework at a time.
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/GuidedTour/Compatibility.md
+++ b/TSPL.docc/GuidedTour/Compatibility.md
@@ -2,18 +2,18 @@
 
 Learn what functionality is available in older language modes.
 
-This book describes Swift 5.8,
+This book describes Swift 5.9,
 the default version of Swift that's included in Xcode 14.
 You can use Xcode 14 to build targets
-that are written in either Swift 5.8, Swift 4.2, or Swift 4.
+that are written in either Swift 5.9, Swift 4.2, or Swift 4.
 
 <!--
   - test: `swift-version`
 
   ```swifttest
-  >> #if swift(>=5.8.1)
+  >> #if swift(>=5.9.1)
   >>     print("Too new")
-  >> #elseif swift(>=5.8)
+  >> #elseif swift(>=5.9)
   >>     print("Just right")
   >> #else
   >>     print("Too old")
@@ -23,9 +23,9 @@ that are written in either Swift 5.8, Swift 4.2, or Swift 4.
 -->
 
 When you use Xcode 14 to build Swift 4 and Swift 4.2 code,
-most Swift 5.8 functionality is available.
+most Swift 5.9 functionality is available.
 That said,
-the following changes are available only to code that uses Swift 5.8 or later:
+the following changes are available only to code that uses Swift 5.9 or later:
 
 - Functions that return an opaque type require the Swift 5.1 runtime.
 - The `try?` expression doesn't introduce an extra level of optionality
@@ -35,18 +35,18 @@ the following changes are available only to code that uses Swift 5.8 or later:
   For example, `UInt64(0xffff_ffff_ffff_ffff)` evaluates to the correct value
   rather than overflowing.
 
-Concurrency requires Swift 5.8 or later,
+Concurrency requires Swift 5.9 or later,
 and a version of the Swift standard library
 that provides the corresponding concurrency types.
 On Apple platforms, set a deployment target
 of at least iOS 13, macOS 10.15, tvOS 13, or watchOS 6.
 
-A target written in Swift 5.8 can depend on
+A target written in Swift 5.9 can depend on
 a target that's written in Swift 4.2 or Swift 4,
 and vice versa.
 This means, if you have a large project
 that's divided into multiple frameworks,
-you can migrate your code from Swift 4 to Swift 5.8
+you can migrate your code from Swift 4 to Swift 5.9
 one framework at a time.
 
 > Beta Software:

--- a/TSPL.docc/GuidedTour/GuidedTour.md
+++ b/TSPL.docc/GuidedTour/GuidedTour.md
@@ -2366,6 +2366,12 @@ anyCommonElements([1, 2, 3], [3])
 Writing `<T: Equatable>`
 is the same as writing `<T> ... where T: Equatable`.
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/AccessControl.md
+++ b/TSPL.docc/LanguageGuide/AccessControl.md
@@ -1483,6 +1483,12 @@ but a public type alias can't alias an internal, file-private, or private type.
   ```
 -->
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/AdvancedOperators.md
+++ b/TSPL.docc/LanguageGuide/AdvancedOperators.md
@@ -1561,6 +1561,12 @@ see <doc:Attributes#resultBuilder>.
   TODO: generic operators
 -->
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/AutomaticReferenceCounting.md
+++ b/TSPL.docc/LanguageGuide/AutomaticReferenceCounting.md
@@ -1512,6 +1512,12 @@ paragraph = nil
 For more information about capture lists,
 see <doc:Expressions#Capture-Lists>.
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/BasicOperators.md
+++ b/TSPL.docc/LanguageGuide/BasicOperators.md
@@ -1231,6 +1231,12 @@ but the overall intention is clearer to the reader.
 Readability is always preferred over brevity;
 use parentheses where they help to make your intentions clear.
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/ClassesAndStructures.md
+++ b/TSPL.docc/LanguageGuide/ClassesAndStructures.md
@@ -710,6 +710,12 @@ see [Manual Memory Management](https://developer.apple.com/documentation/swift/s
   QUESTION: what's the deal with tuples and reference types / value types?
 -->
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/Closures.md
+++ b/TSPL.docc/LanguageGuide/Closures.md
@@ -1332,6 +1332,12 @@ As a result,
 the value of the `customerProvider` argument
 must be allowed to escape the function's scope.
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/CollectionTypes.md
+++ b/TSPL.docc/LanguageGuide/CollectionTypes.md
@@ -1469,6 +1469,12 @@ Swift's `Dictionary` type doesn't have a defined ordering.
 To iterate over the keys or values of a dictionary in a specific order,
 use the `sorted()` method on its `keys` or `values` property.
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/Concurrency.md
+++ b/TSPL.docc/LanguageGuide/Concurrency.md
@@ -1174,6 +1174,12 @@ struct TemperatureReading {
   but maybe link to them?
 -->
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/ControlFlow.md
+++ b/TSPL.docc/LanguageGuide/ControlFlow.md
@@ -2105,6 +2105,12 @@ when the check contains only fallback code.
   You can use it with if-let, and other Boolean conditions, using a comma
 -->
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/Deinitialization.md
+++ b/TSPL.docc/LanguageGuide/Deinitialization.md
@@ -242,6 +242,12 @@ and so it's deallocated in order to free up its memory.
 Just before this happens, its deinitializer is called automatically,
 and its coins are returned to the bank.
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/Enumerations.md
+++ b/TSPL.docc/LanguageGuide/Enumerations.md
@@ -830,6 +830,12 @@ by evaluating the expression on the left-hand side,
 evaluating the expression on the right-hand side,
 and then adding them or multiplying them.
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/ErrorHandling.md
+++ b/TSPL.docc/LanguageGuide/ErrorHandling.md
@@ -773,6 +773,12 @@ has a corresponding call to `close(_:)`.
 > Note: You can use a `defer` statement
 > even when no error handling code is involved.
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/Extensions.md
+++ b/TSPL.docc/LanguageGuide/Extensions.md
@@ -682,6 +682,12 @@ and prints an appropriate description.
 > can be written in shorthand form inside the `switch` statement,
 > such as `.negative` rather than `Int.Kind.negative`.
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/Functions.md
+++ b/TSPL.docc/LanguageGuide/Functions.md
@@ -323,8 +323,13 @@ but the returned value isn't used.
 > and attempting to do so will result in a compile-time error.
 
 <!--
-  FIXME Unless the function is marked @discardableResult,
-  ignoring its return value triggers a compile-time warning.
+FIXME Unless the function is marked @discardableResult,
+ignoring its return value triggers a compile-time warning.
+
+If the returned value is coincidental
+marking with @discardableResult is good,
+like array.removeFirst(...) ---
+otherwise, using `_ = foo()` at the call site is better.
 -->
 
 ### Functions with Multiple Return Values

--- a/TSPL.docc/LanguageGuide/Functions.md
+++ b/TSPL.docc/LanguageGuide/Functions.md
@@ -1299,6 +1299,12 @@ print("zero!")
   ```
 -->
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/Generics.md
+++ b/TSPL.docc/LanguageGuide/Generics.md
@@ -1964,6 +1964,12 @@ is a sequence of integers.
   TODO: Describe how Optional<Wrapped> works
 -->
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/Inheritance.md
+++ b/TSPL.docc/LanguageGuide/Inheritance.md
@@ -606,6 +606,12 @@ Any attempt to subclass a final class is reported as a compile-time error.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 -->
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/Initialization.md
+++ b/TSPL.docc/LanguageGuide/Initialization.md
@@ -2954,6 +2954,12 @@ print(board.squareIsBlackAt(row: 7, column: 7))
   ```
 -->
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/MemorySafety.md
+++ b/TSPL.docc/LanguageGuide/MemorySafety.md
@@ -742,6 +742,12 @@ it doesn't allow the access.
   on performance and memory usage.
 -->
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/Methods.md
+++ b/TSPL.docc/LanguageGuide/Methods.md
@@ -650,6 +650,12 @@ if player.tracker.advance(to: 6) {
   (see Doug's comments from the 2014-03-12 release notes)
 -->
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/NestedTypes.md
+++ b/TSPL.docc/LanguageGuide/NestedTypes.md
@@ -191,6 +191,12 @@ For the example above,
 this enables the names of `Suit`, `Rank`, and `Values` to be kept deliberately short,
 because their names are naturally qualified by the context in which they're defined.
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/OpaqueTypes.md
+++ b/TSPL.docc/LanguageGuide/OpaqueTypes.md
@@ -784,6 +784,12 @@ which means that the type of `twelve` is also inferred to be `Int`.
   }
 -->
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/OptionalChaining.md
+++ b/TSPL.docc/LanguageGuide/OptionalChaining.md
@@ -883,6 +883,12 @@ if let beginsWithThe =
   the sugar for optional protocol requirements works.
 -->
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/Properties.md
+++ b/TSPL.docc/LanguageGuide/Properties.md
@@ -2060,6 +2060,12 @@ print(AudioChannel.maxInputLevelForAllChannels)
   ```
 -->
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/Protocols.md
+++ b/TSPL.docc/LanguageGuide/Protocols.md
@@ -2670,6 +2670,12 @@ print(differentNumbers.allEqual())
   Checking for (and calling) optional implementations via optional binding and closures
 -->
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/StringsAndCharacters.md
+++ b/TSPL.docc/LanguageGuide/StringsAndCharacters.md
@@ -1785,6 +1785,12 @@ for scalar in dogString.unicodeScalars {
   ```
 -->
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/Subscripts.md
+++ b/TSPL.docc/LanguageGuide/Subscripts.md
@@ -422,6 +422,12 @@ print(mars)
   ```
 -->
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/TheBasics.md
+++ b/TSPL.docc/LanguageGuide/TheBasics.md
@@ -2038,6 +2038,12 @@ by one of the switch's other cases.
   but doesn't stop at assertions.
 -->
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/LanguageGuide/TypeCasting.md
+++ b/TSPL.docc/LanguageGuide/TypeCasting.md
@@ -522,6 +522,12 @@ for thing in things {
   ```
 -->
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/ReferenceManual/AboutTheLanguageReference.md
+++ b/TSPL.docc/ReferenceManual/AboutTheLanguageReference.md
@@ -49,6 +49,12 @@ where the alternatives are spelled out explicitly:
 >
 > *getter-setter-block* → **`{`** *setter-clause* *getter-clause* **`}`**
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/ReferenceManual/Attributes.md
+++ b/TSPL.docc/ReferenceManual/Attributes.md
@@ -2255,6 +2255,12 @@ see <doc:Statements#Switching-Over-Future-Enumeration-Cases>.
 >
 > *balanced-token* → Any punctuation except  **`(`**,  **`)`**,  **`[`**,  **`]`**,  **`{`**, or  **`}`**
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/ReferenceManual/Declarations.md
+++ b/TSPL.docc/ReferenceManual/Declarations.md
@@ -3843,6 +3843,12 @@ as discussed in <doc:AccessControl#Getters-and-Setters>.
 >
 > *actor-isolation-modifier* → **`nonisolated`**
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/ReferenceManual/Expressions.md
+++ b/TSPL.docc/ReferenceManual/Expressions.md
@@ -3257,6 +3257,12 @@ someDictionary["a"]?[0] = someFunctionWithSideEffects()
 >
 > *optional-chaining-expression* → *postfix-expression* **`?`**
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/ReferenceManual/GenericParametersAndArguments.md
+++ b/TSPL.docc/ReferenceManual/GenericParametersAndArguments.md
@@ -304,6 +304,12 @@ of a generic function or initializer.
 >
 > *generic-argument* → *type*
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/ReferenceManual/LexicalStructure.md
+++ b/TSPL.docc/ReferenceManual/LexicalStructure.md
@@ -1401,6 +1401,12 @@ see <doc:AdvancedOperators#Operator-Methods>.
 >
 > *postfix-operator* → *operator*
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/ReferenceManual/Patterns.md
+++ b/TSPL.docc/ReferenceManual/Patterns.md
@@ -500,6 +500,12 @@ default:
 >
 > *expression-pattern* → *expression*
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/ReferenceManual/Statements.md
+++ b/TSPL.docc/ReferenceManual/Statements.md
@@ -1558,6 +1558,12 @@ It has the same meaning as the `*` argument in an availability condition.
   ```
 -->
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
+++ b/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
@@ -1659,6 +1659,12 @@ make the same change here also.
 >
 > *generic-argument* → *type*
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/ReferenceManual/Types.md
+++ b/TSPL.docc/ReferenceManual/Types.md
@@ -1273,6 +1273,12 @@ the expression or one of its subexpressions.
   is allowed and when types must be fully typed.
 -->
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/RevisionHistory/RevisionHistory.md
+++ b/TSPL.docc/RevisionHistory/RevisionHistory.md
@@ -793,6 +793,12 @@ Review the recent changes to this book.
   for the <doc:BasicOperators#Half-Open-Range-Operator>.
 - Added an example of <doc:Generics#Extending-a-Generic-Type>.
 
+> Beta Software:
+>
+> This documentation contains preliminary information about an API or technology in development. This information is subject to change, and software implemented according to this documentation should be tested with final operating system software.
+>
+> Learn more about using [Apple's beta software](https://developer.apple.com/support/beta-software/).
+
 <!--
 This source file is part of the Swift.org open source project
 

--- a/TSPL.docc/RevisionHistory/RevisionHistory.md
+++ b/TSPL.docc/RevisionHistory/RevisionHistory.md
@@ -189,7 +189,7 @@ Review the recent changes to this book.
   and to the <doc:Protocols#Conditionally-Conforming-to-a-Protocol> section
   of the <doc:Protocols> chapter.
 - Added information about recursive protocol constraints
-  to the <doc:Generics#Using-a-Protocol-in-Its-Associated-Type's-Constraints> section.
+  to the <doc:Generics#Using-a-Protocol-in-Its-Associated-Types-Constraints> section.
 - Added information about
   the `canImport()` and `targetEnvironment()` platform conditions
   to <doc:Statements#Conditional-Compilation-Block>.

--- a/TSPL.docc/The-Swift-Programming-Language.md
+++ b/TSPL.docc/The-Swift-Programming-Language.md
@@ -1,4 +1,4 @@
-# The Swift Programming Language
+# The Swift Programming Language (5.9 beta)
 
 @Metadata {
   @TechnologyRoot

--- a/bin/find_screenshot_changes
+++ b/bin/find_screenshot_changes
@@ -2,6 +2,14 @@
 
 setopt ERR_EXIT NO_UNSET PIPE_FAIL
 
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2023 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+
 # This script helps identify changes that show up in screenshots.
 #
 # Set $COMMIT to the oldest commit this script should consider:


### PR DESCRIPTION
- For Swift 5.9 beta, put the beta banner back and update prose
- Fix a link that broke due to a DocC change
- Improve the GitHub PR template
- Mark the grammar format conversion as an ignored commit for Git blame
- Add a file that lets Git log/diff show changes in chapter order