### PR TITLE
Add missing `open` access control level examples

### DIFF
--- a/TSPL.docc/LanguageGuide/AccessControl.md
+++ b/TSPL.docc/LanguageGuide/AccessControl.md
@@ -153,11 +153,13 @@ one of the `open`, `public`, `internal`, `fileprivate`, or `private` modifiers
 at the beginning of the entity's declaration.
 
 ```swift
+open class SomeOpenClass {}
 public class SomePublicClass {}
 internal class SomeInternalClass {}
 fileprivate class SomeFilePrivateClass {}
 private class SomePrivateClass {}
 
+open var someOpenVariable = 0
 public var somePublicVariable = 0
 internal let someInternalConstant = 0
 fileprivate func someFilePrivateFunction() {}
@@ -168,11 +170,13 @@ private func somePrivateFunction() {}
   - test: `accessControlSyntax`
 
   ```swifttest
+  -> open class SomeOpenClass {}
   -> public class SomePublicClass {}
   -> internal class SomeInternalClass {}
   -> fileprivate class SomeFilePrivateClass {}
   -> private class SomePrivateClass {}
   ---
+  -> open var someOpenVariable = 0
   -> public var somePublicVariable = 0
   -> internal let someInternalConstant = 0
   -> fileprivate func someFilePrivateFunction() {}


### PR DESCRIPTION
The `open` access control level was missing from the Access Control Syntax section.