### PR TITLE
Describe how result builders interact with "build partial block"

### DIFF
--- a/TSPL.docc/ReferenceManual/Attributes.md
+++ b/TSPL.docc/ReferenceManual/Attributes.md
@@ -1883,7 +1883,7 @@ into code that calls the static methods of the result builder type:
       var second: Second
       func draw() -> String { return first.draw() + second.draw() }
   }
-  
+
   @resultBuilder
   struct DrawingPartialBlockBuilder {
       static func buildPartialBlock<D: Drawable>(first: D) -> D {
@@ -1895,7 +1895,7 @@ into code that calls the static methods of the result builder type:
           return DrawBoth(first: accumulated, second: next)
       }
   }
-  
+
   @DrawingPartialBlockBuilder var builderBlock: some Drawable {
       Text("First")
       Line(elements: [Text("Second"), Text("Third")])

--- a/TSPL.docc/ReferenceManual/Attributes.md
+++ b/TSPL.docc/ReferenceManual/Attributes.md
@@ -1866,13 +1866,16 @@ into code that calls the static methods of the result builder type:
     >> assert(builderOptional == manualOptional)
     ```
   -->
-- If the result builder implements the `buildPartialBlock(first:)` and
-  `buildPartialBlock(accumulated:next:)` methods, a code block or `do`
-  statement becomes a call to those methods. The first statement inside
-  of the block is transformed to become an argument to the
-  `buildPartialBlock(first:)` method, and the remaining statements
-  become nested calls to the `buildPartialBlock(accumulated:next:)`
-  method. For example, the following declarations are equivalent:
+- If the result builder implements
+  the `buildPartialBlock(first:)`
+  and `buildPartialBlock(accumulated:next:)` methods,
+  a code block or `do` statement becomes a call to those methods.
+  The first statement inside of the block
+  is transformed to become an argument
+  to the `buildPartialBlock(first:)` method,
+  and the remaining statements become nested calls
+  to the `buildPartialBlock(accumulated:next:)` method.
+  For example, the following declarations are equivalent:
 
   ```swift
   struct DrawBoth<First: Drawable, Second: Drawable>: Drawable {


### PR DESCRIPTION
The `buildPartialBlock(first:)` and `buildPartialBlock(accumulated:next:)` methods are described by the "Result-Building Methods" subsection of `@resultBuilder`, but there is no corresponding detail provided in the "Result Transformations" subsection. This adds the appropriate description, including example code which demonstrates the intended use case.

(The point is admittedly partly moot in Swift 5.9, given that it became possible to write a result builder that has `func buildBlock<each D: Drawable>(_ components: repeat each D) -> some Drawable`, but the `buildPartialBlock()` methods may still be a better fit for some use cases. Even if this were not the case, they still exist and should be fully documented.)