### PR TITLE
Remove an infinite loop in the grammar

### DIFF
--- a/TSPL.docc/ReferenceManual/Expressions.md
+++ b/TSPL.docc/ReferenceManual/Expressions.md
@@ -927,7 +927,7 @@ even if one of the branches of a conditional expression is throwing.
 >
 > *if-expression-tail* → **`else`** *if-expression*
 >
-> *if-expression-tail* → **`else`** **`{`** *statement* **`}`** *if-expression-tail*
+> *if-expression-tail* → **`else`** **`{`** *statement* **`}`**
 >
 >
 >

--- a/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
+++ b/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
@@ -653,7 +653,7 @@ make the same change here also.
 >
 > *if-expression-tail* → **`else`** *if-expression*
 >
-> *if-expression-tail* → **`else`** **`{`** *statement* **`}`** *if-expression-tail*
+> *if-expression-tail* → **`else`** **`{`** *statement* **`}`**
 >
 >
 >


### PR DESCRIPTION
Reviewed by @hamishknight in the issue's discussion.  This looks like it was just a copy/paste error.

Fixes: https://github.com/apple/swift-book/issues/145