### PR TITLE
Use the short syntax to unwrap optional properties

### DIFF
--- a/TSPL.docc/LanguageGuide/OptionalChaining.md
+++ b/TSPL.docc/LanguageGuide/OptionalChaining.md
@@ -352,7 +352,7 @@ class Address {
         var buildingNumber: String?
         var street: String?
         func buildingIdentifier() -> String? {
-           if let buildingNumber = buildingNumber, let street = street {
+           if let buildingNumber, let street {
                return "\(buildingNumber) \(street)"
            } else if buildingName != nil {
                return buildingName


### PR DESCRIPTION
Because we're reusing the property names, we can use the shorter form as described in The Basics.