### PR TITLE
Switch the grammar to use hard breaks.

### DIFF
--- a/TSPL.docc/ReferenceManual/AboutTheLanguageReference.md
+++ b/TSPL.docc/ReferenceManual/AboutTheLanguageReference.md
@@ -45,8 +45,7 @@ where the alternatives are spelled out explicitly:
 > Grammar of a getter-setter block:
 >
 >
-> *getter-setter-block* → **`{`** *getter-clause* *setter-clause*_?_ **`}`**
->
+> *getter-setter-block* → **`{`** *getter-clause* *setter-clause*_?_ **`}`** \
 > *getter-setter-block* → **`{`** *setter-clause* *getter-clause* **`}`**
 
 > Beta Software:

--- a/TSPL.docc/ReferenceManual/Attributes.md
+++ b/TSPL.docc/ReferenceManual/Attributes.md
@@ -2370,26 +2370,16 @@ see <doc:Statements#Switching-Over-Future-Enumeration-Cases>.
 
 > Grammar of an attribute:
 >
-> *attribute* → **`@`** *attribute-name* *attribute-argument-clause*_?_
->
-> *attribute-name* → *identifier*
->
-> *attribute-argument-clause* → **`(`** *balanced-tokens*_?_ **`)`**
->
+> *attribute* → **`@`** *attribute-name* *attribute-argument-clause*_?_ \
+> *attribute-name* → *identifier* \
+> *attribute-argument-clause* → **`(`** *balanced-tokens*_?_ **`)`** \
 > *attributes* → *attribute* *attributes*_?_
 >
->
->
-> *balanced-tokens* → *balanced-token* *balanced-tokens*_?_
->
-> *balanced-token* → **`(`** *balanced-tokens*_?_ **`)`**
->
-> *balanced-token* → **`[`** *balanced-tokens*_?_ **`]`**
->
-> *balanced-token* → **`{`** *balanced-tokens*_?_ **`}`**
->
-> *balanced-token* → Any identifier, keyword, literal, or operator
->
+> *balanced-tokens* → *balanced-token* *balanced-tokens*_?_ \
+> *balanced-token* → **`(`** *balanced-tokens*_?_ **`)`** \
+> *balanced-token* → **`[`** *balanced-tokens*_?_ **`]`** \
+> *balanced-token* → **`{`** *balanced-tokens*_?_ **`}`** \
+> *balanced-token* → Any identifier, keyword, literal, or operator \
 > *balanced-token* → Any punctuation except  **`(`**,  **`)`**,  **`[`**,  **`]`**,  **`{`**, or  **`}`**
 
 > Beta Software:

--- a/TSPL.docc/ReferenceManual/Declarations.md
+++ b/TSPL.docc/ReferenceManual/Declarations.md
@@ -17,40 +17,23 @@ the term *declaration* covers both declarations and definitions.
 
 > Grammar of a declaration:
 >
-> *declaration* → *import-declaration*
->
-> *declaration* → *constant-declaration*
->
-> *declaration* → *variable-declaration*
->
-> *declaration* → *typealias-declaration*
->
-> *declaration* → *function-declaration*
->
-> *declaration* → *enum-declaration*
->
-> *declaration* → *struct-declaration*
->
-> *declaration* → *class-declaration*
->
-> *declaration* → *actor-declaration*
->
-> *declaration* → *protocol-declaration*
->
-> *declaration* → *initializer-declaration*
->
-> *declaration* → *deinitializer-declaration*
->
-> *declaration* → *extension-declaration*
->
-> *declaration* → *subscript-declaration*
->
-> *declaration* → *macro-declaration*
->
-> *declaration* → *operator-declaration*
->
-> *declaration* → *precedence-group-declaration*
->
+> *declaration* → *import-declaration* \
+> *declaration* → *constant-declaration* \
+> *declaration* → *variable-declaration* \
+> *declaration* → *typealias-declaration* \
+> *declaration* → *function-declaration* \
+> *declaration* → *enum-declaration* \
+> *declaration* → *struct-declaration* \
+> *declaration* → *class-declaration* \
+> *declaration* → *actor-declaration* \
+> *declaration* → *protocol-declaration* \
+> *declaration* → *initializer-declaration* \
+> *declaration* → *deinitializer-declaration* \
+> *declaration* → *extension-declaration* \
+> *declaration* → *subscript-declaration* \
+> *declaration* → *macro-declaration* \
+> *declaration* → *operator-declaration* \
+> *declaration* → *precedence-group-declaration* \
 > *declarations* → *declaration* *declarations*_?_
 
 ## Top-Level Code
@@ -146,10 +129,7 @@ import <#module#>.<#submodule#>
 >
 > *import-declaration* → *attributes*_?_ **`import`** *import-kind*_?_ *import-path*
 >
->
->
-> *import-kind* → **`typealias`** | **`struct`** | **`class`** | **`enum`** | **`protocol`** | **`let`** | **`var`** | **`func`**
->
+> *import-kind* → **`typealias`** | **`struct`** | **`class`** | **`enum`** | **`protocol`** | **`let`** | **`var`** | **`func`** \
 > *import-path* → *identifier* | *identifier* **`.`** *import-path*
 
 ## Constant Declaration
@@ -254,12 +234,8 @@ see <doc:TheBasics#Constants-and-Variables> and <doc:Properties#Stored-Propertie
 >
 > *constant-declaration* → *attributes*_?_ *declaration-modifiers*_?_ **`let`** *pattern-initializer-list*
 >
->
->
-> *pattern-initializer-list* → *pattern-initializer* | *pattern-initializer* **`,`** *pattern-initializer-list*
->
-> *pattern-initializer* → *pattern* *initializer*_?_
->
+> *pattern-initializer-list* → *pattern-initializer* | *pattern-initializer* **`,`** *pattern-initializer-list* \
+> *pattern-initializer* → *pattern* *initializer*_?_ \
 > *initializer* → **`=`** *expression*
 
 ## Variable Declaration
@@ -545,56 +521,31 @@ Type properties are discussed in <doc:Properties#Type-Properties>.
 
 > Grammar of a variable declaration:
 >
-> *variable-declaration* → *variable-declaration-head* *pattern-initializer-list*
->
-> *variable-declaration* → *variable-declaration-head* *variable-name* *type-annotation* *code-block*
->
-> *variable-declaration* → *variable-declaration-head* *variable-name* *type-annotation* *getter-setter-block*
->
-> *variable-declaration* → *variable-declaration-head* *variable-name* *type-annotation* *getter-setter-keyword-block*
->
-> *variable-declaration* → *variable-declaration-head* *variable-name* *initializer* *willSet-didSet-block*
->
+> *variable-declaration* → *variable-declaration-head* *pattern-initializer-list* \
+> *variable-declaration* → *variable-declaration-head* *variable-name* *type-annotation* *code-block* \
+> *variable-declaration* → *variable-declaration-head* *variable-name* *type-annotation* *getter-setter-block* \
+> *variable-declaration* → *variable-declaration-head* *variable-name* *type-annotation* *getter-setter-keyword-block* \
+> *variable-declaration* → *variable-declaration-head* *variable-name* *initializer* *willSet-didSet-block* \
 > *variable-declaration* → *variable-declaration-head* *variable-name* *type-annotation* *initializer*_?_ *willSet-didSet-block*
 >
->
->
-> *variable-declaration-head* → *attributes*_?_ *declaration-modifiers*_?_ **`var`**
->
+> *variable-declaration-head* → *attributes*_?_ *declaration-modifiers*_?_ **`var`** \
 > *variable-name* → *identifier*
 >
->
->
-> *getter-setter-block* → *code-block*
->
-> *getter-setter-block* → **`{`** *getter-clause* *setter-clause*_?_ **`}`**
->
-> *getter-setter-block* → **`{`** *setter-clause* *getter-clause* **`}`**
->
-> *getter-clause* → *attributes*_?_ *mutation-modifier*_?_ **`get`** *code-block*
->
-> *setter-clause* → *attributes*_?_ *mutation-modifier*_?_ **`set`** *setter-name*_?_ *code-block*
->
+> *getter-setter-block* → *code-block* \
+> *getter-setter-block* → **`{`** *getter-clause* *setter-clause*_?_ **`}`** \
+> *getter-setter-block* → **`{`** *setter-clause* *getter-clause* **`}`** \
+> *getter-clause* → *attributes*_?_ *mutation-modifier*_?_ **`get`** *code-block* \
+> *setter-clause* → *attributes*_?_ *mutation-modifier*_?_ **`set`** *setter-name*_?_ *code-block* \
 > *setter-name* → **`(`** *identifier* **`)`**
 >
->
->
-> *getter-setter-keyword-block* → **`{`** *getter-keyword-clause* *setter-keyword-clause*_?_ **`}`**
->
-> *getter-setter-keyword-block* → **`{`** *setter-keyword-clause* *getter-keyword-clause* **`}`**
->
-> *getter-keyword-clause* → *attributes*_?_ *mutation-modifier*_?_ **`get`**
->
+> *getter-setter-keyword-block* → **`{`** *getter-keyword-clause* *setter-keyword-clause*_?_ **`}`** \
+> *getter-setter-keyword-block* → **`{`** *setter-keyword-clause* *getter-keyword-clause* **`}`** \
+> *getter-keyword-clause* → *attributes*_?_ *mutation-modifier*_?_ **`get`** \
 > *setter-keyword-clause* → *attributes*_?_ *mutation-modifier*_?_ **`set`**
 >
->
->
-> *willSet-didSet-block* → **`{`** *willSet-clause* *didSet-clause*_?_ **`}`**
->
-> *willSet-didSet-block* → **`{`** *didSet-clause* *willSet-clause*_?_ **`}`**
->
-> *willSet-clause* → *attributes*_?_ **`willSet`** *setter-name*_?_ *code-block*
->
+> *willSet-didSet-block* → **`{`** *willSet-clause* *didSet-clause*_?_ **`}`** \
+> *willSet-didSet-block* → **`{`** *didSet-clause* *willSet-clause*_?_ **`}`** \
+> *willSet-clause* → *attributes*_?_ **`willSet`** *setter-name*_?_ *code-block* \
 > *didSet-clause* → *attributes*_?_ **`didSet`** *setter-name*_?_ *code-block*
 
 <!--
@@ -733,10 +684,8 @@ See also <doc:Declarations#Protocol-Associated-Type-Declaration>.
 
 > Grammar of a type alias declaration:
 >
-> *typealias-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`typealias`** *typealias-name* *generic-parameter-clause*_?_ *typealias-assignment*
->
-> *typealias-name* → *identifier*
->
+> *typealias-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`typealias`** *typealias-name* *generic-parameter-clause*_?_ *typealias-assignment* \
+> *typealias-name* → *identifier* \
 > *typealias-assignment* → **`=`** *type*
 
 <!--
@@ -1484,38 +1433,21 @@ but the new method must preserve its return type and nonreturning behavior.
 >
 > *function-declaration* → *function-head* *function-name* *generic-parameter-clause*_?_ *function-signature* *generic-where-clause*_?_ *function-body*_?_
 >
->
->
-> *function-head* → *attributes*_?_ *declaration-modifiers*_?_ **`func`**
->
+> *function-head* → *attributes*_?_ *declaration-modifiers*_?_ **`func`** \
 > *function-name* → *identifier* | *operator*
 >
->
->
-> *function-signature* → *parameter-clause* **`async`**_?_ **`throws`**_?_ *function-result*_?_
->
-> *function-signature* → *parameter-clause* **`async`**_?_ **`rethrows`** *function-result*_?_
->
-> *function-result* → **`->`** *attributes*_?_ *type*
->
+> *function-signature* → *parameter-clause* **`async`**_?_ **`throws`**_?_ *function-result*_?_ \
+> *function-signature* → *parameter-clause* **`async`**_?_ **`rethrows`** *function-result*_?_ \
+> *function-result* → **`->`** *attributes*_?_ *type* \
 > *function-body* → *code-block*
 >
->
->
-> *parameter-clause* → **`(`** **`)`** | **`(`** *parameter-list* **`)`**
->
-> *parameter-list* → *parameter* | *parameter* **`,`** *parameter-list*
->
-> *parameter* → *external-parameter-name*_?_ *local-parameter-name* *type-annotation* *default-argument-clause*_?_
->
-> *parameter* → *external-parameter-name*_?_ *local-parameter-name* *type-annotation*
->
-> *parameter* → *external-parameter-name*_?_ *local-parameter-name* *type-annotation* **`...`**
->
-> *external-parameter-name* → *identifier*
->
-> *local-parameter-name* → *identifier*
->
+> *parameter-clause* → **`(`** **`)`** | **`(`** *parameter-list* **`)`** \
+> *parameter-list* → *parameter* | *parameter* **`,`** *parameter-list* \
+> *parameter* → *external-parameter-name*_?_ *local-parameter-name* *type-annotation* *default-argument-clause*_?_ \
+> *parameter* → *external-parameter-name*_?_ *local-parameter-name* *type-annotation* \
+> *parameter* → *external-parameter-name*_?_ *local-parameter-name* *type-annotation* **`...`** \
+> *external-parameter-name* → *identifier* \
+> *local-parameter-name* → *identifier* \
 > *default-argument-clause* → **`=`** *expression*
 
 <!--
@@ -1840,44 +1772,25 @@ as described in <doc:Patterns#Enumeration-Case-Pattern>.
 
 > Grammar of an enumeration declaration:
 >
-> *enum-declaration* → *attributes*_?_ *access-level-modifier*_?_ *union-style-enum*
->
+> *enum-declaration* → *attributes*_?_ *access-level-modifier*_?_ *union-style-enum* \
 > *enum-declaration* → *attributes*_?_ *access-level-modifier*_?_ *raw-value-style-enum*
 >
->
->
-> *union-style-enum* → **`indirect`**_?_ **`enum`** *enum-name* *generic-parameter-clause*_?_ *type-inheritance-clause*_?_ *generic-where-clause*_?_ **`{`** *union-style-enum-members*_?_ **`}`**
->
-> *union-style-enum-members* → *union-style-enum-member* *union-style-enum-members*_?_
->
-> *union-style-enum-member* → *declaration* | *union-style-enum-case-clause* | *compiler-control-statement*
->
-> *union-style-enum-case-clause* → *attributes*_?_ **`indirect`**_?_ **`case`** *union-style-enum-case-list*
->
-> *union-style-enum-case-list* → *union-style-enum-case* | *union-style-enum-case* **`,`** *union-style-enum-case-list*
->
-> *union-style-enum-case* → *enum-case-name* *tuple-type*_?_
->
-> *enum-name* → *identifier*
->
+> *union-style-enum* → **`indirect`**_?_ **`enum`** *enum-name* *generic-parameter-clause*_?_ *type-inheritance-clause*_?_ *generic-where-clause*_?_ **`{`** *union-style-enum-members*_?_ **`}`** \
+> *union-style-enum-members* → *union-style-enum-member* *union-style-enum-members*_?_ \
+> *union-style-enum-member* → *declaration* | *union-style-enum-case-clause* | *compiler-control-statement* \
+> *union-style-enum-case-clause* → *attributes*_?_ **`indirect`**_?_ **`case`** *union-style-enum-case-list* \
+> *union-style-enum-case-list* → *union-style-enum-case* | *union-style-enum-case* **`,`** *union-style-enum-case-list* \
+> *union-style-enum-case* → *enum-case-name* *tuple-type*_?_ \
+> *enum-name* → *identifier* \
 > *enum-case-name* → *identifier*
 >
->
->
-> *raw-value-style-enum* → **`enum`** *enum-name* *generic-parameter-clause*_?_ *type-inheritance-clause* *generic-where-clause*_?_ **`{`** *raw-value-style-enum-members* **`}`**
->
-> *raw-value-style-enum-members* → *raw-value-style-enum-member* *raw-value-style-enum-members*_?_
->
-> *raw-value-style-enum-member* → *declaration* | *raw-value-style-enum-case-clause* | *compiler-control-statement*
->
-> *raw-value-style-enum-case-clause* → *attributes*_?_ **`case`** *raw-value-style-enum-case-list*
->
-> *raw-value-style-enum-case-list* → *raw-value-style-enum-case* | *raw-value-style-enum-case* **`,`** *raw-value-style-enum-case-list*
->
-> *raw-value-style-enum-case* → *enum-case-name* *raw-value-assignment*_?_
->
-> *raw-value-assignment* → **`=`** *raw-value-literal*
->
+> *raw-value-style-enum* → **`enum`** *enum-name* *generic-parameter-clause*_?_ *type-inheritance-clause* *generic-where-clause*_?_ **`{`** *raw-value-style-enum-members* **`}`** \
+> *raw-value-style-enum-members* → *raw-value-style-enum-member* *raw-value-style-enum-members*_?_ \
+> *raw-value-style-enum-member* → *declaration* | *raw-value-style-enum-case-clause* | *compiler-control-statement* \
+> *raw-value-style-enum-case-clause* → *attributes*_?_ **`case`** *raw-value-style-enum-case-list* \
+> *raw-value-style-enum-case-list* → *raw-value-style-enum-case* | *raw-value-style-enum-case* **`,`** *raw-value-style-enum-case-list* \
+> *raw-value-style-enum-case* → *enum-case-name* *raw-value-assignment*_?_ \
+> *raw-value-assignment* → **`=`** *raw-value-literal* \
 > *raw-value-literal* → *numeric-literal* | *static-string-literal* | *boolean-literal*
 
 <!--
@@ -1960,16 +1873,11 @@ as discussed in <doc:Declarations#Extension-Declaration>.
 
 > Grammar of a structure declaration:
 >
-> *struct-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`struct`** *struct-name* *generic-parameter-clause*_?_ *type-inheritance-clause*_?_ *generic-where-clause*_?_ *struct-body*
->
-> *struct-name* → *identifier*
->
+> *struct-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`struct`** *struct-name* *generic-parameter-clause*_?_ *type-inheritance-clause*_?_ *generic-where-clause*_?_ *struct-body* \
+> *struct-name* → *identifier* \
 > *struct-body* → **`{`** *struct-members*_?_ **`}`**
 >
->
->
-> *struct-members* → *struct-member* *struct-members*_?_
->
+> *struct-members* → *struct-member* *struct-members*_?_ \
 > *struct-member* → *declaration* | *compiler-control-statement*
 
 ## Class Declaration
@@ -2055,18 +1963,12 @@ as discussed in <doc:Declarations#Extension-Declaration>.
 
 > Grammar of a class declaration:
 >
-> *class-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`final`**_?_ **`class`** *class-name* *generic-parameter-clause*_?_ *type-inheritance-clause*_?_ *generic-where-clause*_?_ *class-body*
->
-> *class-declaration* → *attributes*_?_ **`final`** *access-level-modifier*_?_ **`class`** *class-name* *generic-parameter-clause*_?_ *type-inheritance-clause*_?_ *generic-where-clause*_?_ *class-body*
->
-> *class-name* → *identifier*
->
+> *class-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`final`**_?_ **`class`** *class-name* *generic-parameter-clause*_?_ *type-inheritance-clause*_?_ *generic-where-clause*_?_ *class-body* \
+> *class-declaration* → *attributes*_?_ **`final`** *access-level-modifier*_?_ **`class`** *class-name* *generic-parameter-clause*_?_ *type-inheritance-clause*_?_ *generic-where-clause*_?_ *class-body* \
+> *class-name* → *identifier* \
 > *class-body* → **`{`** *class-members*_?_ **`}`**
 >
->
->
-> *class-members* → *class-member* *class-members*_?_
->
+> *class-members* → *class-member* *class-members*_?_ \
 > *class-member* → *declaration* | *compiler-control-statement*
 
 ## Actor Declaration
@@ -2149,16 +2051,11 @@ as discussed in <doc:Declarations#Extension-Declaration>.
 
 > Grammar of an actor declaration:
 >
-> *actor-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`actor`** *actor-name* *generic-parameter-clause*_?_ *type-inheritance-clause*_?_ *generic-where-clause*_?_ *actor-body*
->
-> *actor-name* → *identifier*
->
+> *actor-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`actor`** *actor-name* *generic-parameter-clause*_?_ *type-inheritance-clause*_?_ *generic-where-clause*_?_ *actor-body* \
+> *actor-name* → *identifier* \
 > *actor-body* → **`{`** *actor-members*_?_ **`}`**
 >
->
->
-> *actor-members* → *actor-member* *actor-members*_?_
->
+> *actor-members* → *actor-member* *actor-members*_?_ \
 > *actor-member* → *declaration* | *compiler-control-statement*
 
 ## Protocol Declaration
@@ -2302,30 +2199,18 @@ should implement, as described in <doc:Protocols#Delegation>.
 
 > Grammar of a protocol declaration:
 >
-> *protocol-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`protocol`** *protocol-name* *type-inheritance-clause*_?_ *generic-where-clause*_?_ *protocol-body*
->
-> *protocol-name* → *identifier*
->
+> *protocol-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`protocol`** *protocol-name* *type-inheritance-clause*_?_ *generic-where-clause*_?_ *protocol-body* \
+> *protocol-name* → *identifier* \
 > *protocol-body* → **`{`** *protocol-members*_?_ **`}`**
 >
->
->
-> *protocol-members* → *protocol-member* *protocol-members*_?_
->
+> *protocol-members* → *protocol-member* *protocol-members*_?_ \
 > *protocol-member* → *protocol-member-declaration* | *compiler-control-statement*
 >
->
->
-> *protocol-member-declaration* → *protocol-property-declaration*
->
-> *protocol-member-declaration* → *protocol-method-declaration*
->
-> *protocol-member-declaration* → *protocol-initializer-declaration*
->
-> *protocol-member-declaration* → *protocol-subscript-declaration*
->
-> *protocol-member-declaration* → *protocol-associated-type-declaration*
->
+> *protocol-member-declaration* → *protocol-property-declaration* \
+> *protocol-member-declaration* → *protocol-method-declaration* \
+> *protocol-member-declaration* → *protocol-initializer-declaration* \
+> *protocol-member-declaration* → *protocol-subscript-declaration* \
+> *protocol-member-declaration* → *protocol-associated-type-declaration* \
 > *protocol-member-declaration* → *typealias-declaration*
 
 ### Protocol Property Declaration
@@ -2458,8 +2343,7 @@ See also <doc:Declarations#Initializer-Declaration>.
 
 > Grammar of a protocol initializer declaration:
 >
-> *protocol-initializer-declaration* → *initializer-head* *generic-parameter-clause*_?_ *parameter-clause* **`throws`**_?_ *generic-where-clause*_?_
->
+> *protocol-initializer-declaration* → *initializer-head* *generic-parameter-clause*_?_ *parameter-clause* **`throws`**_?_ *generic-where-clause*_?_ \
 > *protocol-initializer-declaration* → *initializer-head* *generic-parameter-clause*_?_ *parameter-clause* **`rethrows`** *generic-where-clause*_?_
 
 ### Protocol Subscript Declaration
@@ -2804,16 +2688,11 @@ see <doc:Initialization#Failable-Initializers>.
 
 > Grammar of an initializer declaration:
 >
-> *initializer-declaration* → *initializer-head* *generic-parameter-clause*_?_ *parameter-clause* **`async`**_?_ **`throws`**_?_ *generic-where-clause*_?_ *initializer-body*
->
-> *initializer-declaration* → *initializer-head* *generic-parameter-clause*_?_ *parameter-clause* **`async`**_?_ **`rethrows`** *generic-where-clause*_?_ *initializer-body*
->
-> *initializer-head* → *attributes*_?_ *declaration-modifiers*_?_ **`init`**
->
-> *initializer-head* → *attributes*_?_ *declaration-modifiers*_?_ **`init`** **`?`**
->
-> *initializer-head* → *attributes*_?_ *declaration-modifiers*_?_ **`init`** **`!`**
->
+> *initializer-declaration* → *initializer-head* *generic-parameter-clause*_?_ *parameter-clause* **`async`**_?_ **`throws`**_?_ *generic-where-clause*_?_ *initializer-body* \
+> *initializer-declaration* → *initializer-head* *generic-parameter-clause*_?_ *parameter-clause* **`async`**_?_ **`rethrows`** *generic-where-clause*_?_ *initializer-body* \
+> *initializer-head* → *attributes*_?_ *declaration-modifiers*_?_ **`init`** \
+> *initializer-head* → *attributes*_?_ *declaration-modifiers*_?_ **`init`** **`?`** \
+> *initializer-head* → *attributes*_?_ *declaration-modifiers*_?_ **`init`** **`!`** \
 > *initializer-body* → *code-block*
 
 ## Deinitializer Declaration
@@ -3333,14 +3212,10 @@ extension Array: Loggable where Element: MarkedLoggable { }
 
 > Grammar of an extension declaration:
 >
-> *extension-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`extension`** *type-identifier* *type-inheritance-clause*_?_ *generic-where-clause*_?_ *extension-body*
->
+> *extension-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`extension`** *type-identifier* *type-inheritance-clause*_?_ *generic-where-clause*_?_ *extension-body* \
 > *extension-body* → **`{`** *extension-members*_?_ **`}`**
 >
->
->
-> *extension-members* → *extension-member* *extension-members*_?_
->
+> *extension-members* → *extension-member* *extension-members*_?_ \
 > *extension-member* → *declaration* | *compiler-control-statement*
 
 ## Subscript Declaration
@@ -3434,14 +3309,10 @@ with both the `class` and `final` declaration modifiers.
 
 > Grammar of a subscript declaration:
 >
-> *subscript-declaration* → *subscript-head* *subscript-result* *generic-where-clause*_?_ *code-block*
->
-> *subscript-declaration* → *subscript-head* *subscript-result* *generic-where-clause*_?_ *getter-setter-block*
->
-> *subscript-declaration* → *subscript-head* *subscript-result* *generic-where-clause*_?_ *getter-setter-keyword-block*
->
-> *subscript-head* → *attributes*_?_ *declaration-modifiers*_?_ **`subscript`** *generic-parameter-clause*_?_ *parameter-clause*
->
+> *subscript-declaration* → *subscript-head* *subscript-result* *generic-where-clause*_?_ *code-block* \
+> *subscript-declaration* → *subscript-head* *subscript-result* *generic-where-clause*_?_ *getter-setter-block* \
+> *subscript-declaration* → *subscript-head* *subscript-result* *generic-where-clause*_?_ *getter-setter-keyword-block* \
+> *subscript-head* → *attributes*_?_ *declaration-modifiers*_?_ **`subscript`** *generic-parameter-clause*_?_ *parameter-clause* \
 > *subscript-result* → **`->`** *attributes*_?_ *type*
 
 ## Macro Declaration
@@ -3468,14 +3339,10 @@ For more information, see <doc:Macros>.
 
 > Grammar of a macro declaration:
 >
-> *macro-declaration* → *macro-head* *identifier* *generic-parameter-clause*_?_ *macro-signature* *macro-definition*_?_ *generic-where-clause*
->
-> *macro-head* → *attributes*_?_ *declaration-modifiers*_?_ **`macro`**
->
-> *macro-signature* → *parameter-clause* *macro-function-signature-result*_?_
->
-> *macro-function-signature-result* → **`->`** *type*
->
+> *macro-declaration* → *macro-head* *identifier* *generic-parameter-clause*_?_ *macro-signature* *macro-definition*_?_ *generic-where-clause* \
+> *macro-head* → *attributes*_?_ *declaration-modifiers*_?_ **`macro`** \
+> *macro-signature* → *parameter-clause* *macro-function-signature-result*_?_ \
+> *macro-function-signature-result* → **`->`** *type* \
 > *macro-definition* → **`=`** *expression*
 
 <!--
@@ -3555,15 +3422,9 @@ see <doc:AdvancedOperators#Custom-Operators>.
 >
 > *operator-declaration* → *prefix-operator-declaration* | *postfix-operator-declaration* | *infix-operator-declaration*
 >
->
->
-> *prefix-operator-declaration* → **`prefix`** **`operator`** *operator*
->
-> *postfix-operator-declaration* → **`postfix`** **`operator`** *operator*
->
+> *prefix-operator-declaration* → **`prefix`** **`operator`** *operator* \
+> *postfix-operator-declaration* → **`postfix`** **`operator`** *operator* \
 > *infix-operator-declaration* → **`infix`** **`operator`** *operator* *infix-operator-group*_?_
->
->
 >
 > *infix-operator-group* → **`:`** *precedence-group-name*
 
@@ -3645,38 +3506,21 @@ as operators that don't perform assignment.
 >
 > *precedence-group-declaration* → **`precedencegroup`** *precedence-group-name* **`{`** *precedence-group-attributes*_?_ **`}`**
 >
->
->
-> *precedence-group-attributes* → *precedence-group-attribute* *precedence-group-attributes*_?_
->
-> *precedence-group-attribute* → *precedence-group-relation*
->
-> *precedence-group-attribute* → *precedence-group-assignment*
->
+> *precedence-group-attributes* → *precedence-group-attribute* *precedence-group-attributes*_?_ \
+> *precedence-group-attribute* → *precedence-group-relation* \
+> *precedence-group-attribute* → *precedence-group-assignment* \
 > *precedence-group-attribute* → *precedence-group-associativity*
 >
->
->
-> *precedence-group-relation* → **`higherThan`** **`:`** *precedence-group-names*
->
+> *precedence-group-relation* → **`higherThan`** **`:`** *precedence-group-names* \
 > *precedence-group-relation* → **`lowerThan`** **`:`** *precedence-group-names*
->
->
 >
 > *precedence-group-assignment* → **`assignment`** **`:`** *boolean-literal*
 >
->
->
-> *precedence-group-associativity* → **`associativity`** **`:`** **`left`**
->
-> *precedence-group-associativity* → **`associativity`** **`:`** **`right`**
->
+> *precedence-group-associativity* → **`associativity`** **`:`** **`left`** \
+> *precedence-group-associativity* → **`associativity`** **`:`** **`right`** \
 > *precedence-group-associativity* → **`associativity`** **`:`** **`none`**
 >
->
->
-> *precedence-group-names* → *precedence-group-name* | *precedence-group-name* **`,`** *precedence-group-names*
->
+> *precedence-group-names* → *precedence-group-name* | *precedence-group-name* **`,`** *precedence-group-names* \
 > *precedence-group-name* → *identifier*
 
 ## Declaration Modifiers
@@ -3853,33 +3697,19 @@ as discussed in <doc:AccessControl#Getters-and-Setters>.
 
 > Grammar of a declaration modifier:
 >
-> *declaration-modifier* → **`class`** | **`convenience`** | **`dynamic`** | **`final`** | **`infix`** | **`lazy`** | **`optional`** | **`override`** | **`postfix`** | **`prefix`** | **`required`** | **`static`** | **`unowned`** | **`unowned`** **`(`** **`safe`** **`)`** | **`unowned`** **`(`** **`unsafe`** **`)`** | **`weak`**
->
-> *declaration-modifier* → *access-level-modifier*
->
-> *declaration-modifier* → *mutation-modifier*
->
-> *declaration-modifier* → *actor-isolation-modifier*
->
+> *declaration-modifier* → **`class`** | **`convenience`** | **`dynamic`** | **`final`** | **`infix`** | **`lazy`** | **`optional`** | **`override`** | **`postfix`** | **`prefix`** | **`required`** | **`static`** | **`unowned`** | **`unowned`** **`(`** **`safe`** **`)`** | **`unowned`** **`(`** **`unsafe`** **`)`** | **`weak`** \
+> *declaration-modifier* → *access-level-modifier* \
+> *declaration-modifier* → *mutation-modifier* \
+> *declaration-modifier* → *actor-isolation-modifier* \
 > *declaration-modifiers* → *declaration-modifier* *declaration-modifiers*_?_
 >
->
->
-> *access-level-modifier* → **`private`** | **`private`** **`(`** **`set`** **`)`**
->
-> *access-level-modifier* → **`fileprivate`** | **`fileprivate`** **`(`** **`set`** **`)`**
->
-> *access-level-modifier* → **`internal`** | **`internal`** **`(`** **`set`** **`)`**
->
-> *access-level-modifier* → **`public`** | **`public`** **`(`** **`set`** **`)`**
->
+> *access-level-modifier* → **`private`** | **`private`** **`(`** **`set`** **`)`** \
+> *access-level-modifier* → **`fileprivate`** | **`fileprivate`** **`(`** **`set`** **`)`** \
+> *access-level-modifier* → **`internal`** | **`internal`** **`(`** **`set`** **`)`** \
+> *access-level-modifier* → **`public`** | **`public`** **`(`** **`set`** **`)`** \
 > *access-level-modifier* → **`open`** | **`open`** **`(`** **`set`** **`)`**
 >
->
->
 > *mutation-modifier* → **`mutating`** | **`nonmutating`**
->
->
 >
 > *actor-isolation-modifier* → **`nonisolated`**
 

--- a/TSPL.docc/ReferenceManual/Expressions.md
+++ b/TSPL.docc/ReferenceManual/Expressions.md
@@ -20,8 +20,7 @@ in the sections below.
 
 > Grammar of an expression:
 >
-> *expression* → *try-operator*_?_ *await-operator*_?_ *prefix-expression* *infix-expressions*_?_
->
+> *expression* → *try-operator*_?_ *await-operator*_?_ *prefix-expression* *infix-expressions*_?_ \
 > *expression-list* → *expression* | *expression* **`,`** *expression-list*
 
 ## Prefix Expressions
@@ -39,8 +38,7 @@ see [Operator Declarations](https://developer.apple.com/documentation/swift/oper
 
 > Grammar of a prefix expression:
 >
-> *prefix-expression* → *prefix-operator*_?_ *postfix-expression*
->
+> *prefix-expression* → *prefix-operator*_?_ *postfix-expression* \
 > *prefix-expression* → *in-out-expression*
 
 ### In-Out Expression
@@ -328,14 +326,10 @@ see [Operator Declarations](https://developer.apple.com/documentation/swift/oper
 
 > Grammar of an infix expression:
 >
-> *infix-expression* → *infix-operator* *prefix-expression*
->
-> *infix-expression* → *assignment-operator* *try-operator*_?_ *prefix-expression*
->
-> *infix-expression* → *conditional-operator* *try-operator*_?_ *prefix-expression*
->
-> *infix-expression* → *type-casting-operator*
->
+> *infix-expression* → *infix-operator* *prefix-expression* \
+> *infix-expression* → *assignment-operator* *try-operator*_?_ *prefix-expression* \
+> *infix-expression* → *conditional-operator* *try-operator*_?_ *prefix-expression* \
+> *infix-expression* → *type-casting-operator* \
 > *infix-expressions* → *infix-expression* *infix-expressions*_?_
 
 ### Assignment Operator
@@ -528,12 +522,9 @@ see <doc:TypeCasting>.
 
 > Grammar of a type-casting operator:
 >
-> *type-casting-operator* → **`is`** *type*
->
-> *type-casting-operator* → **`as`** *type*
->
-> *type-casting-operator* → **`as`** **`?`** *type*
->
+> *type-casting-operator* → **`is`** *type* \
+> *type-casting-operator* → **`as`** *type* \
+> *type-casting-operator* → **`as`** **`?`** *type* \
 > *type-casting-operator* → **`as`** **`!`** *type*
 
 ## Primary Expressions
@@ -546,32 +537,19 @@ to make prefix expressions, infix expressions, and postfix expressions.
 
 > Grammar of a primary expression:
 >
-> *primary-expression* → *identifier* *generic-argument-clause*_?_
->
-> *primary-expression* → *literal-expression*
->
-> *primary-expression* → *self-expression*
->
-> *primary-expression* → *superclass-expression*
->
-> *primary-expression* → *conditional-expression*
->
-> *primary-expression* → *closure-expression*
->
-> *primary-expression* → *parenthesized-expression*
->
-> *primary-expression* → *tuple-expression*
->
-> *primary-expression* → *implicit-member-expression*
->
-> *primary-expression* → *wildcard-expression*
->
-> *primary-expression* → *macro-expansion-expression*
->
-> *primary-expression* → *key-path-expression*
->
-> *primary-expression* → *selector-expression*
->
+> *primary-expression* → *identifier* *generic-argument-clause*_?_ \
+> *primary-expression* → *literal-expression* \
+> *primary-expression* → *self-expression* \
+> *primary-expression* → *superclass-expression* \
+> *primary-expression* → *conditional-expression* \
+> *primary-expression* → *closure-expression* \
+> *primary-expression* → *parenthesized-expression* \
+> *primary-expression* → *tuple-expression* \
+> *primary-expression* → *implicit-member-expression* \
+> *primary-expression* → *wildcard-expression* \
+> *primary-expression* → *macro-expansion-expression* \
+> *primary-expression* → *key-path-expression* \
+> *primary-expression* → *selector-expression* \
 > *primary-expression* → *key-path-string-expression*
 
 <!--
@@ -690,32 +668,19 @@ in Xcode Help.
 
 > Grammar of a literal expression:
 >
-> *literal-expression* → *literal*
->
+> *literal-expression* → *literal* \
 > *literal-expression* → *array-literal* | *dictionary-literal* | *playground-literal*
 >
->
->
-> *array-literal* → **`[`** *array-literal-items*_?_ **`]`**
->
-> *array-literal-items* → *array-literal-item* **`,`**_?_ | *array-literal-item* **`,`** *array-literal-items*
->
+> *array-literal* → **`[`** *array-literal-items*_?_ **`]`** \
+> *array-literal-items* → *array-literal-item* **`,`**_?_ | *array-literal-item* **`,`** *array-literal-items* \
 > *array-literal-item* → *expression*
 >
->
->
-> *dictionary-literal* → **`[`** *dictionary-literal-items* **`]`** | **`[`** **`:`** **`]`**
->
-> *dictionary-literal-items* → *dictionary-literal-item* **`,`**_?_ | *dictionary-literal-item* **`,`** *dictionary-literal-items*
->
+> *dictionary-literal* → **`[`** *dictionary-literal-items* **`]`** | **`[`** **`:`** **`]`** \
+> *dictionary-literal-items* → *dictionary-literal-item* **`,`**_?_ | *dictionary-literal-item* **`,`** *dictionary-literal-items* \
 > *dictionary-literal-item* → *expression* **`:`** *expression*
 >
->
->
-> *playground-literal* → **`#colorLiteral`** **`(`** **`red`** **`:`** *expression* **`,`** **`green`** **`:`** *expression* **`,`** **`blue`** **`:`** *expression* **`,`** **`alpha`** **`:`** *expression* **`)`**
->
-> *playground-literal* → **`#fileLiteral`** **`(`** **`resourceName`** **`:`** *expression* **`)`**
->
+> *playground-literal* → **`#colorLiteral`** **`(`** **`red`** **`:`** *expression* **`,`** **`green`** **`:`** *expression* **`,`** **`blue`** **`:`** *expression* **`,`** **`alpha`** **`:`** *expression* **`)`** \
+> *playground-literal* → **`#fileLiteral`** **`(`** **`resourceName`** **`:`** *expression* **`)`** \
 > *playground-literal* → **`#imageLiteral`** **`(`** **`resourceName`** **`:`** *expression* **`)`**
 
 ### Self Expression
@@ -804,12 +769,8 @@ struct Point {
 >
 > *self-expression* → **`self`** | *self-method-expression* | *self-subscript-expression* | *self-initializer-expression*
 >
->
->
-> *self-method-expression* → **`self`** **`.`** *identifier*
->
-> *self-subscript-expression* → **`self`** **`[`** *function-call-argument-list* **`]`**
->
+> *self-method-expression* → **`self`** **`.`** *identifier* \
+> *self-subscript-expression* → **`self`** **`[`** *function-call-argument-list* **`]`** \
 > *self-initializer-expression* → **`self`** **`.`** **`init`**
 
 ### Superclass Expression
@@ -836,12 +797,8 @@ to make use of the implementation in their superclass.
 >
 > *superclass-expression* → *superclass-method-expression* | *superclass-subscript-expression* | *superclass-initializer-expression*
 >
->
->
-> *superclass-method-expression* → **`super`** **`.`** *identifier*
->
-> *superclass-subscript-expression* → **`super`** **`[`** *function-call-argument-list* **`]`**
->
+> *superclass-method-expression* → **`super`** **`.`** *identifier* \
+> *superclass-subscript-expression* → **`super`** **`[`** *function-call-argument-list* **`]`** \
 > *superclass-initializer-expression* → **`super`** **`.`** **`init`**
 
 ### Conditional Expression
@@ -921,22 +878,13 @@ even if one of the branches of a conditional expression is throwing.
 >
 > *conditional-expression* → *if-expression* | *switch-expression*
 >
->
->
-> *if-expression* → **`if`** *condition-list* **`{`** *statement* **`}`** *if-expression-tail*
->
-> *if-expression-tail* → **`else`** *if-expression*
->
+> *if-expression* → **`if`** *condition-list* **`{`** *statement* **`}`** *if-expression-tail* \
+> *if-expression-tail* → **`else`** *if-expression* \
 > *if-expression-tail* → **`else`** **`{`** *statement* **`}`** *if-expression-tail*
 >
->
->
-> *switch-expression* → **`switch`** *expression* **`{`** *switch-expression-cases* **`}`**
->
-> *switch-expression-cases* → *switch-expression-case* *switch-expression-cases*_?_
->
-> *switch-expression-case* → *case-label* *statement*
->
+> *switch-expression* → **`switch`** *expression* **`{`** *switch-expression-cases* **`}`** \
+> *switch-expression-cases* → *switch-expression-case* *switch-expression-cases*_?_ \
+> *switch-expression-case* → *case-label* *statement* \
 > *switch-expression-case* → *default-label* *statement*
 
 ### Closure Expression
@@ -1291,36 +1239,20 @@ see <doc:AutomaticReferenceCounting#Resolving-Strong-Reference-Cycles-for-Closur
 >
 > *closure-expression* → **`{`** *attributes*_?_ *closure-signature*_?_ *statements*_?_ **`}`**
 >
->
->
-> *closure-signature* → *capture-list*_?_ *closure-parameter-clause* **`async`**_?_ **`throws`**_?_ *function-result*_?_ **`in`**
->
+> *closure-signature* → *capture-list*_?_ *closure-parameter-clause* **`async`**_?_ **`throws`**_?_ *function-result*_?_ **`in`** \
 > *closure-signature* → *capture-list* **`in`**
 >
->
->
-> *closure-parameter-clause* → **`(`** **`)`** | **`(`** *closure-parameter-list* **`)`** | *identifier-list*
->
-> *closure-parameter-list* → *closure-parameter* | *closure-parameter* **`,`** *closure-parameter-list*
->
-> *closure-parameter* → *closure-parameter-name* *type-annotation*_?_
->
-> *closure-parameter* → *closure-parameter-name* *type-annotation* **`...`**
->
+> *closure-parameter-clause* → **`(`** **`)`** | **`(`** *closure-parameter-list* **`)`** | *identifier-list* \
+> *closure-parameter-list* → *closure-parameter* | *closure-parameter* **`,`** *closure-parameter-list* \
+> *closure-parameter* → *closure-parameter-name* *type-annotation*_?_ \
+> *closure-parameter* → *closure-parameter-name* *type-annotation* **`...`** \
 > *closure-parameter-name* → *identifier*
 >
->
->
-> *capture-list* → **`[`** *capture-list-items* **`]`**
->
-> *capture-list-items* → *capture-list-item* | *capture-list-item* **`,`** *capture-list-items*
->
-> *capture-list-item* → *capture-specifier*_?_ *identifier*
->
-> *capture-list-item* → *capture-specifier*_?_ *identifier* **`=`** *expression*
->
-> *capture-list-item* → *capture-specifier*_?_ *self-expression*
->
+> *capture-list* → **`[`** *capture-list-items* **`]`** \
+> *capture-list-items* → *capture-list-item* | *capture-list-item* **`,`** *capture-list-items* \
+> *capture-list-item* → *capture-specifier*_?_ *identifier* \
+> *capture-list-item* → *capture-specifier*_?_ *identifier* **`=`** *expression* \
+> *capture-list-item* → *capture-specifier*_?_ *self-expression* \
 > *capture-specifier* → **`weak`** | **`unowned`** | **`unowned(safe)`** | **`unowned(unsafe)`**
 
 ### Implicit Member Expression
@@ -1427,8 +1359,7 @@ and the type of `z` is convertible from `SomeSubclass` to `SomeClass`.
 
 > Grammar of a implicit member expression:
 >
-> *implicit-member-expression* → **`.`** *identifier*
->
+> *implicit-member-expression* → **`.`** *identifier* \
 > *implicit-member-expression* → **`.`** *identifier* **`.`** *postfix-expression*
 
 <!--
@@ -1535,10 +1466,8 @@ A single expression inside parentheses is a parenthesized expression.
 
 > Grammar of a tuple expression:
 >
-> *tuple-expression* → **`(`** **`)`** | **`(`** *tuple-element* **`,`** *tuple-element-list* **`)`**
->
-> *tuple-element-list* → *tuple-element* | *tuple-element* **`,`** *tuple-element-list*
->
+> *tuple-expression* → **`(`** **`)`** | **`(`** *tuple-element* **`,`** *tuple-element-list* **`)`** \
+> *tuple-element-list* → *tuple-element* | *tuple-element* **`,`** *tuple-element-list* \
 > *tuple-element* → *expression* | *identifier* **`:`** *expression*
 
 ### Wildcard Expression
@@ -2028,16 +1957,11 @@ and [Key-Value Observing Programming Guide](https://developer.apple.com/library/
 
 > Grammar of a key-path expression:
 >
-> *key-path-expression* → **`\`** *type*_?_ **`.`** *key-path-components*
->
-> *key-path-components* → *key-path-component* | *key-path-component* **`.`** *key-path-components*
->
+> *key-path-expression* → **`\`** *type*_?_ **`.`** *key-path-components* \
+> *key-path-components* → *key-path-component* | *key-path-component* **`.`** *key-path-components* \
 > *key-path-component* → *identifier* *key-path-postfixes*_?_ | *key-path-postfixes*
 >
->
->
-> *key-path-postfixes* → *key-path-postfix* *key-path-postfixes*_?_
->
+> *key-path-postfixes* → *key-path-postfix* *key-path-postfixes*_?_ \
 > *key-path-postfix* → **`?`** | **`!`** | **`self`** | **`[`** *function-call-argument-list* **`]`**
 
 ### Selector Expression
@@ -2145,10 +2069,8 @@ see [Using Objective-C Runtime Features in Swift](https://developer.apple.com/do
 
 > Grammar of a selector expression:
 >
-> *selector-expression* → **`#selector`** **`(`** *expression* **`)`**
->
-> *selector-expression* → **`#selector`** **`(`** **`getter:`** *expression* **`)`**
->
+> *selector-expression* → **`#selector`** **`(`** *expression* **`)`** \
+> *selector-expression* → **`#selector`** **`(`** **`getter:`** *expression* **`)`** \
 > *selector-expression* → **`#selector`** **`(`** **`setter:`** *expression* **`)`**
 
 <!--
@@ -2273,22 +2195,14 @@ see [Operator Declarations](https://developer.apple.com/documentation/swift/oper
 
 > Grammar of a postfix expression:
 >
-> *postfix-expression* → *primary-expression*
->
-> *postfix-expression* → *postfix-expression* *postfix-operator*
->
-> *postfix-expression* → *function-call-expression*
->
-> *postfix-expression* → *initializer-expression*
->
-> *postfix-expression* → *explicit-member-expression*
->
-> *postfix-expression* → *postfix-self-expression*
->
-> *postfix-expression* → *subscript-expression*
->
-> *postfix-expression* → *forced-value-expression*
->
+> *postfix-expression* → *primary-expression* \
+> *postfix-expression* → *postfix-expression* *postfix-operator* \
+> *postfix-expression* → *function-call-expression* \
+> *postfix-expression* → *initializer-expression* \
+> *postfix-expression* → *explicit-member-expression* \
+> *postfix-expression* → *postfix-self-expression* \
+> *postfix-expression* → *subscript-expression* \
+> *postfix-expression* → *forced-value-expression* \
 > *postfix-expression* → *optional-chaining-expression*
 
 ### Function Call Expression
@@ -2649,26 +2563,16 @@ avoid using `&` instead of using the unsafe APIs explicitly.
 
 > Grammar of a function call expression:
 >
-> *function-call-expression* → *postfix-expression* *function-call-argument-clause*
->
+> *function-call-expression* → *postfix-expression* *function-call-argument-clause* \
 > *function-call-expression* → *postfix-expression* *function-call-argument-clause*_?_ *trailing-closures*
 >
->
->
-> *function-call-argument-clause* → **`(`** **`)`** | **`(`** *function-call-argument-list* **`)`**
->
-> *function-call-argument-list* → *function-call-argument* | *function-call-argument* **`,`** *function-call-argument-list*
->
-> *function-call-argument* → *expression* | *identifier* **`:`** *expression*
->
+> *function-call-argument-clause* → **`(`** **`)`** | **`(`** *function-call-argument-list* **`)`** \
+> *function-call-argument-list* → *function-call-argument* | *function-call-argument* **`,`** *function-call-argument-list* \
+> *function-call-argument* → *expression* | *identifier* **`:`** *expression* \
 > *function-call-argument* → *operator* | *identifier* **`:`** *operator*
 >
->
->
-> *trailing-closures* → *closure-expression* *labeled-trailing-closures*_?_
->
-> *labeled-trailing-closures* → *labeled-trailing-closure* *labeled-trailing-closures*_?_
->
+> *trailing-closures* → *closure-expression* *labeled-trailing-closures*_?_ \
+> *labeled-trailing-closures* → *labeled-trailing-closure* *labeled-trailing-closures*_?_ \
 > *labeled-trailing-closure* → *identifier* **`:`** *closure-expression*
 
 ### Initializer Expression
@@ -2766,8 +2670,7 @@ let s4 = type(of: someValue)(data: 5)       // Error
 
 > Grammar of an initializer expression:
 >
-> *initializer-expression* → *postfix-expression* **`.`** **`init`**
->
+> *initializer-expression* → *postfix-expression* **`.`** **`init`** \
 > *initializer-expression* → *postfix-expression* **`.`** **`init`** **`(`** *argument-names* **`)`**
 
 ### Explicit Member Expression
@@ -3027,18 +2930,12 @@ The other branches can be empty.
 
 > Grammar of an explicit member expression:
 >
-> *explicit-member-expression* → *postfix-expression* **`.`** *decimal-digits*
->
-> *explicit-member-expression* → *postfix-expression* **`.`** *identifier* *generic-argument-clause*_?_
->
-> *explicit-member-expression* → *postfix-expression* **`.`** *identifier* **`(`** *argument-names* **`)`**
->
+> *explicit-member-expression* → *postfix-expression* **`.`** *decimal-digits* \
+> *explicit-member-expression* → *postfix-expression* **`.`** *identifier* *generic-argument-clause*_?_ \
+> *explicit-member-expression* → *postfix-expression* **`.`** *identifier* **`(`** *argument-names* **`)`** \
 > *explicit-member-expression* → *postfix-expression* *conditional-compilation-block*
 >
->
->
-> *argument-names* → *argument-name* *argument-names*_?_
->
+> *argument-names* → *argument-name* *argument-names*_?_ \
 > *argument-name* → *identifier* **`:`**
 
 <!--

--- a/TSPL.docc/ReferenceManual/GenericParametersAndArguments.md
+++ b/TSPL.docc/ReferenceManual/GenericParametersAndArguments.md
@@ -206,30 +206,18 @@ see <doc:Generics#Generic-Where-Clauses>.
 
 > Grammar of a generic parameter clause:
 >
-> *generic-parameter-clause* → **`<`** *generic-parameter-list* **`>`**
->
-> *generic-parameter-list* → *generic-parameter* | *generic-parameter* **`,`** *generic-parameter-list*
->
-> *generic-parameter* → *type-name*
->
-> *generic-parameter* → *type-name* **`:`** *type-identifier*
->
+> *generic-parameter-clause* → **`<`** *generic-parameter-list* **`>`** \
+> *generic-parameter-list* → *generic-parameter* | *generic-parameter* **`,`** *generic-parameter-list* \
+> *generic-parameter* → *type-name* \
+> *generic-parameter* → *type-name* **`:`** *type-identifier* \
 > *generic-parameter* → *type-name* **`:`** *protocol-composition-type*
 >
->
->
-> *generic-where-clause* → **`where`** *requirement-list*
->
-> *requirement-list* → *requirement* | *requirement* **`,`** *requirement-list*
->
+> *generic-where-clause* → **`where`** *requirement-list* \
+> *requirement-list* → *requirement* | *requirement* **`,`** *requirement-list* \
 > *requirement* → *conformance-requirement* | *same-type-requirement*
 >
->
->
-> *conformance-requirement* → *type-identifier* **`:`** *type-identifier*
->
-> *conformance-requirement* → *type-identifier* **`:`** *protocol-composition-type*
->
+> *conformance-requirement* → *type-identifier* **`:`** *type-identifier* \
+> *conformance-requirement* → *type-identifier* **`:`** *protocol-composition-type* \
 > *same-type-requirement* → *type-identifier* **`==`** *type*
 
 <!--
@@ -298,10 +286,8 @@ of a generic function or initializer.
 
 > Grammar of a generic argument clause:
 >
-> *generic-argument-clause* → **`<`** *generic-argument-list* **`>`**
->
-> *generic-argument-list* → *generic-argument* | *generic-argument* **`,`** *generic-argument-list*
->
+> *generic-argument-clause* → **`<`** *generic-argument-list* **`>`** \
+> *generic-argument-list* → *generic-argument* | *generic-argument* **`,`** *generic-argument-list* \
 > *generic-argument* → *type*
 
 > Beta Software:

--- a/TSPL.docc/ReferenceManual/LexicalStructure.md
+++ b/TSPL.docc/ReferenceManual/LexicalStructure.md
@@ -47,52 +47,29 @@ as described in [Markup Formatting Reference](https://developer.apple.com/librar
 
 > Grammar of whitespace:
 >
-> *whitespace* → *whitespace-item* *whitespace*_?_
->
-> *whitespace-item* → *line-break*
->
-> *whitespace-item* → *inline-space*
->
-> *whitespace-item* → *comment*
->
-> *whitespace-item* → *multiline-comment*
->
+> *whitespace* → *whitespace-item* *whitespace*_?_ \
+> *whitespace-item* → *line-break* \
+> *whitespace-item* → *inline-space* \
+> *whitespace-item* → *comment* \
+> *whitespace-item* → *multiline-comment* \
 > *whitespace-item* → U+0000, U+000B, or U+000C
 >
->
->
-> *line-break* → U+000A
->
-> *line-break* → U+000D
->
+> *line-break* → U+000A \
+> *line-break* → U+000D \
 > *line-break* → U+000D followed by U+000A
 >
->
->
-> *inline-spaces* → *inline-space* *inline-spaces*_?_
->
+> *inline-spaces* → *inline-space* *inline-spaces*_?_ \
 > *inline-space* → U+0009 or U+0020
 >
->
->
-> *comment* → **`//`** *comment-text* *line-break*
->
+> *comment* → **`//`** *comment-text* *line-break* \
 > *multiline-comment* → **`/*`** *multiline-comment-text* **`*/`**
 >
->
->
-> *comment-text* → *comment-text-item* *comment-text*_?_
->
+> *comment-text* → *comment-text-item* *comment-text*_?_ \
 > *comment-text-item* → Any Unicode scalar value except U+000A or U+000D
 >
->
->
-> *multiline-comment-text* → *multiline-comment-text-item* *multiline-comment-text*_?_
->
-> *multiline-comment-text-item* → *multiline-comment*
->
-> *multiline-comment-text-item* → *comment-text-item*
->
+> *multiline-comment-text* → *multiline-comment-text-item* *multiline-comment-text*_?_ \
+> *multiline-comment-text-item* → *multiline-comment* \
+> *multiline-comment-text-item* → *comment-text-item* \
 > *multiline-comment-text-item* → Any Unicode scalar value except  **`/*`** or  **`*/`**
 
 ## Identifiers
@@ -162,64 +139,35 @@ https://github.com/apple/swift-markdown/issues/93
 
 > Grammar of an identifier:
 >
-> *identifier* → *identifier-head* *identifier-characters*_?_
->
-> *identifier* → **`` ` ``** *identifier-head* *identifier-characters*_?_ **`` ` ``**
->
-> *identifier* → *implicit-parameter-name*
->
-> *identifier* → *property-wrapper-projection*
->
+> *identifier* → *identifier-head* *identifier-characters*_?_ \
+> *identifier* → **`` ` ``** *identifier-head* *identifier-characters*_?_ **`` ` ``** \
+> *identifier* → *implicit-parameter-name* \
+> *identifier* → *property-wrapper-projection* \
 > *identifier-list* → *identifier* | *identifier* **`,`** *identifier-list*
 >
->
->
-> *identifier-head* → Upper- or lowercase letter A through Z
->
-> *identifier-head* → **`_`**
->
-> *identifier-head* → U+00A8, U+00AA, U+00AD, U+00AF, U+00B2–U+00B5, or U+00B7–U+00BA
->
-> *identifier-head* → U+00BC–U+00BE, U+00C0–U+00D6, U+00D8–U+00F6, or U+00F8–U+00FF
->
-> *identifier-head* → U+0100–U+02FF, U+0370–U+167F, U+1681–U+180D, or U+180F–U+1DBF
->
-> *identifier-head* → U+1E00–U+1FFF
->
-> *identifier-head* → U+200B–U+200D, U+202A–U+202E, U+203F–U+2040, U+2054, or U+2060–U+206F
->
-> *identifier-head* → U+2070–U+20CF, U+2100–U+218F, U+2460–U+24FF, or U+2776–U+2793
->
-> *identifier-head* → U+2C00–U+2DFF or U+2E80–U+2FFF
->
-> *identifier-head* → U+3004–U+3007, U+3021–U+302F, U+3031–U+303F, or U+3040–U+D7FF
->
-> *identifier-head* → U+F900–U+FD3D, U+FD40–U+FDCF, U+FDF0–U+FE1F, or U+FE30–U+FE44
->
-> *identifier-head* → U+FE47–U+FFFD
->
-> *identifier-head* → U+10000–U+1FFFD, U+20000–U+2FFFD, U+30000–U+3FFFD, or U+40000–U+4FFFD
->
-> *identifier-head* → U+50000–U+5FFFD, U+60000–U+6FFFD, U+70000–U+7FFFD, or U+80000–U+8FFFD
->
-> *identifier-head* → U+90000–U+9FFFD, U+A0000–U+AFFFD, U+B0000–U+BFFFD, or U+C0000–U+CFFFD
->
+> *identifier-head* → Upper- or lowercase letter A through Z \
+> *identifier-head* → **`_`** \
+> *identifier-head* → U+00A8, U+00AA, U+00AD, U+00AF, U+00B2–U+00B5, or U+00B7–U+00BA \
+> *identifier-head* → U+00BC–U+00BE, U+00C0–U+00D6, U+00D8–U+00F6, or U+00F8–U+00FF \
+> *identifier-head* → U+0100–U+02FF, U+0370–U+167F, U+1681–U+180D, or U+180F–U+1DBF \
+> *identifier-head* → U+1E00–U+1FFF \
+> *identifier-head* → U+200B–U+200D, U+202A–U+202E, U+203F–U+2040, U+2054, or U+2060–U+206F \
+> *identifier-head* → U+2070–U+20CF, U+2100–U+218F, U+2460–U+24FF, or U+2776–U+2793 \
+> *identifier-head* → U+2C00–U+2DFF or U+2E80–U+2FFF \
+> *identifier-head* → U+3004–U+3007, U+3021–U+302F, U+3031–U+303F, or U+3040–U+D7FF \
+> *identifier-head* → U+F900–U+FD3D, U+FD40–U+FDCF, U+FDF0–U+FE1F, or U+FE30–U+FE44 \
+> *identifier-head* → U+FE47–U+FFFD \
+> *identifier-head* → U+10000–U+1FFFD, U+20000–U+2FFFD, U+30000–U+3FFFD, or U+40000–U+4FFFD \
+> *identifier-head* → U+50000–U+5FFFD, U+60000–U+6FFFD, U+70000–U+7FFFD, or U+80000–U+8FFFD \
+> *identifier-head* → U+90000–U+9FFFD, U+A0000–U+AFFFD, U+B0000–U+BFFFD, or U+C0000–U+CFFFD \
 > *identifier-head* → U+D0000–U+DFFFD or U+E0000–U+EFFFD
 >
->
->
-> *identifier-character* → Digit 0 through 9
->
-> *identifier-character* → U+0300–U+036F, U+1DC0–U+1DFF, U+20D0–U+20FF, or U+FE20–U+FE2F
->
-> *identifier-character* → *identifier-head*
->
+> *identifier-character* → Digit 0 through 9 \
+> *identifier-character* → U+0300–U+036F, U+1DC0–U+1DFF, U+20D0–U+20FF, or U+FE20–U+FE2F \
+> *identifier-character* → *identifier-head* \
 > *identifier-characters* → *identifier-character* *identifier-characters*_?_
 >
->
->
-> *implicit-parameter-name* → **`$`** *decimal-digits*
->
+> *implicit-parameter-name* → **`$`** *decimal-digits* \
 > *property-wrapper-projection* → **`$`** *identifier-characters*
 
 ## Keywords and Punctuation
@@ -537,12 +485,8 @@ in the declaration `let x: Int8 = 42`.
 >
 > *literal* → *numeric-literal* | *string-literal* | *regular-expression-literal* | *boolean-literal* | *nil-literal*
 >
->
->
-> *numeric-literal* → **`-`**_?_ *integer-literal* | **`-`**_?_ *floating-point-literal*
->
-> *boolean-literal* → **`true`** | **`false`**
->
+> *numeric-literal* → **`-`**_?_ *integer-literal* | **`-`**_?_ *floating-point-literal* \
+> *boolean-literal* → **`true`** | **`false`** \
 > *nil-literal* → **`nil`**
 
 ### Integer Literals
@@ -593,54 +537,30 @@ as described in <doc:TheBasics#Integers>.
 
 > Grammar of an integer literal:
 >
-> *integer-literal* → *binary-literal*
->
-> *integer-literal* → *octal-literal*
->
-> *integer-literal* → *decimal-literal*
->
+> *integer-literal* → *binary-literal* \
+> *integer-literal* → *octal-literal* \
+> *integer-literal* → *decimal-literal* \
 > *integer-literal* → *hexadecimal-literal*
 >
->
->
-> *binary-literal* → **`0b`** *binary-digit* *binary-literal-characters*_?_
->
-> *binary-digit* → Digit 0 or 1
->
-> *binary-literal-character* → *binary-digit* | **`_`**
->
+> *binary-literal* → **`0b`** *binary-digit* *binary-literal-characters*_?_ \
+> *binary-digit* → Digit 0 or 1 \
+> *binary-literal-character* → *binary-digit* | **`_`** \
 > *binary-literal-characters* → *binary-literal-character* *binary-literal-characters*_?_
 >
->
->
-> *octal-literal* → **`0o`** *octal-digit* *octal-literal-characters*_?_
->
-> *octal-digit* → Digit 0 through 7
->
-> *octal-literal-character* → *octal-digit* | **`_`**
->
+> *octal-literal* → **`0o`** *octal-digit* *octal-literal-characters*_?_ \
+> *octal-digit* → Digit 0 through 7 \
+> *octal-literal-character* → *octal-digit* | **`_`** \
 > *octal-literal-characters* → *octal-literal-character* *octal-literal-characters*_?_
 >
->
->
-> *decimal-literal* → *decimal-digit* *decimal-literal-characters*_?_
->
-> *decimal-digit* → Digit 0 through 9
->
-> *decimal-digits* → *decimal-digit* *decimal-digits*_?_
->
-> *decimal-literal-character* → *decimal-digit* | **`_`**
->
+> *decimal-literal* → *decimal-digit* *decimal-literal-characters*_?_ \
+> *decimal-digit* → Digit 0 through 9 \
+> *decimal-digits* → *decimal-digit* *decimal-digits*_?_ \
+> *decimal-literal-character* → *decimal-digit* | **`_`** \
 > *decimal-literal-characters* → *decimal-literal-character* *decimal-literal-characters*_?_
 >
->
->
-> *hexadecimal-literal* → **`0x`** *hexadecimal-digit* *hexadecimal-literal-characters*_?_
->
-> *hexadecimal-digit* → Digit 0 through 9, a through f, or A through F
->
-> *hexadecimal-literal-character* → *hexadecimal-digit* | **`_`**
->
+> *hexadecimal-literal* → **`0x`** *hexadecimal-digit* *hexadecimal-literal-characters*_?_ \
+> *hexadecimal-digit* → Digit 0 through 9, a through f, or A through F \
+> *hexadecimal-literal-character* → *hexadecimal-digit* | **`_`** \
 > *hexadecimal-literal-characters* → *hexadecimal-literal-character* *hexadecimal-literal-characters*_?_
 
 ### Floating-Point Literals
@@ -691,28 +611,17 @@ which represents a 32-bit floating-point number.
 
 > Grammar of a floating-point literal:
 >
-> *floating-point-literal* → *decimal-literal* *decimal-fraction*_?_ *decimal-exponent*_?_
->
+> *floating-point-literal* → *decimal-literal* *decimal-fraction*_?_ *decimal-exponent*_?_ \
 > *floating-point-literal* → *hexadecimal-literal* *hexadecimal-fraction*_?_ *hexadecimal-exponent*
 >
->
->
-> *decimal-fraction* → **`.`** *decimal-literal*
->
+> *decimal-fraction* → **`.`** *decimal-literal* \
 > *decimal-exponent* → *floating-point-e* *sign*_?_ *decimal-literal*
 >
->
->
-> *hexadecimal-fraction* → **`.`** *hexadecimal-digit* *hexadecimal-literal-characters*_?_
->
+> *hexadecimal-fraction* → **`.`** *hexadecimal-digit* *hexadecimal-literal-characters*_?_ \
 > *hexadecimal-exponent* → *floating-point-p* *sign*_?_ *decimal-literal*
 >
->
->
-> *floating-point-e* → **`e`** | **`E`**
->
-> *floating-point-p* → **`p`** | **`P`**
->
+> *floating-point-e* → **`e`** | **`E`** \
+> *floating-point-p* → **`p`** | **`P`** \
 > *sign* → **`+`** | **`-`**
 
 ### String Literals
@@ -960,73 +869,38 @@ let textB = "Hello world"
 >
 > *string-literal* → *static-string-literal* | *interpolated-string-literal*
 >
->
->
-> *string-literal-opening-delimiter* → *extended-string-literal-delimiter*_?_ **`"`**
->
+> *string-literal-opening-delimiter* → *extended-string-literal-delimiter*_?_ **`"`** \
 > *string-literal-closing-delimiter* → **`"`** *extended-string-literal-delimiter*_?_
 >
->
->
-> *static-string-literal* → *string-literal-opening-delimiter* *quoted-text*_?_ *string-literal-closing-delimiter*
->
+> *static-string-literal* → *string-literal-opening-delimiter* *quoted-text*_?_ *string-literal-closing-delimiter* \
 > *static-string-literal* → *multiline-string-literal-opening-delimiter* *multiline-quoted-text*_?_ *multiline-string-literal-closing-delimiter*
 >
->
->
-> *multiline-string-literal-opening-delimiter* → *extended-string-literal-delimiter*_?_ **`"""`**
->
-> *multiline-string-literal-closing-delimiter* → **`"""`** *extended-string-literal-delimiter*_?_
->
+> *multiline-string-literal-opening-delimiter* → *extended-string-literal-delimiter*_?_ **`"""`** \
+> *multiline-string-literal-closing-delimiter* → **`"""`** *extended-string-literal-delimiter*_?_ \
 > *extended-string-literal-delimiter* → **`#`** *extended-string-literal-delimiter*_?_
 >
->
->
-> *quoted-text* → *quoted-text-item* *quoted-text*_?_
->
-> *quoted-text-item* → *escaped-character*
->
+> *quoted-text* → *quoted-text-item* *quoted-text*_?_ \
+> *quoted-text-item* → *escaped-character* \
 > *quoted-text-item* → Any Unicode scalar value except  **`"`**,  **`\`**, U+000A, or U+000D
 >
->
->
-> *multiline-quoted-text* → *multiline-quoted-text-item* *multiline-quoted-text*_?_
->
-> *multiline-quoted-text-item* → *escaped-character*
->
-> *multiline-quoted-text-item* → Any Unicode scalar value except  **`\`**
->
+> *multiline-quoted-text* → *multiline-quoted-text-item* *multiline-quoted-text*_?_ \
+> *multiline-quoted-text-item* → *escaped-character* \
+> *multiline-quoted-text-item* → Any Unicode scalar value except  **`\`** \
 > *multiline-quoted-text-item* → *escaped-newline*
 >
->
->
-> *interpolated-string-literal* → *string-literal-opening-delimiter* *interpolated-text*_?_ *string-literal-closing-delimiter*
->
+> *interpolated-string-literal* → *string-literal-opening-delimiter* *interpolated-text*_?_ *string-literal-closing-delimiter* \
 > *interpolated-string-literal* → *multiline-string-literal-opening-delimiter* *multiline-interpolated-text*_?_ *multiline-string-literal-closing-delimiter*
 >
->
->
-> *interpolated-text* → *interpolated-text-item* *interpolated-text*_?_
->
+> *interpolated-text* → *interpolated-text-item* *interpolated-text*_?_ \
 > *interpolated-text-item* → **`\(`** *expression* **`)`** | *quoted-text-item*
 >
->
->
-> *multiline-interpolated-text* → *multiline-interpolated-text-item* *multiline-interpolated-text*_?_
->
+> *multiline-interpolated-text* → *multiline-interpolated-text-item* *multiline-interpolated-text*_?_ \
 > *multiline-interpolated-text-item* → **`\(`** *expression* **`)`** | *multiline-quoted-text-item*
 >
->
->
-> *escape-sequence* → **`\`** *extended-string-literal-delimiter*
->
-> *escaped-character* → *escape-sequence* **`0`** | *escape-sequence* **`\`** | *escape-sequence* **`t`** | *escape-sequence* **`n`** | *escape-sequence* **`r`** | *escape-sequence* **`"`** | *escape-sequence* **`'`**
->
-> *escaped-character* → *escape-sequence* **`u`** **`{`** *unicode-scalar-digits* **`}`**
->
+> *escape-sequence* → **`\`** *extended-string-literal-delimiter* \
+> *escaped-character* → *escape-sequence* **`0`** | *escape-sequence* **`\`** | *escape-sequence* **`t`** | *escape-sequence* **`n`** | *escape-sequence* **`r`** | *escape-sequence* **`"`** | *escape-sequence* **`'`** \
+> *escaped-character* → *escape-sequence* **`u`** **`{`** *unicode-scalar-digits* **`}`** \
 > *unicode-scalar-digits* → Between one and eight hexadecimal digits
->
->
 >
 > *escaped-newline* → *escape-sequence* *inline-spaces*_?_ *line-break*
 
@@ -1151,17 +1025,11 @@ you must use the extended delimiter syntax.
 
 > Grammar of a regular expression literal:
 >
-> *regular-expression-literal* → *regular-expression-literal-opening-delimiter* *regular-expression* *regular-expression-literal-closing-delimiter*
->
+> *regular-expression-literal* → *regular-expression-literal-opening-delimiter* *regular-expression* *regular-expression-literal-closing-delimiter* \
 > *regular-expression* → Any regular expression
 >
->
->
-> *regular-expression-literal-opening-delimiter* → *extended-regular-expression-literal-delimiter*_?_ **`/`**
->
+> *regular-expression-literal-opening-delimiter* → *extended-regular-expression-literal-delimiter*_?_ **`/`** \
 > *regular-expression-literal-closing-delimiter* → **`/`** *extended-regular-expression-literal-delimiter*_?_
->
->
 >
 > *extended-regular-expression-literal-delimiter* → **`#`** *extended-regular-expression-literal-delimiter*_?_
 
@@ -1330,80 +1198,43 @@ see <doc:AdvancedOperators#Operator-Methods>.
 
 > Grammar of operators:
 >
-> *operator* → *operator-head* *operator-characters*_?_
->
+> *operator* → *operator-head* *operator-characters*_?_ \
 > *operator* → *dot-operator-head* *dot-operator-characters*
 >
->
->
-> *operator-head* → **`/`** | **`=`** | **`-`** | **`+`** | **`!`** | **`*`** | **`%`** | **`<`** | **`>`** | **`&`** | **`|`** | **`^`** | **`~`** | **`?`**
->
-> *operator-head* → U+00A1–U+00A7
->
-> *operator-head* → U+00A9 or U+00AB
->
-> *operator-head* → U+00AC or U+00AE
->
-> *operator-head* → U+00B0–U+00B1
->
-> *operator-head* → U+00B6, U+00BB, U+00BF, U+00D7, or U+00F7
->
-> *operator-head* → U+2016–U+2017
->
-> *operator-head* → U+2020–U+2027
->
-> *operator-head* → U+2030–U+203E
->
-> *operator-head* → U+2041–U+2053
->
-> *operator-head* → U+2055–U+205E
->
-> *operator-head* → U+2190–U+23FF
->
-> *operator-head* → U+2500–U+2775
->
-> *operator-head* → U+2794–U+2BFF
->
-> *operator-head* → U+2E00–U+2E7F
->
-> *operator-head* → U+3001–U+3003
->
-> *operator-head* → U+3008–U+3020
->
+> *operator-head* → **`/`** | **`=`** | **`-`** | **`+`** | **`!`** | **`*`** | **`%`** | **`<`** | **`>`** | **`&`** | **`|`** | **`^`** | **`~`** | **`?`** \
+> *operator-head* → U+00A1–U+00A7 \
+> *operator-head* → U+00A9 or U+00AB \
+> *operator-head* → U+00AC or U+00AE \
+> *operator-head* → U+00B0–U+00B1 \
+> *operator-head* → U+00B6, U+00BB, U+00BF, U+00D7, or U+00F7 \
+> *operator-head* → U+2016–U+2017 \
+> *operator-head* → U+2020–U+2027 \
+> *operator-head* → U+2030–U+203E \
+> *operator-head* → U+2041–U+2053 \
+> *operator-head* → U+2055–U+205E \
+> *operator-head* → U+2190–U+23FF \
+> *operator-head* → U+2500–U+2775 \
+> *operator-head* → U+2794–U+2BFF \
+> *operator-head* → U+2E00–U+2E7F \
+> *operator-head* → U+3001–U+3003 \
+> *operator-head* → U+3008–U+3020 \
 > *operator-head* → U+3030
 >
->
->
-> *operator-character* → *operator-head*
->
-> *operator-character* → U+0300–U+036F
->
-> *operator-character* → U+1DC0–U+1DFF
->
-> *operator-character* → U+20D0–U+20FF
->
-> *operator-character* → U+FE00–U+FE0F
->
-> *operator-character* → U+FE20–U+FE2F
->
-> *operator-character* → U+E0100–U+E01EF
->
+> *operator-character* → *operator-head* \
+> *operator-character* → U+0300–U+036F \
+> *operator-character* → U+1DC0–U+1DFF \
+> *operator-character* → U+20D0–U+20FF \
+> *operator-character* → U+FE00–U+FE0F \
+> *operator-character* → U+FE20–U+FE2F \
+> *operator-character* → U+E0100–U+E01EF \
 > *operator-characters* → *operator-character* *operator-characters*_?_
 >
->
->
-> *dot-operator-head* → **`.`**
->
-> *dot-operator-character* → **`.`** | *operator-character*
->
+> *dot-operator-head* → **`.`** \
+> *dot-operator-character* → **`.`** | *operator-character* \
 > *dot-operator-characters* → *dot-operator-character* *dot-operator-characters*_?_
 >
->
->
-> *infix-operator* → *operator*
->
-> *prefix-operator* → *operator*
->
+> *infix-operator* → *operator* \
+> *prefix-operator* → *operator* \
 > *postfix-operator* → *operator*
 
 > Beta Software:

--- a/TSPL.docc/ReferenceManual/Patterns.md
+++ b/TSPL.docc/ReferenceManual/Patterns.md
@@ -33,20 +33,13 @@ or in the case condition of an `if`, `while`,
 
 > Grammar of a pattern:
 >
-> *pattern* → *wildcard-pattern* *type-annotation*_?_
->
-> *pattern* → *identifier-pattern* *type-annotation*_?_
->
-> *pattern* → *value-binding-pattern*
->
-> *pattern* → *tuple-pattern* *type-annotation*_?_
->
-> *pattern* → *enum-case-pattern*
->
-> *pattern* → *optional-pattern*
->
-> *pattern* → *type-casting-pattern*
->
+> *pattern* → *wildcard-pattern* *type-annotation*_?_ \
+> *pattern* → *identifier-pattern* *type-annotation*_?_ \
+> *pattern* → *value-binding-pattern* \
+> *pattern* → *tuple-pattern* *type-annotation*_?_ \
+> *pattern* → *enum-case-pattern* \
+> *pattern* → *optional-pattern* \
+> *pattern* → *type-casting-pattern* \
 > *pattern* → *expression-pattern*
 
 ## Wildcard Pattern
@@ -240,10 +233,8 @@ let (a): Int = 2 // a: Int = 2
 
 > Grammar of a tuple pattern:
 >
-> *tuple-pattern* → **`(`** *tuple-pattern-element-list*_?_ **`)`**
->
-> *tuple-pattern-element-list* → *tuple-pattern-element* | *tuple-pattern-element* **`,`** *tuple-pattern-element-list*
->
+> *tuple-pattern* → **`(`** *tuple-pattern-element-list*_?_ **`)`** \
+> *tuple-pattern-element-list* → *tuple-pattern-element* | *tuple-pattern-element* **`,`** *tuple-pattern-element-list* \
 > *tuple-pattern-element* → *pattern* | *identifier* **`:`** *pattern*
 
 ## Enumeration Case Pattern
@@ -408,10 +399,8 @@ see <doc:TypeCasting#Type-Casting-for-Any-and-AnyObject>.
 
 > Grammar of a type casting pattern:
 >
-> *type-casting-pattern* → *is-pattern* | *as-pattern*
->
-> *is-pattern* → **`is`** *type*
->
+> *type-casting-pattern* → *is-pattern* | *as-pattern* \
+> *is-pattern* → **`is`** *type* \
 > *as-pattern* → *pattern* **`as`** *type*
 
 ## Expression Pattern

--- a/TSPL.docc/ReferenceManual/Statements.md
+++ b/TSPL.docc/ReferenceManual/Statements.md
@@ -24,24 +24,15 @@ and is used to separate multiple statements if they appear on the same line.
 
 > Grammar of a statement:
 >
-> *statement* → *expression* **`;`**_?_
->
-> *statement* → *declaration* **`;`**_?_
->
-> *statement* → *loop-statement* **`;`**_?_
->
-> *statement* → *branch-statement* **`;`**_?_
->
-> *statement* → *labeled-statement* **`;`**_?_
->
-> *statement* → *control-transfer-statement* **`;`**_?_
->
-> *statement* → *defer-statement* **`;`**_?_
->
-> *statement* → *do-statement* **`;`**_?_
->
-> *statement* → *compiler-control-statement*
->
+> *statement* → *expression* **`;`**_?_ \
+> *statement* → *declaration* **`;`**_?_ \
+> *statement* → *loop-statement* **`;`**_?_ \
+> *statement* → *branch-statement* **`;`**_?_ \
+> *statement* → *labeled-statement* **`;`**_?_ \
+> *statement* → *control-transfer-statement* **`;`**_?_ \
+> *statement* → *defer-statement* **`;`**_?_ \
+> *statement* → *do-statement* **`;`**_?_ \
+> *statement* → *compiler-control-statement* \
 > *statements* → *statement* *statements*_?_
 
 <!--
@@ -70,10 +61,8 @@ and a `continue` statement and is discussed in <doc:Statements#Break-Statement> 
 
 > Grammar of a loop statement:
 >
-> *loop-statement* → *for-in-statement*
->
-> *loop-statement* → *while-statement*
->
+> *loop-statement* → *for-in-statement* \
+> *loop-statement* → *while-statement* \
 > *loop-statement* → *repeat-while-statement*
 
 ### For-In Statement
@@ -141,16 +130,10 @@ as discussed in <doc:TheBasics#Optional-Binding>.
 >
 > *while-statement* → **`while`** *condition-list* *code-block*
 >
->
->
-> *condition-list* → *condition* | *condition* **`,`** *condition-list*
->
+> *condition-list* → *condition* | *condition* **`,`** *condition-list* \
 > *condition* → *expression* | *availability-condition* | *case-condition* | *optional-binding-condition*
 >
->
->
-> *case-condition* → **`case`** *pattern* *initializer*
->
+> *case-condition* → **`case`** *pattern* *initializer* \
 > *optional-binding-condition* → **`let`** *pattern* *initializer*_?_ | **`var`** *pattern* *initializer*_?_
 
 ### Repeat-While Statement
@@ -199,10 +182,8 @@ and is discussed in <doc:Statements#Break-Statement> below.
 
 > Grammar of a branch statement:
 >
-> *branch-statement* → *if-statement*
->
-> *branch-statement* → *guard-statement*
->
+> *branch-statement* → *if-statement* \
+> *branch-statement* → *guard-statement* \
 > *branch-statement* → *switch-statement*
 
 ### If Statement
@@ -257,8 +238,7 @@ as discussed in <doc:TheBasics#Optional-Binding>.
 
 > Grammar of an if statement:
 >
-> *if-statement* → **`if`** *condition-list* *code-block* *else-clause*_?_
->
+> *if-statement* → **`if`** *condition-list* *code-block* *else-clause*_?_ \
 > *else-clause* → **`else`** *code-block* | **`else`** *if-statement*
 
 ### Guard Statement
@@ -517,40 +497,23 @@ see <doc:Statements#Fallthrough-Statement> below.
 
 > Grammar of a switch statement:
 >
-> *switch-statement* → **`switch`** *expression* **`{`** *switch-cases*_?_ **`}`**
->
-> *switch-cases* → *switch-case* *switch-cases*_?_
->
-> *switch-case* → *case-label* *statements*
->
-> *switch-case* → *default-label* *statements*
->
+> *switch-statement* → **`switch`** *expression* **`{`** *switch-cases*_?_ **`}`** \
+> *switch-cases* → *switch-case* *switch-cases*_?_ \
+> *switch-case* → *case-label* *statements* \
+> *switch-case* → *default-label* *statements* \
 > *switch-case* → *conditional-switch-case*
 >
->
->
-> *case-label* → *attributes*_?_ **`case`** *case-item-list* **`:`**
->
-> *case-item-list* → *pattern* *where-clause*_?_ | *pattern* *where-clause*_?_ **`,`** *case-item-list*
->
+> *case-label* → *attributes*_?_ **`case`** *case-item-list* **`:`** \
+> *case-item-list* → *pattern* *where-clause*_?_ | *pattern* *where-clause*_?_ **`,`** *case-item-list* \
 > *default-label* → *attributes*_?_ **`default`** **`:`**
 >
->
->
-> *where-clause* → **`where`** *where-expression*
->
+> *where-clause* → **`where`** *where-expression* \
 > *where-expression* → *expression*
 >
->
->
-> *conditional-switch-case* → *switch-if-directive-clause* *switch-elseif-directive-clauses*_?_ *switch-else-directive-clause*_?_ *endif-directive*
->
-> *switch-if-directive-clause* → *if-directive* *compilation-condition* *switch-cases*_?_
->
-> *switch-elseif-directive-clauses* → *elseif-directive-clause* *switch-elseif-directive-clauses*_?_
->
-> *switch-elseif-directive-clause* → *elseif-directive* *compilation-condition* *switch-cases*_?_
->
+> *conditional-switch-case* → *switch-if-directive-clause* *switch-elseif-directive-clauses*_?_ *switch-else-directive-clause*_?_ *endif-directive* \
+> *switch-if-directive-clause* → *if-directive* *compilation-condition* *switch-cases*_?_ \
+> *switch-elseif-directive-clauses* → *elseif-directive-clause* *switch-elseif-directive-clauses*_?_ \
+> *switch-elseif-directive-clause* → *elseif-directive* *compilation-condition* *switch-cases*_?_ \
 > *switch-else-directive-clause* → *else-directive* *switch-cases*_?_
 
 <!--
@@ -594,18 +557,12 @@ see <doc:ControlFlow#Labeled-Statements> in <doc:ControlFlow>.
 
 > Grammar of a labeled statement:
 >
-> *labeled-statement* → *statement-label* *loop-statement*
->
-> *labeled-statement* → *statement-label* *if-statement*
->
-> *labeled-statement* → *statement-label* *switch-statement*
->
+> *labeled-statement* → *statement-label* *loop-statement* \
+> *labeled-statement* → *statement-label* *if-statement* \
+> *labeled-statement* → *statement-label* *switch-statement* \
 > *labeled-statement* → *statement-label* *do-statement*
 >
->
->
-> *statement-label* → *label-name* **`:`**
->
+> *statement-label* → *label-name* **`:`** \
 > *label-name* → *identifier*
 
 ## Control Transfer Statements
@@ -617,14 +574,10 @@ a `fallthrough` statement, a `return` statement, and a `throw` statement.
 
 > Grammar of a control transfer statement:
 >
-> *control-transfer-statement* → *break-statement*
->
-> *control-transfer-statement* → *continue-statement*
->
-> *control-transfer-statement* → *fallthrough-statement*
->
-> *control-transfer-statement* → *return-statement*
->
+> *control-transfer-statement* → *break-statement* \
+> *control-transfer-statement* → *continue-statement* \
+> *control-transfer-statement* → *fallthrough-statement* \
+> *control-transfer-statement* → *return-statement* \
 > *control-transfer-statement* → *throw-statement*
 
 ### Break Statement
@@ -961,14 +914,10 @@ see <doc:ErrorHandling#Handling-Errors>.
 
 > Grammar of a do statement:
 >
-> *do-statement* → **`do`** *code-block* *catch-clauses*_?_
->
-> *catch-clauses* → *catch-clause* *catch-clauses*_?_
->
-> *catch-clause* → **`catch`** *catch-pattern-list*_?_ *code-block*
->
-> *catch-pattern-list* → *catch-pattern* | *catch-pattern* **`,`** *catch-pattern-list*
->
+> *do-statement* → **`do`** *code-block* *catch-clauses*_?_ \
+> *catch-clauses* → *catch-clause* *catch-clauses*_?_ \
+> *catch-clause* → **`catch`** *catch-pattern-list*_?_ *code-block* \
+> *catch-pattern-list* → *catch-pattern* | *catch-pattern* **`,`** *catch-pattern-list* \
 > *catch-pattern* → *pattern* *where-clause*_?_
 
 ## Compiler Control Statements
@@ -981,10 +930,8 @@ and a compile-time diagnostic statement.
 
 > Grammar of a compiler control statement:
 >
-> *compiler-control-statement* → *conditional-compilation-block*
->
-> *compiler-control-statement* → *line-control-statement*
->
+> *compiler-control-statement* → *conditional-compilation-block* \
+> *compiler-control-statement* → *line-control-statement* \
 > *compiler-control-statement* → *diagnostic-statement*
 
 ### Conditional Compilation Block
@@ -1239,64 +1186,34 @@ see <doc:Expressions#Explicit-Member-Expression>.
 >
 > *conditional-compilation-block* → *if-directive-clause* *elseif-directive-clauses*_?_ *else-directive-clause*_?_ *endif-directive*
 >
->
->
-> *if-directive-clause* → *if-directive* *compilation-condition* *statements*_?_
->
-> *elseif-directive-clauses* → *elseif-directive-clause* *elseif-directive-clauses*_?_
->
-> *elseif-directive-clause* → *elseif-directive* *compilation-condition* *statements*_?_
->
-> *else-directive-clause* → *else-directive* *statements*_?_
->
-> *if-directive* → **`#if`**
->
-> *elseif-directive* → **`#elseif`**
->
-> *else-directive* → **`#else`**
->
+> *if-directive-clause* → *if-directive* *compilation-condition* *statements*_?_ \
+> *elseif-directive-clauses* → *elseif-directive-clause* *elseif-directive-clauses*_?_ \
+> *elseif-directive-clause* → *elseif-directive* *compilation-condition* *statements*_?_ \
+> *else-directive-clause* → *else-directive* *statements*_?_ \
+> *if-directive* → **`#if`** \
+> *elseif-directive* → **`#elseif`** \
+> *else-directive* → **`#else`** \
 > *endif-directive* → **`#endif`**
 >
->
->
-> *compilation-condition* → *platform-condition*
->
-> *compilation-condition* → *identifier*
->
-> *compilation-condition* → *boolean-literal*
->
-> *compilation-condition* → **`(`** *compilation-condition* **`)`**
->
-> *compilation-condition* → **`!`** *compilation-condition*
->
-> *compilation-condition* → *compilation-condition* **`&&`** *compilation-condition*
->
+> *compilation-condition* → *platform-condition* \
+> *compilation-condition* → *identifier* \
+> *compilation-condition* → *boolean-literal* \
+> *compilation-condition* → **`(`** *compilation-condition* **`)`** \
+> *compilation-condition* → **`!`** *compilation-condition* \
+> *compilation-condition* → *compilation-condition* **`&&`** *compilation-condition* \
 > *compilation-condition* → *compilation-condition* **`||`** *compilation-condition*
 >
->
->
-> *platform-condition* → **`os`** **`(`** *operating-system* **`)`**
->
-> *platform-condition* → **`arch`** **`(`** *architecture* **`)`**
->
-> *platform-condition* → **`swift`** **`(`** **`>=`** *swift-version* **`)`** | **`swift`** **`(`** **`<`** *swift-version* **`)`**
->
-> *platform-condition* → **`compiler`** **`(`** **`>=`** *swift-version* **`)`** | **`compiler`** **`(`** **`<`** *swift-version* **`)`**
->
-> *platform-condition* → **`canImport`** **`(`** *import-path* **`)`**
->
+> *platform-condition* → **`os`** **`(`** *operating-system* **`)`** \
+> *platform-condition* → **`arch`** **`(`** *architecture* **`)`** \
+> *platform-condition* → **`swift`** **`(`** **`>=`** *swift-version* **`)`** | **`swift`** **`(`** **`<`** *swift-version* **`)`** \
+> *platform-condition* → **`compiler`** **`(`** **`>=`** *swift-version* **`)`** | **`compiler`** **`(`** **`<`** *swift-version* **`)`** \
+> *platform-condition* → **`canImport`** **`(`** *import-path* **`)`** \
 > *platform-condition* → **`targetEnvironment`** **`(`** *environment* **`)`**
 >
->
->
-> *operating-system* → **`macOS`** | **`iOS`** | **`watchOS`** | **`tvOS`** | **`Linux`** | **`Windows`**
->
-> *architecture* → **`i386`** | **`x86_64`** | **`arm`** | **`arm64`**
->
-> *swift-version* → *decimal-digits* *swift-version-continuation*_?_
->
-> *swift-version-continuation* → **`.`** *decimal-digits* *swift-version-continuation*_?_
->
+> *operating-system* → **`macOS`** | **`iOS`** | **`watchOS`** | **`tvOS`** | **`Linux`** | **`Windows`** \
+> *architecture* → **`i386`** | **`x86_64`** | **`arm`** | **`arm64`** \
+> *swift-version* → *decimal-digits* *swift-version-continuation*_?_ \
+> *swift-version-continuation* → **`.`** *decimal-digits* *swift-version-continuation*_?_ \
 > *environment* → **`simulator`** | **`macCatalyst`**
 
 <!--
@@ -1344,12 +1261,9 @@ resets the source code location back to the default line numbering and file path
 
 > Grammar of a line control statement:
 >
-> *line-control-statement* → **`#sourceLocation`** **`(`** **`file:`** *file-path* **`,`** **`line:`** *line-number* **`)`**
->
-> *line-control-statement* → **`#sourceLocation`** **`(`** **`)`**
->
-> *line-number* → A decimal integer greater than zero
->
+> *line-control-statement* → **`#sourceLocation`** **`(`** **`file:`** *file-path* **`,`** **`line:`** *line-number* **`)`** \
+> *line-control-statement* → **`#sourceLocation`** **`(`** **`)`** \
+> *line-number* → A decimal integer greater than zero \
 > *file-path* → *static-string-literal*
 
 ### Compile-Time Diagnostic Statement
@@ -1410,32 +1324,19 @@ It has the same meaning as the `*` argument in an availability condition.
 
 > Grammar of an availability condition:
 >
-> *availability-condition* → **`#available`** **`(`** *availability-arguments* **`)`**
->
-> *availability-condition* → **`#unavailable`** **`(`** *availability-arguments* **`)`**
->
-> *availability-arguments* → *availability-argument* | *availability-argument* **`,`** *availability-arguments*
->
-> *availability-argument* → *platform-name* *platform-version*
->
+> *availability-condition* → **`#available`** **`(`** *availability-arguments* **`)`** \
+> *availability-condition* → **`#unavailable`** **`(`** *availability-arguments* **`)`** \
+> *availability-arguments* → *availability-argument* | *availability-argument* **`,`** *availability-arguments* \
+> *availability-argument* → *platform-name* *platform-version* \
 > *availability-argument* → **`*`**
 >
->
->
-> *platform-name* → **`iOS`** | **`iOSApplicationExtension`**
->
-> *platform-name* → **`macOS`** | **`macOSApplicationExtension`**
->
-> *platform-name* → **`macCatalyst`** | **`macCatalystApplicationExtension`**
->
-> *platform-name* → **`watchOS`** | **`watchOSApplicationExtension`**
->
-> *platform-name* → **`tvOS`** | **`tvOSApplicationExtension`**
->
-> *platform-version* → *decimal-digits*
->
-> *platform-version* → *decimal-digits* **`.`** *decimal-digits*
->
+> *platform-name* → **`iOS`** | **`iOSApplicationExtension`** \
+> *platform-name* → **`macOS`** | **`macOSApplicationExtension`** \
+> *platform-name* → **`macCatalyst`** | **`macCatalystApplicationExtension`** \
+> *platform-name* → **`watchOS`** | **`watchOSApplicationExtension`** \
+> *platform-name* → **`tvOS`** | **`tvOSApplicationExtension`** \
+> *platform-version* → *decimal-digits* \
+> *platform-version* → *decimal-digits* **`.`** *decimal-digits* \
 > *platform-version* → *decimal-digits* **`.`** *decimal-digits* **`.`** *decimal-digits*
 
 <!--

--- a/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
+++ b/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
@@ -19,402 +19,221 @@ make the same change here also.
 
 > Grammar of whitespace:
 >
-> *whitespace* → *whitespace-item* *whitespace*_?_
->
-> *whitespace-item* → *line-break*
->
-> *whitespace-item* → *inline-space*
->
-> *whitespace-item* → *comment*
->
-> *whitespace-item* → *multiline-comment*
->
+> *whitespace* → *whitespace-item* *whitespace*_?_ \
+> *whitespace-item* → *line-break* \
+> *whitespace-item* → *inline-space* \
+> *whitespace-item* → *comment* \
+> *whitespace-item* → *multiline-comment* \
 > *whitespace-item* → U+0000, U+000B, or U+000C
 >
->
->
-> *line-break* → U+000A
->
-> *line-break* → U+000D
->
+> *line-break* → U+000A \
+> *line-break* → U+000D \
 > *line-break* → U+000D followed by U+000A
 >
->
->
-> *inline-spaces* → *inline-space* *inline-spaces*_?_
->
+> *inline-spaces* → *inline-space* *inline-spaces*_?_ \
 > *inline-space* → U+0009 or U+0020
 >
->
->
-> *comment* → **`//`** *comment-text* *line-break*
->
+> *comment* → **`//`** *comment-text* *line-break* \
 > *multiline-comment* → **`/*`** *multiline-comment-text* **`*/`**
 >
->
->
-> *comment-text* → *comment-text-item* *comment-text*_?_
->
+> *comment-text* → *comment-text-item* *comment-text*_?_ \
 > *comment-text-item* → Any Unicode scalar value except U+000A or U+000D
 >
->
->
-> *multiline-comment-text* → *multiline-comment-text-item* *multiline-comment-text*_?_
->
-> *multiline-comment-text-item* → *multiline-comment*
->
-> *multiline-comment-text-item* → *comment-text-item*
->
+> *multiline-comment-text* → *multiline-comment-text-item* *multiline-comment-text*_?_ \
+> *multiline-comment-text-item* → *multiline-comment* \
+> *multiline-comment-text-item* → *comment-text-item* \
 > *multiline-comment-text-item* → Any Unicode scalar value except  **`/*`** or  **`*/`**
 
 > Grammar of an identifier:
 >
-> *identifier* → *identifier-head* *identifier-characters*_?_
->
-> *identifier* → **`` ` ``** *identifier-head* *identifier-characters*_?_ **`` ` ``**
->
-> *identifier* → *implicit-parameter-name*
->
-> *identifier* → *property-wrapper-projection*
->
+> *identifier* → *identifier-head* *identifier-characters*_?_ \
+> *identifier* → **`` ` ``** *identifier-head* *identifier-characters*_?_ **`` ` ``** \
+> *identifier* → *implicit-parameter-name* \
+> *identifier* → *property-wrapper-projection* \
 > *identifier-list* → *identifier* | *identifier* **`,`** *identifier-list*
 >
->
->
-> *identifier-head* → Upper- or lowercase letter A through Z
->
-> *identifier-head* → **`_`**
->
-> *identifier-head* → U+00A8, U+00AA, U+00AD, U+00AF, U+00B2–U+00B5, or U+00B7–U+00BA
->
-> *identifier-head* → U+00BC–U+00BE, U+00C0–U+00D6, U+00D8–U+00F6, or U+00F8–U+00FF
->
-> *identifier-head* → U+0100–U+02FF, U+0370–U+167F, U+1681–U+180D, or U+180F–U+1DBF
->
-> *identifier-head* → U+1E00–U+1FFF
->
-> *identifier-head* → U+200B–U+200D, U+202A–U+202E, U+203F–U+2040, U+2054, or U+2060–U+206F
->
-> *identifier-head* → U+2070–U+20CF, U+2100–U+218F, U+2460–U+24FF, or U+2776–U+2793
->
-> *identifier-head* → U+2C00–U+2DFF or U+2E80–U+2FFF
->
-> *identifier-head* → U+3004–U+3007, U+3021–U+302F, U+3031–U+303F, or U+3040–U+D7FF
->
-> *identifier-head* → U+F900–U+FD3D, U+FD40–U+FDCF, U+FDF0–U+FE1F, or U+FE30–U+FE44
->
-> *identifier-head* → U+FE47–U+FFFD
->
-> *identifier-head* → U+10000–U+1FFFD, U+20000–U+2FFFD, U+30000–U+3FFFD, or U+40000–U+4FFFD
->
-> *identifier-head* → U+50000–U+5FFFD, U+60000–U+6FFFD, U+70000–U+7FFFD, or U+80000–U+8FFFD
->
-> *identifier-head* → U+90000–U+9FFFD, U+A0000–U+AFFFD, U+B0000–U+BFFFD, or U+C0000–U+CFFFD
->
+> *identifier-head* → Upper- or lowercase letter A through Z \
+> *identifier-head* → **`_`** \
+> *identifier-head* → U+00A8, U+00AA, U+00AD, U+00AF, U+00B2–U+00B5, or U+00B7–U+00BA \
+> *identifier-head* → U+00BC–U+00BE, U+00C0–U+00D6, U+00D8–U+00F6, or U+00F8–U+00FF \
+> *identifier-head* → U+0100–U+02FF, U+0370–U+167F, U+1681–U+180D, or U+180F–U+1DBF \
+> *identifier-head* → U+1E00–U+1FFF \
+> *identifier-head* → U+200B–U+200D, U+202A–U+202E, U+203F–U+2040, U+2054, or U+2060–U+206F \
+> *identifier-head* → U+2070–U+20CF, U+2100–U+218F, U+2460–U+24FF, or U+2776–U+2793 \
+> *identifier-head* → U+2C00–U+2DFF or U+2E80–U+2FFF \
+> *identifier-head* → U+3004–U+3007, U+3021–U+302F, U+3031–U+303F, or U+3040–U+D7FF \
+> *identifier-head* → U+F900–U+FD3D, U+FD40–U+FDCF, U+FDF0–U+FE1F, or U+FE30–U+FE44 \
+> *identifier-head* → U+FE47–U+FFFD \
+> *identifier-head* → U+10000–U+1FFFD, U+20000–U+2FFFD, U+30000–U+3FFFD, or U+40000–U+4FFFD \
+> *identifier-head* → U+50000–U+5FFFD, U+60000–U+6FFFD, U+70000–U+7FFFD, or U+80000–U+8FFFD \
+> *identifier-head* → U+90000–U+9FFFD, U+A0000–U+AFFFD, U+B0000–U+BFFFD, or U+C0000–U+CFFFD \
 > *identifier-head* → U+D0000–U+DFFFD or U+E0000–U+EFFFD
 >
->
->
-> *identifier-character* → Digit 0 through 9
->
-> *identifier-character* → U+0300–U+036F, U+1DC0–U+1DFF, U+20D0–U+20FF, or U+FE20–U+FE2F
->
-> *identifier-character* → *identifier-head*
->
+> *identifier-character* → Digit 0 through 9 \
+> *identifier-character* → U+0300–U+036F, U+1DC0–U+1DFF, U+20D0–U+20FF, or U+FE20–U+FE2F \
+> *identifier-character* → *identifier-head* \
 > *identifier-characters* → *identifier-character* *identifier-characters*_?_
 >
->
->
-> *implicit-parameter-name* → **`$`** *decimal-digits*
->
+> *implicit-parameter-name* → **`$`** *decimal-digits* \
 > *property-wrapper-projection* → **`$`** *identifier-characters*
 
 > Grammar of a literal:
 >
 > *literal* → *numeric-literal* | *string-literal* | *regular-expression-literal* | *boolean-literal* | *nil-literal*
 >
->
->
-> *numeric-literal* → **`-`**_?_ *integer-literal* | **`-`**_?_ *floating-point-literal*
->
-> *boolean-literal* → **`true`** | **`false`**
->
+> *numeric-literal* → **`-`**_?_ *integer-literal* | **`-`**_?_ *floating-point-literal* \
+> *boolean-literal* → **`true`** | **`false`** \
 > *nil-literal* → **`nil`**
 
 > Grammar of an integer literal:
 >
-> *integer-literal* → *binary-literal*
->
-> *integer-literal* → *octal-literal*
->
-> *integer-literal* → *decimal-literal*
->
+> *integer-literal* → *binary-literal* \
+> *integer-literal* → *octal-literal* \
+> *integer-literal* → *decimal-literal* \
 > *integer-literal* → *hexadecimal-literal*
 >
->
->
-> *binary-literal* → **`0b`** *binary-digit* *binary-literal-characters*_?_
->
-> *binary-digit* → Digit 0 or 1
->
-> *binary-literal-character* → *binary-digit* | **`_`**
->
+> *binary-literal* → **`0b`** *binary-digit* *binary-literal-characters*_?_ \
+> *binary-digit* → Digit 0 or 1 \
+> *binary-literal-character* → *binary-digit* | **`_`** \
 > *binary-literal-characters* → *binary-literal-character* *binary-literal-characters*_?_
 >
->
->
-> *octal-literal* → **`0o`** *octal-digit* *octal-literal-characters*_?_
->
-> *octal-digit* → Digit 0 through 7
->
-> *octal-literal-character* → *octal-digit* | **`_`**
->
+> *octal-literal* → **`0o`** *octal-digit* *octal-literal-characters*_?_ \
+> *octal-digit* → Digit 0 through 7 \
+> *octal-literal-character* → *octal-digit* | **`_`** \
 > *octal-literal-characters* → *octal-literal-character* *octal-literal-characters*_?_
 >
->
->
-> *decimal-literal* → *decimal-digit* *decimal-literal-characters*_?_
->
-> *decimal-digit* → Digit 0 through 9
->
-> *decimal-digits* → *decimal-digit* *decimal-digits*_?_
->
-> *decimal-literal-character* → *decimal-digit* | **`_`**
->
+> *decimal-literal* → *decimal-digit* *decimal-literal-characters*_?_ \
+> *decimal-digit* → Digit 0 through 9 \
+> *decimal-digits* → *decimal-digit* *decimal-digits*_?_ \
+> *decimal-literal-character* → *decimal-digit* | **`_`** \
 > *decimal-literal-characters* → *decimal-literal-character* *decimal-literal-characters*_?_
 >
->
->
-> *hexadecimal-literal* → **`0x`** *hexadecimal-digit* *hexadecimal-literal-characters*_?_
->
-> *hexadecimal-digit* → Digit 0 through 9, a through f, or A through F
->
-> *hexadecimal-literal-character* → *hexadecimal-digit* | **`_`**
->
+> *hexadecimal-literal* → **`0x`** *hexadecimal-digit* *hexadecimal-literal-characters*_?_ \
+> *hexadecimal-digit* → Digit 0 through 9, a through f, or A through F \
+> *hexadecimal-literal-character* → *hexadecimal-digit* | **`_`** \
 > *hexadecimal-literal-characters* → *hexadecimal-literal-character* *hexadecimal-literal-characters*_?_
 
 > Grammar of a floating-point literal:
 >
-> *floating-point-literal* → *decimal-literal* *decimal-fraction*_?_ *decimal-exponent*_?_
->
+> *floating-point-literal* → *decimal-literal* *decimal-fraction*_?_ *decimal-exponent*_?_ \
 > *floating-point-literal* → *hexadecimal-literal* *hexadecimal-fraction*_?_ *hexadecimal-exponent*
 >
->
->
-> *decimal-fraction* → **`.`** *decimal-literal*
->
+> *decimal-fraction* → **`.`** *decimal-literal* \
 > *decimal-exponent* → *floating-point-e* *sign*_?_ *decimal-literal*
 >
->
->
-> *hexadecimal-fraction* → **`.`** *hexadecimal-digit* *hexadecimal-literal-characters*_?_
->
+> *hexadecimal-fraction* → **`.`** *hexadecimal-digit* *hexadecimal-literal-characters*_?_ \
 > *hexadecimal-exponent* → *floating-point-p* *sign*_?_ *decimal-literal*
 >
->
->
-> *floating-point-e* → **`e`** | **`E`**
->
-> *floating-point-p* → **`p`** | **`P`**
->
+> *floating-point-e* → **`e`** | **`E`** \
+> *floating-point-p* → **`p`** | **`P`** \
 > *sign* → **`+`** | **`-`**
 
 > Grammar of a string literal:
 >
 > *string-literal* → *static-string-literal* | *interpolated-string-literal*
 >
->
->
-> *string-literal-opening-delimiter* → *extended-string-literal-delimiter*_?_ **`"`**
->
+> *string-literal-opening-delimiter* → *extended-string-literal-delimiter*_?_ **`"`** \
 > *string-literal-closing-delimiter* → **`"`** *extended-string-literal-delimiter*_?_
 >
->
->
-> *static-string-literal* → *string-literal-opening-delimiter* *quoted-text*_?_ *string-literal-closing-delimiter*
->
+> *static-string-literal* → *string-literal-opening-delimiter* *quoted-text*_?_ *string-literal-closing-delimiter* \
 > *static-string-literal* → *multiline-string-literal-opening-delimiter* *multiline-quoted-text*_?_ *multiline-string-literal-closing-delimiter*
 >
->
->
-> *multiline-string-literal-opening-delimiter* → *extended-string-literal-delimiter*_?_ **`"""`**
->
-> *multiline-string-literal-closing-delimiter* → **`"""`** *extended-string-literal-delimiter*_?_
->
+> *multiline-string-literal-opening-delimiter* → *extended-string-literal-delimiter*_?_ **`"""`** \
+> *multiline-string-literal-closing-delimiter* → **`"""`** *extended-string-literal-delimiter*_?_ \
 > *extended-string-literal-delimiter* → **`#`** *extended-string-literal-delimiter*_?_
 >
->
->
-> *quoted-text* → *quoted-text-item* *quoted-text*_?_
->
-> *quoted-text-item* → *escaped-character*
->
+> *quoted-text* → *quoted-text-item* *quoted-text*_?_ \
+> *quoted-text-item* → *escaped-character* \
 > *quoted-text-item* → Any Unicode scalar value except  **`"`**,  **`\`**, U+000A, or U+000D
 >
->
->
-> *multiline-quoted-text* → *multiline-quoted-text-item* *multiline-quoted-text*_?_
->
-> *multiline-quoted-text-item* → *escaped-character*
->
-> *multiline-quoted-text-item* → Any Unicode scalar value except  **`\`**
->
+> *multiline-quoted-text* → *multiline-quoted-text-item* *multiline-quoted-text*_?_ \
+> *multiline-quoted-text-item* → *escaped-character* \
+> *multiline-quoted-text-item* → Any Unicode scalar value except  **`\`** \
 > *multiline-quoted-text-item* → *escaped-newline*
 >
->
->
-> *interpolated-string-literal* → *string-literal-opening-delimiter* *interpolated-text*_?_ *string-literal-closing-delimiter*
->
+> *interpolated-string-literal* → *string-literal-opening-delimiter* *interpolated-text*_?_ *string-literal-closing-delimiter* \
 > *interpolated-string-literal* → *multiline-string-literal-opening-delimiter* *multiline-interpolated-text*_?_ *multiline-string-literal-closing-delimiter*
 >
->
->
-> *interpolated-text* → *interpolated-text-item* *interpolated-text*_?_
->
+> *interpolated-text* → *interpolated-text-item* *interpolated-text*_?_ \
 > *interpolated-text-item* → **`\(`** *expression* **`)`** | *quoted-text-item*
 >
->
->
-> *multiline-interpolated-text* → *multiline-interpolated-text-item* *multiline-interpolated-text*_?_
->
+> *multiline-interpolated-text* → *multiline-interpolated-text-item* *multiline-interpolated-text*_?_ \
 > *multiline-interpolated-text-item* → **`\(`** *expression* **`)`** | *multiline-quoted-text-item*
 >
->
->
-> *escape-sequence* → **`\`** *extended-string-literal-delimiter*
->
-> *escaped-character* → *escape-sequence* **`0`** | *escape-sequence* **`\`** | *escape-sequence* **`t`** | *escape-sequence* **`n`** | *escape-sequence* **`r`** | *escape-sequence* **`"`** | *escape-sequence* **`'`**
->
-> *escaped-character* → *escape-sequence* **`u`** **`{`** *unicode-scalar-digits* **`}`**
->
+> *escape-sequence* → **`\`** *extended-string-literal-delimiter* \
+> *escaped-character* → *escape-sequence* **`0`** | *escape-sequence* **`\`** | *escape-sequence* **`t`** | *escape-sequence* **`n`** | *escape-sequence* **`r`** | *escape-sequence* **`"`** | *escape-sequence* **`'`** \
+> *escaped-character* → *escape-sequence* **`u`** **`{`** *unicode-scalar-digits* **`}`** \
 > *unicode-scalar-digits* → Between one and eight hexadecimal digits
->
->
 >
 > *escaped-newline* → *escape-sequence* *inline-spaces*_?_ *line-break*
 
 > Grammar of a regular expression literal:
 >
-> *regular-expression-literal* → *regular-expression-literal-opening-delimiter* *regular-expression* *regular-expression-literal-closing-delimiter*
->
+> *regular-expression-literal* → *regular-expression-literal-opening-delimiter* *regular-expression* *regular-expression-literal-closing-delimiter* \
 > *regular-expression* → Any regular expression
 >
->
->
-> *regular-expression-literal-opening-delimiter* → *extended-regular-expression-literal-delimiter*_?_ **`/`**
->
+> *regular-expression-literal-opening-delimiter* → *extended-regular-expression-literal-delimiter*_?_ **`/`** \
 > *regular-expression-literal-closing-delimiter* → **`/`** *extended-regular-expression-literal-delimiter*_?_
->
->
 >
 > *extended-regular-expression-literal-delimiter* → **`#`** *extended-regular-expression-literal-delimiter*_?_
 
 > Grammar of operators:
 >
-> *operator* → *operator-head* *operator-characters*_?_
->
+> *operator* → *operator-head* *operator-characters*_?_ \
 > *operator* → *dot-operator-head* *dot-operator-characters*
 >
->
->
-> *operator-head* → **`/`** | **`=`** | **`-`** | **`+`** | **`!`** | **`*`** | **`%`** | **`<`** | **`>`** | **`&`** | **`|`** | **`^`** | **`~`** | **`?`**
->
-> *operator-head* → U+00A1–U+00A7
->
-> *operator-head* → U+00A9 or U+00AB
->
-> *operator-head* → U+00AC or U+00AE
->
-> *operator-head* → U+00B0–U+00B1
->
-> *operator-head* → U+00B6, U+00BB, U+00BF, U+00D7, or U+00F7
->
-> *operator-head* → U+2016–U+2017
->
-> *operator-head* → U+2020–U+2027
->
-> *operator-head* → U+2030–U+203E
->
-> *operator-head* → U+2041–U+2053
->
-> *operator-head* → U+2055–U+205E
->
-> *operator-head* → U+2190–U+23FF
->
-> *operator-head* → U+2500–U+2775
->
-> *operator-head* → U+2794–U+2BFF
->
-> *operator-head* → U+2E00–U+2E7F
->
-> *operator-head* → U+3001–U+3003
->
-> *operator-head* → U+3008–U+3020
->
+> *operator-head* → **`/`** | **`=`** | **`-`** | **`+`** | **`!`** | **`*`** | **`%`** | **`<`** | **`>`** | **`&`** | **`|`** | **`^`** | **`~`** | **`?`** \
+> *operator-head* → U+00A1–U+00A7 \
+> *operator-head* → U+00A9 or U+00AB \
+> *operator-head* → U+00AC or U+00AE \
+> *operator-head* → U+00B0–U+00B1 \
+> *operator-head* → U+00B6, U+00BB, U+00BF, U+00D7, or U+00F7 \
+> *operator-head* → U+2016–U+2017 \
+> *operator-head* → U+2020–U+2027 \
+> *operator-head* → U+2030–U+203E \
+> *operator-head* → U+2041–U+2053 \
+> *operator-head* → U+2055–U+205E \
+> *operator-head* → U+2190–U+23FF \
+> *operator-head* → U+2500–U+2775 \
+> *operator-head* → U+2794–U+2BFF \
+> *operator-head* → U+2E00–U+2E7F \
+> *operator-head* → U+3001–U+3003 \
+> *operator-head* → U+3008–U+3020 \
 > *operator-head* → U+3030
 >
->
->
-> *operator-character* → *operator-head*
->
-> *operator-character* → U+0300–U+036F
->
-> *operator-character* → U+1DC0–U+1DFF
->
-> *operator-character* → U+20D0–U+20FF
->
-> *operator-character* → U+FE00–U+FE0F
->
-> *operator-character* → U+FE20–U+FE2F
->
-> *operator-character* → U+E0100–U+E01EF
->
+> *operator-character* → *operator-head* \
+> *operator-character* → U+0300–U+036F \
+> *operator-character* → U+1DC0–U+1DFF \
+> *operator-character* → U+20D0–U+20FF \
+> *operator-character* → U+FE00–U+FE0F \
+> *operator-character* → U+FE20–U+FE2F \
+> *operator-character* → U+E0100–U+E01EF \
 > *operator-characters* → *operator-character* *operator-characters*_?_
 >
->
->
-> *dot-operator-head* → **`.`**
->
-> *dot-operator-character* → **`.`** | *operator-character*
->
+> *dot-operator-head* → **`.`** \
+> *dot-operator-character* → **`.`** | *operator-character* \
 > *dot-operator-characters* → *dot-operator-character* *dot-operator-characters*_?_
 >
->
->
-> *infix-operator* → *operator*
->
-> *prefix-operator* → *operator*
->
+> *infix-operator* → *operator* \
+> *prefix-operator* → *operator* \
 > *postfix-operator* → *operator*
 
 ## Types
 
 > Grammar of a type:
 >
-> *type* → *function-type*
->
-> *type* → *array-type*
->
-> *type* → *dictionary-type*
->
-> *type* → *type-identifier*
->
-> *type* → *tuple-type*
->
-> *type* → *optional-type*
->
-> *type* → *implicitly-unwrapped-optional-type*
->
-> *type* → *protocol-composition-type*
->
-> *type* → *opaque-type*
->
-> *type* → *metatype-type*
->
-> *type* → *any-type*
->
-> *type* → *self-type*
->
+> *type* → *function-type* \
+> *type* → *array-type* \
+> *type* → *dictionary-type* \
+> *type* → *type-identifier* \
+> *type* → *tuple-type* \
+> *type* → *optional-type* \
+> *type* → *implicitly-unwrapped-optional-type* \
+> *type* → *protocol-composition-type* \
+> *type* → *opaque-type* \
+> *type* → *metatype-type* \
+> *type* → *any-type* \
+> *type* → *self-type* \
 > *type* → **`(`** *type* **`)`**
 
 > Grammar of a type annotation:
@@ -423,36 +242,25 @@ make the same change here also.
 
 > Grammar of a type identifier:
 >
-> *type-identifier* → *type-name* *generic-argument-clause*_?_ | *type-name* *generic-argument-clause*_?_ **`.`** *type-identifier*
->
+> *type-identifier* → *type-name* *generic-argument-clause*_?_ | *type-name* *generic-argument-clause*_?_ **`.`** *type-identifier* \
 > *type-name* → *identifier*
 
 > Grammar of a tuple type:
 >
-> *tuple-type* → **`(`** **`)`** | **`(`** *tuple-type-element* **`,`** *tuple-type-element-list* **`)`**
->
-> *tuple-type-element-list* → *tuple-type-element* | *tuple-type-element* **`,`** *tuple-type-element-list*
->
-> *tuple-type-element* → *element-name* *type-annotation* | *type*
->
+> *tuple-type* → **`(`** **`)`** | **`(`** *tuple-type-element* **`,`** *tuple-type-element-list* **`)`** \
+> *tuple-type-element-list* → *tuple-type-element* | *tuple-type-element* **`,`** *tuple-type-element-list* \
+> *tuple-type-element* → *element-name* *type-annotation* | *type* \
 > *element-name* → *identifier*
 
 > Grammar of a function type:
 >
 > *function-type* → *attributes*_?_ *function-type-argument-clause* **`async`**_?_ **`throws`**_?_ **`->`** *type*
 >
->
->
-> *function-type-argument-clause* → **`(`** **`)`**
->
+> *function-type-argument-clause* → **`(`** **`)`** \
 > *function-type-argument-clause* → **`(`** *function-type-argument-list* **`...`**_?_ **`)`**
 >
->
->
-> *function-type-argument-list* → *function-type-argument* | *function-type-argument* **`,`** *function-type-argument-list*
->
-> *function-type-argument* → *attributes*_?_ **`inout`**_?_ *type* | *argument-label* *type-annotation*
->
+> *function-type-argument-list* → *function-type-argument* | *function-type-argument* **`,`** *function-type-argument-list* \
+> *function-type-argument* → *attributes*_?_ **`inout`**_?_ *type* | *argument-label* *type-annotation* \
 > *argument-label* → *identifier*
 
 > Grammar of an array type:
@@ -473,8 +281,7 @@ make the same change here also.
 
 > Grammar of a protocol composition type:
 >
-> *protocol-composition-type* → *type-identifier* **`&`** *protocol-composition-continuation*
->
+> *protocol-composition-type* → *type-identifier* **`&`** *protocol-composition-continuation* \
 > *protocol-composition-continuation* → *type-identifier* | *protocol-composition-type*
 
 > Grammar of an opaque type:
@@ -499,22 +306,19 @@ make the same change here also.
 
 > Grammar of a type inheritance clause:
 >
-> *type-inheritance-clause* → **`:`** *type-inheritance-list*
->
+> *type-inheritance-clause* → **`:`** *type-inheritance-list* \
 > *type-inheritance-list* → *attributes*_?_ *type-identifier* | *attributes*_?_ *type-identifier* **`,`** *type-inheritance-list*
 
 ## Expressions
 
 > Grammar of an expression:
 >
-> *expression* → *try-operator*_?_ *await-operator*_?_ *prefix-expression* *infix-expressions*_?_
->
+> *expression* → *try-operator*_?_ *await-operator*_?_ *prefix-expression* *infix-expressions*_?_ \
 > *expression-list* → *expression* | *expression* **`,`** *expression-list*
 
 > Grammar of a prefix expression:
 >
-> *prefix-expression* → *prefix-operator*_?_ *postfix-expression*
->
+> *prefix-expression* → *prefix-operator*_?_ *postfix-expression* \
 > *prefix-expression* → *in-out-expression*
 
 > Grammar of an in-out expression:
@@ -531,14 +335,10 @@ make the same change here also.
 
 > Grammar of an infix expression:
 >
-> *infix-expression* → *infix-operator* *prefix-expression*
->
-> *infix-expression* → *assignment-operator* *try-operator*_?_ *prefix-expression*
->
-> *infix-expression* → *conditional-operator* *try-operator*_?_ *prefix-expression*
->
-> *infix-expression* → *type-casting-operator*
->
+> *infix-expression* → *infix-operator* *prefix-expression* \
+> *infix-expression* → *assignment-operator* *try-operator*_?_ *prefix-expression* \
+> *infix-expression* → *conditional-operator* *try-operator*_?_ *prefix-expression* \
+> *infix-expression* → *type-casting-operator* \
 > *infix-expressions* → *infix-expression* *infix-expressions*_?_
 
 > Grammar of an assignment operator:
@@ -551,160 +351,97 @@ make the same change here also.
 
 > Grammar of a type-casting operator:
 >
-> *type-casting-operator* → **`is`** *type*
->
-> *type-casting-operator* → **`as`** *type*
->
-> *type-casting-operator* → **`as`** **`?`** *type*
->
+> *type-casting-operator* → **`is`** *type* \
+> *type-casting-operator* → **`as`** *type* \
+> *type-casting-operator* → **`as`** **`?`** *type* \
 > *type-casting-operator* → **`as`** **`!`** *type*
 
 > Grammar of a primary expression:
 >
-> *primary-expression* → *identifier* *generic-argument-clause*_?_
->
-> *primary-expression* → *literal-expression*
->
-> *primary-expression* → *self-expression*
->
-> *primary-expression* → *superclass-expression*
->
-> *primary-expression* → *conditional-expression*
->
-> *primary-expression* → *closure-expression*
->
-> *primary-expression* → *parenthesized-expression*
->
-> *primary-expression* → *tuple-expression*
->
-> *primary-expression* → *implicit-member-expression*
->
-> *primary-expression* → *wildcard-expression*
->
-> *primary-expression* → *macro-expansion-expression*
->
-> *primary-expression* → *key-path-expression*
->
-> *primary-expression* → *selector-expression*
->
+> *primary-expression* → *identifier* *generic-argument-clause*_?_ \
+> *primary-expression* → *literal-expression* \
+> *primary-expression* → *self-expression* \
+> *primary-expression* → *superclass-expression* \
+> *primary-expression* → *conditional-expression* \
+> *primary-expression* → *closure-expression* \
+> *primary-expression* → *parenthesized-expression* \
+> *primary-expression* → *tuple-expression* \
+> *primary-expression* → *implicit-member-expression* \
+> *primary-expression* → *wildcard-expression* \
+> *primary-expression* → *macro-expansion-expression* \
+> *primary-expression* → *key-path-expression* \
+> *primary-expression* → *selector-expression* \
 > *primary-expression* → *key-path-string-expression*
 
 > Grammar of a literal expression:
 >
-> *literal-expression* → *literal*
->
+> *literal-expression* → *literal* \
 > *literal-expression* → *array-literal* | *dictionary-literal* | *playground-literal*
 >
->
->
-> *array-literal* → **`[`** *array-literal-items*_?_ **`]`**
->
-> *array-literal-items* → *array-literal-item* **`,`**_?_ | *array-literal-item* **`,`** *array-literal-items*
->
+> *array-literal* → **`[`** *array-literal-items*_?_ **`]`** \
+> *array-literal-items* → *array-literal-item* **`,`**_?_ | *array-literal-item* **`,`** *array-literal-items* \
 > *array-literal-item* → *expression*
 >
->
->
-> *dictionary-literal* → **`[`** *dictionary-literal-items* **`]`** | **`[`** **`:`** **`]`**
->
-> *dictionary-literal-items* → *dictionary-literal-item* **`,`**_?_ | *dictionary-literal-item* **`,`** *dictionary-literal-items*
->
+> *dictionary-literal* → **`[`** *dictionary-literal-items* **`]`** | **`[`** **`:`** **`]`** \
+> *dictionary-literal-items* → *dictionary-literal-item* **`,`**_?_ | *dictionary-literal-item* **`,`** *dictionary-literal-items* \
 > *dictionary-literal-item* → *expression* **`:`** *expression*
 >
->
->
-> *playground-literal* → **`#colorLiteral`** **`(`** **`red`** **`:`** *expression* **`,`** **`green`** **`:`** *expression* **`,`** **`blue`** **`:`** *expression* **`,`** **`alpha`** **`:`** *expression* **`)`**
->
-> *playground-literal* → **`#fileLiteral`** **`(`** **`resourceName`** **`:`** *expression* **`)`**
->
+> *playground-literal* → **`#colorLiteral`** **`(`** **`red`** **`:`** *expression* **`,`** **`green`** **`:`** *expression* **`,`** **`blue`** **`:`** *expression* **`,`** **`alpha`** **`:`** *expression* **`)`** \
+> *playground-literal* → **`#fileLiteral`** **`(`** **`resourceName`** **`:`** *expression* **`)`** \
 > *playground-literal* → **`#imageLiteral`** **`(`** **`resourceName`** **`:`** *expression* **`)`**
 
 > Grammar of a self expression:
 >
 > *self-expression* → **`self`** | *self-method-expression* | *self-subscript-expression* | *self-initializer-expression*
 >
->
->
-> *self-method-expression* → **`self`** **`.`** *identifier*
->
-> *self-subscript-expression* → **`self`** **`[`** *function-call-argument-list* **`]`**
->
+> *self-method-expression* → **`self`** **`.`** *identifier* \
+> *self-subscript-expression* → **`self`** **`[`** *function-call-argument-list* **`]`** \
 > *self-initializer-expression* → **`self`** **`.`** **`init`**
 
 > Grammar of a superclass expression:
 >
 > *superclass-expression* → *superclass-method-expression* | *superclass-subscript-expression* | *superclass-initializer-expression*
 >
->
->
-> *superclass-method-expression* → **`super`** **`.`** *identifier*
->
-> *superclass-subscript-expression* → **`super`** **`[`** *function-call-argument-list* **`]`**
->
+> *superclass-method-expression* → **`super`** **`.`** *identifier* \
+> *superclass-subscript-expression* → **`super`** **`[`** *function-call-argument-list* **`]`** \
 > *superclass-initializer-expression* → **`super`** **`.`** **`init`**
 
 > Grammar of a conditional expression:
 >
 > *conditional-expression* → *if-expression* | *switch-expression*
 >
->
->
-> *if-expression* → **`if`** *condition-list* **`{`** *statement* **`}`** *if-expression-tail*
->
-> *if-expression-tail* → **`else`** *if-expression*
->
+> *if-expression* → **`if`** *condition-list* **`{`** *statement* **`}`** *if-expression-tail* \
+> *if-expression-tail* → **`else`** *if-expression* \
 > *if-expression-tail* → **`else`** **`{`** *statement* **`}`** *if-expression-tail*
 >
->
->
-> *switch-expression* → **`switch`** *expression* **`{`** *switch-expression-cases* **`}`**
->
-> *switch-expression-cases* → *switch-expression-case* *switch-expression-cases*_?_
->
-> *switch-expression-case* → *case-label* *statement*
->
+> *switch-expression* → **`switch`** *expression* **`{`** *switch-expression-cases* **`}`** \
+> *switch-expression-cases* → *switch-expression-case* *switch-expression-cases*_?_ \
+> *switch-expression-case* → *case-label* *statement* \
 > *switch-expression-case* → *default-label* *statement*
 
 > Grammar of a closure expression:
 >
 > *closure-expression* → **`{`** *attributes*_?_ *closure-signature*_?_ *statements*_?_ **`}`**
 >
->
->
-> *closure-signature* → *capture-list*_?_ *closure-parameter-clause* **`async`**_?_ **`throws`**_?_ *function-result*_?_ **`in`**
->
+> *closure-signature* → *capture-list*_?_ *closure-parameter-clause* **`async`**_?_ **`throws`**_?_ *function-result*_?_ **`in`** \
 > *closure-signature* → *capture-list* **`in`**
 >
->
->
-> *closure-parameter-clause* → **`(`** **`)`** | **`(`** *closure-parameter-list* **`)`** | *identifier-list*
->
-> *closure-parameter-list* → *closure-parameter* | *closure-parameter* **`,`** *closure-parameter-list*
->
-> *closure-parameter* → *closure-parameter-name* *type-annotation*_?_
->
-> *closure-parameter* → *closure-parameter-name* *type-annotation* **`...`**
->
+> *closure-parameter-clause* → **`(`** **`)`** | **`(`** *closure-parameter-list* **`)`** | *identifier-list* \
+> *closure-parameter-list* → *closure-parameter* | *closure-parameter* **`,`** *closure-parameter-list* \
+> *closure-parameter* → *closure-parameter-name* *type-annotation*_?_ \
+> *closure-parameter* → *closure-parameter-name* *type-annotation* **`...`** \
 > *closure-parameter-name* → *identifier*
 >
->
->
-> *capture-list* → **`[`** *capture-list-items* **`]`**
->
-> *capture-list-items* → *capture-list-item* | *capture-list-item* **`,`** *capture-list-items*
->
-> *capture-list-item* → *capture-specifier*_?_ *identifier*
->
-> *capture-list-item* → *capture-specifier*_?_ *identifier* **`=`** *expression*
->
-> *capture-list-item* → *capture-specifier*_?_ *self-expression*
->
+> *capture-list* → **`[`** *capture-list-items* **`]`** \
+> *capture-list-items* → *capture-list-item* | *capture-list-item* **`,`** *capture-list-items* \
+> *capture-list-item* → *capture-specifier*_?_ *identifier* \
+> *capture-list-item* → *capture-specifier*_?_ *identifier* **`=`** *expression* \
+> *capture-list-item* → *capture-specifier*_?_ *self-expression* \
 > *capture-specifier* → **`weak`** | **`unowned`** | **`unowned(safe)`** | **`unowned(unsafe)`**
 
 > Grammar of a implicit member expression:
 >
-> *implicit-member-expression* → **`.`** *identifier*
->
+> *implicit-member-expression* → **`.`** *identifier* \
 > *implicit-member-expression* → **`.`** *identifier* **`.`** *postfix-expression*
 
 > Grammar of a parenthesized expression:
@@ -713,10 +450,8 @@ make the same change here also.
 
 > Grammar of a tuple expression:
 >
-> *tuple-expression* → **`(`** **`)`** | **`(`** *tuple-element* **`,`** *tuple-element-list* **`)`**
->
-> *tuple-element-list* → *tuple-element* | *tuple-element* **`,`** *tuple-element-list*
->
+> *tuple-expression* → **`(`** **`)`** | **`(`** *tuple-element* **`,`** *tuple-element-list* **`)`** \
+> *tuple-element-list* → *tuple-element* | *tuple-element* **`,`** *tuple-element-list* \
 > *tuple-element* → *expression* | *identifier* **`:`** *expression*
 
 > Grammar of a wildcard expression:
@@ -729,24 +464,17 @@ make the same change here also.
 
 > Grammar of a key-path expression:
 >
-> *key-path-expression* → **`\`** *type*_?_ **`.`** *key-path-components*
->
-> *key-path-components* → *key-path-component* | *key-path-component* **`.`** *key-path-components*
->
+> *key-path-expression* → **`\`** *type*_?_ **`.`** *key-path-components* \
+> *key-path-components* → *key-path-component* | *key-path-component* **`.`** *key-path-components* \
 > *key-path-component* → *identifier* *key-path-postfixes*_?_ | *key-path-postfixes*
 >
->
->
-> *key-path-postfixes* → *key-path-postfix* *key-path-postfixes*_?_
->
+> *key-path-postfixes* → *key-path-postfix* *key-path-postfixes*_?_ \
 > *key-path-postfix* → **`?`** | **`!`** | **`self`** | **`[`** *function-call-argument-list* **`]`**
 
 > Grammar of a selector expression:
 >
-> *selector-expression* → **`#selector`** **`(`** *expression* **`)`**
->
-> *selector-expression* → **`#selector`** **`(`** **`getter:`** *expression* **`)`**
->
+> *selector-expression* → **`#selector`** **`(`** *expression* **`)`** \
+> *selector-expression* → **`#selector`** **`(`** **`getter:`** *expression* **`)`** \
 > *selector-expression* → **`#selector`** **`(`** **`setter:`** *expression* **`)`**
 
 > Grammar of a key-path string expression:
@@ -755,68 +483,43 @@ make the same change here also.
 
 > Grammar of a postfix expression:
 >
-> *postfix-expression* → *primary-expression*
->
-> *postfix-expression* → *postfix-expression* *postfix-operator*
->
-> *postfix-expression* → *function-call-expression*
->
-> *postfix-expression* → *initializer-expression*
->
-> *postfix-expression* → *explicit-member-expression*
->
-> *postfix-expression* → *postfix-self-expression*
->
-> *postfix-expression* → *subscript-expression*
->
-> *postfix-expression* → *forced-value-expression*
->
+> *postfix-expression* → *primary-expression* \
+> *postfix-expression* → *postfix-expression* *postfix-operator* \
+> *postfix-expression* → *function-call-expression* \
+> *postfix-expression* → *initializer-expression* \
+> *postfix-expression* → *explicit-member-expression* \
+> *postfix-expression* → *postfix-self-expression* \
+> *postfix-expression* → *subscript-expression* \
+> *postfix-expression* → *forced-value-expression* \
 > *postfix-expression* → *optional-chaining-expression*
 
 > Grammar of a function call expression:
 >
-> *function-call-expression* → *postfix-expression* *function-call-argument-clause*
->
+> *function-call-expression* → *postfix-expression* *function-call-argument-clause* \
 > *function-call-expression* → *postfix-expression* *function-call-argument-clause*_?_ *trailing-closures*
 >
->
->
-> *function-call-argument-clause* → **`(`** **`)`** | **`(`** *function-call-argument-list* **`)`**
->
-> *function-call-argument-list* → *function-call-argument* | *function-call-argument* **`,`** *function-call-argument-list*
->
-> *function-call-argument* → *expression* | *identifier* **`:`** *expression*
->
+> *function-call-argument-clause* → **`(`** **`)`** | **`(`** *function-call-argument-list* **`)`** \
+> *function-call-argument-list* → *function-call-argument* | *function-call-argument* **`,`** *function-call-argument-list* \
+> *function-call-argument* → *expression* | *identifier* **`:`** *expression* \
 > *function-call-argument* → *operator* | *identifier* **`:`** *operator*
 >
->
->
-> *trailing-closures* → *closure-expression* *labeled-trailing-closures*_?_
->
-> *labeled-trailing-closures* → *labeled-trailing-closure* *labeled-trailing-closures*_?_
->
+> *trailing-closures* → *closure-expression* *labeled-trailing-closures*_?_ \
+> *labeled-trailing-closures* → *labeled-trailing-closure* *labeled-trailing-closures*_?_ \
 > *labeled-trailing-closure* → *identifier* **`:`** *closure-expression*
 
 > Grammar of an initializer expression:
 >
-> *initializer-expression* → *postfix-expression* **`.`** **`init`**
->
+> *initializer-expression* → *postfix-expression* **`.`** **`init`** \
 > *initializer-expression* → *postfix-expression* **`.`** **`init`** **`(`** *argument-names* **`)`**
 
 > Grammar of an explicit member expression:
 >
-> *explicit-member-expression* → *postfix-expression* **`.`** *decimal-digits*
->
-> *explicit-member-expression* → *postfix-expression* **`.`** *identifier* *generic-argument-clause*_?_
->
-> *explicit-member-expression* → *postfix-expression* **`.`** *identifier* **`(`** *argument-names* **`)`**
->
+> *explicit-member-expression* → *postfix-expression* **`.`** *decimal-digits* \
+> *explicit-member-expression* → *postfix-expression* **`.`** *identifier* *generic-argument-clause*_?_ \
+> *explicit-member-expression* → *postfix-expression* **`.`** *identifier* **`(`** *argument-names* **`)`** \
 > *explicit-member-expression* → *postfix-expression* *conditional-compilation-block*
 >
->
->
-> *argument-names* → *argument-name* *argument-names*_?_
->
+> *argument-names* → *argument-name* *argument-names*_?_ \
 > *argument-name* → *identifier* **`:`**
 
 > Grammar of a postfix self expression:
@@ -839,32 +542,21 @@ make the same change here also.
 
 > Grammar of a statement:
 >
-> *statement* → *expression* **`;`**_?_
->
-> *statement* → *declaration* **`;`**_?_
->
-> *statement* → *loop-statement* **`;`**_?_
->
-> *statement* → *branch-statement* **`;`**_?_
->
-> *statement* → *labeled-statement* **`;`**_?_
->
-> *statement* → *control-transfer-statement* **`;`**_?_
->
-> *statement* → *defer-statement* **`;`**_?_
->
-> *statement* → *do-statement* **`;`**_?_
->
-> *statement* → *compiler-control-statement*
->
+> *statement* → *expression* **`;`**_?_ \
+> *statement* → *declaration* **`;`**_?_ \
+> *statement* → *loop-statement* **`;`**_?_ \
+> *statement* → *branch-statement* **`;`**_?_ \
+> *statement* → *labeled-statement* **`;`**_?_ \
+> *statement* → *control-transfer-statement* **`;`**_?_ \
+> *statement* → *defer-statement* **`;`**_?_ \
+> *statement* → *do-statement* **`;`**_?_ \
+> *statement* → *compiler-control-statement* \
 > *statements* → *statement* *statements*_?_
 
 > Grammar of a loop statement:
 >
-> *loop-statement* → *for-in-statement*
->
-> *loop-statement* → *while-statement*
->
+> *loop-statement* → *for-in-statement* \
+> *loop-statement* → *while-statement* \
 > *loop-statement* → *repeat-while-statement*
 
 > Grammar of a for-in statement:
@@ -875,16 +567,10 @@ make the same change here also.
 >
 > *while-statement* → **`while`** *condition-list* *code-block*
 >
->
->
-> *condition-list* → *condition* | *condition* **`,`** *condition-list*
->
+> *condition-list* → *condition* | *condition* **`,`** *condition-list* \
 > *condition* → *expression* | *availability-condition* | *case-condition* | *optional-binding-condition*
 >
->
->
-> *case-condition* → **`case`** *pattern* *initializer*
->
+> *case-condition* → **`case`** *pattern* *initializer* \
 > *optional-binding-condition* → **`let`** *pattern* *initializer*_?_ | **`var`** *pattern* *initializer*_?_
 
 > Grammar of a repeat-while statement:
@@ -893,16 +579,13 @@ make the same change here also.
 
 > Grammar of a branch statement:
 >
-> *branch-statement* → *if-statement*
->
-> *branch-statement* → *guard-statement*
->
+> *branch-statement* → *if-statement* \
+> *branch-statement* → *guard-statement* \
 > *branch-statement* → *switch-statement*
 
 > Grammar of an if statement:
 >
-> *if-statement* → **`if`** *condition-list* *code-block* *else-clause*_?_
->
+> *if-statement* → **`if`** *condition-list* *code-block* *else-clause*_?_ \
 > *else-clause* → **`else`** *code-block* | **`else`** *if-statement*
 
 > Grammar of a guard statement:
@@ -911,68 +594,41 @@ make the same change here also.
 
 > Grammar of a switch statement:
 >
-> *switch-statement* → **`switch`** *expression* **`{`** *switch-cases*_?_ **`}`**
->
-> *switch-cases* → *switch-case* *switch-cases*_?_
->
-> *switch-case* → *case-label* *statements*
->
-> *switch-case* → *default-label* *statements*
->
+> *switch-statement* → **`switch`** *expression* **`{`** *switch-cases*_?_ **`}`** \
+> *switch-cases* → *switch-case* *switch-cases*_?_ \
+> *switch-case* → *case-label* *statements* \
+> *switch-case* → *default-label* *statements* \
 > *switch-case* → *conditional-switch-case*
 >
->
->
-> *case-label* → *attributes*_?_ **`case`** *case-item-list* **`:`**
->
-> *case-item-list* → *pattern* *where-clause*_?_ | *pattern* *where-clause*_?_ **`,`** *case-item-list*
->
+> *case-label* → *attributes*_?_ **`case`** *case-item-list* **`:`** \
+> *case-item-list* → *pattern* *where-clause*_?_ | *pattern* *where-clause*_?_ **`,`** *case-item-list* \
 > *default-label* → *attributes*_?_ **`default`** **`:`**
 >
->
->
-> *where-clause* → **`where`** *where-expression*
->
+> *where-clause* → **`where`** *where-expression* \
 > *where-expression* → *expression*
 >
->
->
-> *conditional-switch-case* → *switch-if-directive-clause* *switch-elseif-directive-clauses*_?_ *switch-else-directive-clause*_?_ *endif-directive*
->
-> *switch-if-directive-clause* → *if-directive* *compilation-condition* *switch-cases*_?_
->
-> *switch-elseif-directive-clauses* → *elseif-directive-clause* *switch-elseif-directive-clauses*_?_
->
-> *switch-elseif-directive-clause* → *elseif-directive* *compilation-condition* *switch-cases*_?_
->
+> *conditional-switch-case* → *switch-if-directive-clause* *switch-elseif-directive-clauses*_?_ *switch-else-directive-clause*_?_ *endif-directive* \
+> *switch-if-directive-clause* → *if-directive* *compilation-condition* *switch-cases*_?_ \
+> *switch-elseif-directive-clauses* → *elseif-directive-clause* *switch-elseif-directive-clauses*_?_ \
+> *switch-elseif-directive-clause* → *elseif-directive* *compilation-condition* *switch-cases*_?_ \
 > *switch-else-directive-clause* → *else-directive* *switch-cases*_?_
 
 > Grammar of a labeled statement:
 >
-> *labeled-statement* → *statement-label* *loop-statement*
->
-> *labeled-statement* → *statement-label* *if-statement*
->
-> *labeled-statement* → *statement-label* *switch-statement*
->
+> *labeled-statement* → *statement-label* *loop-statement* \
+> *labeled-statement* → *statement-label* *if-statement* \
+> *labeled-statement* → *statement-label* *switch-statement* \
 > *labeled-statement* → *statement-label* *do-statement*
 >
->
->
-> *statement-label* → *label-name* **`:`**
->
+> *statement-label* → *label-name* **`:`** \
 > *label-name* → *identifier*
 
 > Grammar of a control transfer statement:
 >
-> *control-transfer-statement* → *break-statement*
->
-> *control-transfer-statement* → *continue-statement*
->
-> *control-transfer-statement* → *fallthrough-statement*
->
-> *control-transfer-statement* → *return-statement*
->
+> *control-transfer-statement* → *break-statement* \
+> *control-transfer-statement* → *continue-statement* \
+> *control-transfer-statement* → *fallthrough-statement* \
+> *control-transfer-statement* → *return-statement* \
 > *control-transfer-statement* → *throw-statement*
 
 > Grammar of a break statement:
@@ -1001,164 +657,96 @@ make the same change here also.
 
 > Grammar of a do statement:
 >
-> *do-statement* → **`do`** *code-block* *catch-clauses*_?_
->
-> *catch-clauses* → *catch-clause* *catch-clauses*_?_
->
-> *catch-clause* → **`catch`** *catch-pattern-list*_?_ *code-block*
->
-> *catch-pattern-list* → *catch-pattern* | *catch-pattern* **`,`** *catch-pattern-list*
->
+> *do-statement* → **`do`** *code-block* *catch-clauses*_?_ \
+> *catch-clauses* → *catch-clause* *catch-clauses*_?_ \
+> *catch-clause* → **`catch`** *catch-pattern-list*_?_ *code-block* \
+> *catch-pattern-list* → *catch-pattern* | *catch-pattern* **`,`** *catch-pattern-list* \
 > *catch-pattern* → *pattern* *where-clause*_?_
 
 > Grammar of a compiler control statement:
 >
-> *compiler-control-statement* → *conditional-compilation-block*
->
-> *compiler-control-statement* → *line-control-statement*
->
+> *compiler-control-statement* → *conditional-compilation-block* \
+> *compiler-control-statement* → *line-control-statement* \
 > *compiler-control-statement* → *diagnostic-statement*
 
 > Grammar of a conditional compilation block:
 >
 > *conditional-compilation-block* → *if-directive-clause* *elseif-directive-clauses*_?_ *else-directive-clause*_?_ *endif-directive*
 >
->
->
-> *if-directive-clause* → *if-directive* *compilation-condition* *statements*_?_
->
-> *elseif-directive-clauses* → *elseif-directive-clause* *elseif-directive-clauses*_?_
->
-> *elseif-directive-clause* → *elseif-directive* *compilation-condition* *statements*_?_
->
-> *else-directive-clause* → *else-directive* *statements*_?_
->
-> *if-directive* → **`#if`**
->
-> *elseif-directive* → **`#elseif`**
->
-> *else-directive* → **`#else`**
->
+> *if-directive-clause* → *if-directive* *compilation-condition* *statements*_?_ \
+> *elseif-directive-clauses* → *elseif-directive-clause* *elseif-directive-clauses*_?_ \
+> *elseif-directive-clause* → *elseif-directive* *compilation-condition* *statements*_?_ \
+> *else-directive-clause* → *else-directive* *statements*_?_ \
+> *if-directive* → **`#if`** \
+> *elseif-directive* → **`#elseif`** \
+> *else-directive* → **`#else`** \
 > *endif-directive* → **`#endif`**
 >
->
->
-> *compilation-condition* → *platform-condition*
->
-> *compilation-condition* → *identifier*
->
-> *compilation-condition* → *boolean-literal*
->
-> *compilation-condition* → **`(`** *compilation-condition* **`)`**
->
-> *compilation-condition* → **`!`** *compilation-condition*
->
-> *compilation-condition* → *compilation-condition* **`&&`** *compilation-condition*
->
+> *compilation-condition* → *platform-condition* \
+> *compilation-condition* → *identifier* \
+> *compilation-condition* → *boolean-literal* \
+> *compilation-condition* → **`(`** *compilation-condition* **`)`** \
+> *compilation-condition* → **`!`** *compilation-condition* \
+> *compilation-condition* → *compilation-condition* **`&&`** *compilation-condition* \
 > *compilation-condition* → *compilation-condition* **`||`** *compilation-condition*
 >
->
->
-> *platform-condition* → **`os`** **`(`** *operating-system* **`)`**
->
-> *platform-condition* → **`arch`** **`(`** *architecture* **`)`**
->
-> *platform-condition* → **`swift`** **`(`** **`>=`** *swift-version* **`)`** | **`swift`** **`(`** **`<`** *swift-version* **`)`**
->
-> *platform-condition* → **`compiler`** **`(`** **`>=`** *swift-version* **`)`** | **`compiler`** **`(`** **`<`** *swift-version* **`)`**
->
-> *platform-condition* → **`canImport`** **`(`** *import-path* **`)`**
->
+> *platform-condition* → **`os`** **`(`** *operating-system* **`)`** \
+> *platform-condition* → **`arch`** **`(`** *architecture* **`)`** \
+> *platform-condition* → **`swift`** **`(`** **`>=`** *swift-version* **`)`** | **`swift`** **`(`** **`<`** *swift-version* **`)`** \
+> *platform-condition* → **`compiler`** **`(`** **`>=`** *swift-version* **`)`** | **`compiler`** **`(`** **`<`** *swift-version* **`)`** \
+> *platform-condition* → **`canImport`** **`(`** *import-path* **`)`** \
 > *platform-condition* → **`targetEnvironment`** **`(`** *environment* **`)`**
 >
->
->
-> *operating-system* → **`macOS`** | **`iOS`** | **`watchOS`** | **`tvOS`** | **`Linux`** | **`Windows`**
->
-> *architecture* → **`i386`** | **`x86_64`** | **`arm`** | **`arm64`**
->
-> *swift-version* → *decimal-digits* *swift-version-continuation*_?_
->
-> *swift-version-continuation* → **`.`** *decimal-digits* *swift-version-continuation*_?_
->
+> *operating-system* → **`macOS`** | **`iOS`** | **`watchOS`** | **`tvOS`** | **`Linux`** | **`Windows`** \
+> *architecture* → **`i386`** | **`x86_64`** | **`arm`** | **`arm64`** \
+> *swift-version* → *decimal-digits* *swift-version-continuation*_?_ \
+> *swift-version-continuation* → **`.`** *decimal-digits* *swift-version-continuation*_?_ \
 > *environment* → **`simulator`** | **`macCatalyst`**
 
 > Grammar of a line control statement:
 >
-> *line-control-statement* → **`#sourceLocation`** **`(`** **`file:`** *file-path* **`,`** **`line:`** *line-number* **`)`**
->
-> *line-control-statement* → **`#sourceLocation`** **`(`** **`)`**
->
-> *line-number* → A decimal integer greater than zero
->
+> *line-control-statement* → **`#sourceLocation`** **`(`** **`file:`** *file-path* **`,`** **`line:`** *line-number* **`)`** \
+> *line-control-statement* → **`#sourceLocation`** **`(`** **`)`** \
+> *line-number* → A decimal integer greater than zero \
 > *file-path* → *static-string-literal*
 
 > Grammar of an availability condition:
 >
-> *availability-condition* → **`#available`** **`(`** *availability-arguments* **`)`**
->
-> *availability-condition* → **`#unavailable`** **`(`** *availability-arguments* **`)`**
->
-> *availability-arguments* → *availability-argument* | *availability-argument* **`,`** *availability-arguments*
->
-> *availability-argument* → *platform-name* *platform-version*
->
+> *availability-condition* → **`#available`** **`(`** *availability-arguments* **`)`** \
+> *availability-condition* → **`#unavailable`** **`(`** *availability-arguments* **`)`** \
+> *availability-arguments* → *availability-argument* | *availability-argument* **`,`** *availability-arguments* \
+> *availability-argument* → *platform-name* *platform-version* \
 > *availability-argument* → **`*`**
 >
->
->
-> *platform-name* → **`iOS`** | **`iOSApplicationExtension`**
->
-> *platform-name* → **`macOS`** | **`macOSApplicationExtension`**
->
-> *platform-name* → **`macCatalyst`** | **`macCatalystApplicationExtension`**
->
-> *platform-name* → **`watchOS`** | **`watchOSApplicationExtension`**
->
-> *platform-name* → **`tvOS`** | **`tvOSApplicationExtension`**
->
-> *platform-version* → *decimal-digits*
->
-> *platform-version* → *decimal-digits* **`.`** *decimal-digits*
->
+> *platform-name* → **`iOS`** | **`iOSApplicationExtension`** \
+> *platform-name* → **`macOS`** | **`macOSApplicationExtension`** \
+> *platform-name* → **`macCatalyst`** | **`macCatalystApplicationExtension`** \
+> *platform-name* → **`watchOS`** | **`watchOSApplicationExtension`** \
+> *platform-name* → **`tvOS`** | **`tvOSApplicationExtension`** \
+> *platform-version* → *decimal-digits* \
+> *platform-version* → *decimal-digits* **`.`** *decimal-digits* \
 > *platform-version* → *decimal-digits* **`.`** *decimal-digits* **`.`** *decimal-digits*
 
 ## Declarations
 
 > Grammar of a declaration:
 >
-> *declaration* → *import-declaration*
->
-> *declaration* → *constant-declaration*
->
-> *declaration* → *variable-declaration*
->
-> *declaration* → *typealias-declaration*
->
-> *declaration* → *function-declaration*
->
-> *declaration* → *enum-declaration*
->
-> *declaration* → *struct-declaration*
->
-> *declaration* → *class-declaration*
->
-> *declaration* → *actor-declaration*
->
-> *declaration* → *protocol-declaration*
->
-> *declaration* → *initializer-declaration*
->
-> *declaration* → *deinitializer-declaration*
->
-> *declaration* → *extension-declaration*
->
-> *declaration* → *subscript-declaration*
->
-> *declaration* → *operator-declaration*
->
-> *declaration* → *precedence-group-declaration*
->
+> *declaration* → *import-declaration* \
+> *declaration* → *constant-declaration* \
+> *declaration* → *variable-declaration* \
+> *declaration* → *typealias-declaration* \
+> *declaration* → *function-declaration* \
+> *declaration* → *enum-declaration* \
+> *declaration* → *struct-declaration* \
+> *declaration* → *class-declaration* \
+> *declaration* → *actor-declaration* \
+> *declaration* → *protocol-declaration* \
+> *declaration* → *initializer-declaration* \
+> *declaration* → *deinitializer-declaration* \
+> *declaration* → *extension-declaration* \
+> *declaration* → *subscript-declaration* \
+> *declaration* → *operator-declaration* \
+> *declaration* → *precedence-group-declaration* \
 > *declarations* → *declaration* *declarations*_?_
 
 > Grammar of a top-level declaration:
@@ -1173,236 +761,138 @@ make the same change here also.
 >
 > *import-declaration* → *attributes*_?_ **`import`** *import-kind*_?_ *import-path*
 >
->
->
-> *import-kind* → **`typealias`** | **`struct`** | **`class`** | **`enum`** | **`protocol`** | **`let`** | **`var`** | **`func`**
->
+> *import-kind* → **`typealias`** | **`struct`** | **`class`** | **`enum`** | **`protocol`** | **`let`** | **`var`** | **`func`** \
 > *import-path* → *identifier* | *identifier* **`.`** *import-path*
 
 > Grammar of a constant declaration:
 >
 > *constant-declaration* → *attributes*_?_ *declaration-modifiers*_?_ **`let`** *pattern-initializer-list*
 >
->
->
-> *pattern-initializer-list* → *pattern-initializer* | *pattern-initializer* **`,`** *pattern-initializer-list*
->
-> *pattern-initializer* → *pattern* *initializer*_?_
->
+> *pattern-initializer-list* → *pattern-initializer* | *pattern-initializer* **`,`** *pattern-initializer-list* \
+> *pattern-initializer* → *pattern* *initializer*_?_ \
 > *initializer* → **`=`** *expression*
 
 > Grammar of a variable declaration:
 >
-> *variable-declaration* → *variable-declaration-head* *pattern-initializer-list*
->
-> *variable-declaration* → *variable-declaration-head* *variable-name* *type-annotation* *code-block*
->
-> *variable-declaration* → *variable-declaration-head* *variable-name* *type-annotation* *getter-setter-block*
->
-> *variable-declaration* → *variable-declaration-head* *variable-name* *type-annotation* *getter-setter-keyword-block*
->
-> *variable-declaration* → *variable-declaration-head* *variable-name* *initializer* *willSet-didSet-block*
->
+> *variable-declaration* → *variable-declaration-head* *pattern-initializer-list* \
+> *variable-declaration* → *variable-declaration-head* *variable-name* *type-annotation* *code-block* \
+> *variable-declaration* → *variable-declaration-head* *variable-name* *type-annotation* *getter-setter-block* \
+> *variable-declaration* → *variable-declaration-head* *variable-name* *type-annotation* *getter-setter-keyword-block* \
+> *variable-declaration* → *variable-declaration-head* *variable-name* *initializer* *willSet-didSet-block* \
 > *variable-declaration* → *variable-declaration-head* *variable-name* *type-annotation* *initializer*_?_ *willSet-didSet-block*
 >
->
->
-> *variable-declaration-head* → *attributes*_?_ *declaration-modifiers*_?_ **`var`**
->
+> *variable-declaration-head* → *attributes*_?_ *declaration-modifiers*_?_ **`var`** \
 > *variable-name* → *identifier*
 >
->
->
-> *getter-setter-block* → *code-block*
->
-> *getter-setter-block* → **`{`** *getter-clause* *setter-clause*_?_ **`}`**
->
-> *getter-setter-block* → **`{`** *setter-clause* *getter-clause* **`}`**
->
-> *getter-clause* → *attributes*_?_ *mutation-modifier*_?_ **`get`** *code-block*
->
-> *setter-clause* → *attributes*_?_ *mutation-modifier*_?_ **`set`** *setter-name*_?_ *code-block*
->
+> *getter-setter-block* → *code-block* \
+> *getter-setter-block* → **`{`** *getter-clause* *setter-clause*_?_ **`}`** \
+> *getter-setter-block* → **`{`** *setter-clause* *getter-clause* **`}`** \
+> *getter-clause* → *attributes*_?_ *mutation-modifier*_?_ **`get`** *code-block* \
+> *setter-clause* → *attributes*_?_ *mutation-modifier*_?_ **`set`** *setter-name*_?_ *code-block* \
 > *setter-name* → **`(`** *identifier* **`)`**
 >
->
->
-> *getter-setter-keyword-block* → **`{`** *getter-keyword-clause* *setter-keyword-clause*_?_ **`}`**
->
-> *getter-setter-keyword-block* → **`{`** *setter-keyword-clause* *getter-keyword-clause* **`}`**
->
-> *getter-keyword-clause* → *attributes*_?_ *mutation-modifier*_?_ **`get`**
->
+> *getter-setter-keyword-block* → **`{`** *getter-keyword-clause* *setter-keyword-clause*_?_ **`}`** \
+> *getter-setter-keyword-block* → **`{`** *setter-keyword-clause* *getter-keyword-clause* **`}`** \
+> *getter-keyword-clause* → *attributes*_?_ *mutation-modifier*_?_ **`get`** \
 > *setter-keyword-clause* → *attributes*_?_ *mutation-modifier*_?_ **`set`**
 >
->
->
-> *willSet-didSet-block* → **`{`** *willSet-clause* *didSet-clause*_?_ **`}`**
->
-> *willSet-didSet-block* → **`{`** *didSet-clause* *willSet-clause*_?_ **`}`**
->
-> *willSet-clause* → *attributes*_?_ **`willSet`** *setter-name*_?_ *code-block*
->
+> *willSet-didSet-block* → **`{`** *willSet-clause* *didSet-clause*_?_ **`}`** \
+> *willSet-didSet-block* → **`{`** *didSet-clause* *willSet-clause*_?_ **`}`** \
+> *willSet-clause* → *attributes*_?_ **`willSet`** *setter-name*_?_ *code-block* \
 > *didSet-clause* → *attributes*_?_ **`didSet`** *setter-name*_?_ *code-block*
 
 > Grammar of a type alias declaration:
 >
-> *typealias-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`typealias`** *typealias-name* *generic-parameter-clause*_?_ *typealias-assignment*
->
-> *typealias-name* → *identifier*
->
+> *typealias-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`typealias`** *typealias-name* *generic-parameter-clause*_?_ *typealias-assignment* \
+> *typealias-name* → *identifier* \
 > *typealias-assignment* → **`=`** *type*
 
 > Grammar of a function declaration:
 >
 > *function-declaration* → *function-head* *function-name* *generic-parameter-clause*_?_ *function-signature* *generic-where-clause*_?_ *function-body*_?_
 >
->
->
-> *function-head* → *attributes*_?_ *declaration-modifiers*_?_ **`func`**
->
+> *function-head* → *attributes*_?_ *declaration-modifiers*_?_ **`func`** \
 > *function-name* → *identifier* | *operator*
 >
->
->
-> *function-signature* → *parameter-clause* **`async`**_?_ **`throws`**_?_ *function-result*_?_
->
-> *function-signature* → *parameter-clause* **`async`**_?_ **`rethrows`** *function-result*_?_
->
-> *function-result* → **`->`** *attributes*_?_ *type*
->
+> *function-signature* → *parameter-clause* **`async`**_?_ **`throws`**_?_ *function-result*_?_ \
+> *function-signature* → *parameter-clause* **`async`**_?_ **`rethrows`** *function-result*_?_ \
+> *function-result* → **`->`** *attributes*_?_ *type* \
 > *function-body* → *code-block*
 >
->
->
-> *parameter-clause* → **`(`** **`)`** | **`(`** *parameter-list* **`)`**
->
-> *parameter-list* → *parameter* | *parameter* **`,`** *parameter-list*
->
-> *parameter* → *external-parameter-name*_?_ *local-parameter-name* *type-annotation* *default-argument-clause*_?_
->
-> *parameter* → *external-parameter-name*_?_ *local-parameter-name* *type-annotation*
->
-> *parameter* → *external-parameter-name*_?_ *local-parameter-name* *type-annotation* **`...`**
->
-> *external-parameter-name* → *identifier*
->
-> *local-parameter-name* → *identifier*
->
+> *parameter-clause* → **`(`** **`)`** | **`(`** *parameter-list* **`)`** \
+> *parameter-list* → *parameter* | *parameter* **`,`** *parameter-list* \
+> *parameter* → *external-parameter-name*_?_ *local-parameter-name* *type-annotation* *default-argument-clause*_?_ \
+> *parameter* → *external-parameter-name*_?_ *local-parameter-name* *type-annotation* \
+> *parameter* → *external-parameter-name*_?_ *local-parameter-name* *type-annotation* **`...`** \
+> *external-parameter-name* → *identifier* \
+> *local-parameter-name* → *identifier* \
 > *default-argument-clause* → **`=`** *expression*
 
 > Grammar of an enumeration declaration:
 >
-> *enum-declaration* → *attributes*_?_ *access-level-modifier*_?_ *union-style-enum*
->
+> *enum-declaration* → *attributes*_?_ *access-level-modifier*_?_ *union-style-enum* \
 > *enum-declaration* → *attributes*_?_ *access-level-modifier*_?_ *raw-value-style-enum*
 >
->
->
-> *union-style-enum* → **`indirect`**_?_ **`enum`** *enum-name* *generic-parameter-clause*_?_ *type-inheritance-clause*_?_ *generic-where-clause*_?_ **`{`** *union-style-enum-members*_?_ **`}`**
->
-> *union-style-enum-members* → *union-style-enum-member* *union-style-enum-members*_?_
->
-> *union-style-enum-member* → *declaration* | *union-style-enum-case-clause* | *compiler-control-statement*
->
-> *union-style-enum-case-clause* → *attributes*_?_ **`indirect`**_?_ **`case`** *union-style-enum-case-list*
->
-> *union-style-enum-case-list* → *union-style-enum-case* | *union-style-enum-case* **`,`** *union-style-enum-case-list*
->
-> *union-style-enum-case* → *enum-case-name* *tuple-type*_?_
->
-> *enum-name* → *identifier*
->
+> *union-style-enum* → **`indirect`**_?_ **`enum`** *enum-name* *generic-parameter-clause*_?_ *type-inheritance-clause*_?_ *generic-where-clause*_?_ **`{`** *union-style-enum-members*_?_ **`}`** \
+> *union-style-enum-members* → *union-style-enum-member* *union-style-enum-members*_?_ \
+> *union-style-enum-member* → *declaration* | *union-style-enum-case-clause* | *compiler-control-statement* \
+> *union-style-enum-case-clause* → *attributes*_?_ **`indirect`**_?_ **`case`** *union-style-enum-case-list* \
+> *union-style-enum-case-list* → *union-style-enum-case* | *union-style-enum-case* **`,`** *union-style-enum-case-list* \
+> *union-style-enum-case* → *enum-case-name* *tuple-type*_?_ \
+> *enum-name* → *identifier* \
 > *enum-case-name* → *identifier*
 >
->
->
-> *raw-value-style-enum* → **`enum`** *enum-name* *generic-parameter-clause*_?_ *type-inheritance-clause* *generic-where-clause*_?_ **`{`** *raw-value-style-enum-members* **`}`**
->
-> *raw-value-style-enum-members* → *raw-value-style-enum-member* *raw-value-style-enum-members*_?_
->
-> *raw-value-style-enum-member* → *declaration* | *raw-value-style-enum-case-clause* | *compiler-control-statement*
->
-> *raw-value-style-enum-case-clause* → *attributes*_?_ **`case`** *raw-value-style-enum-case-list*
->
-> *raw-value-style-enum-case-list* → *raw-value-style-enum-case* | *raw-value-style-enum-case* **`,`** *raw-value-style-enum-case-list*
->
-> *raw-value-style-enum-case* → *enum-case-name* *raw-value-assignment*_?_
->
-> *raw-value-assignment* → **`=`** *raw-value-literal*
->
+> *raw-value-style-enum* → **`enum`** *enum-name* *generic-parameter-clause*_?_ *type-inheritance-clause* *generic-where-clause*_?_ **`{`** *raw-value-style-enum-members* **`}`** \
+> *raw-value-style-enum-members* → *raw-value-style-enum-member* *raw-value-style-enum-members*_?_ \
+> *raw-value-style-enum-member* → *declaration* | *raw-value-style-enum-case-clause* | *compiler-control-statement* \
+> *raw-value-style-enum-case-clause* → *attributes*_?_ **`case`** *raw-value-style-enum-case-list* \
+> *raw-value-style-enum-case-list* → *raw-value-style-enum-case* | *raw-value-style-enum-case* **`,`** *raw-value-style-enum-case-list* \
+> *raw-value-style-enum-case* → *enum-case-name* *raw-value-assignment*_?_ \
+> *raw-value-assignment* → **`=`** *raw-value-literal* \
 > *raw-value-literal* → *numeric-literal* | *static-string-literal* | *boolean-literal*
 
 > Grammar of a structure declaration:
 >
-> *struct-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`struct`** *struct-name* *generic-parameter-clause*_?_ *type-inheritance-clause*_?_ *generic-where-clause*_?_ *struct-body*
->
-> *struct-name* → *identifier*
->
+> *struct-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`struct`** *struct-name* *generic-parameter-clause*_?_ *type-inheritance-clause*_?_ *generic-where-clause*_?_ *struct-body* \
+> *struct-name* → *identifier* \
 > *struct-body* → **`{`** *struct-members*_?_ **`}`**
 >
->
->
-> *struct-members* → *struct-member* *struct-members*_?_
->
+> *struct-members* → *struct-member* *struct-members*_?_ \
 > *struct-member* → *declaration* | *compiler-control-statement*
 
 > Grammar of a class declaration:
 >
-> *class-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`final`**_?_ **`class`** *class-name* *generic-parameter-clause*_?_ *type-inheritance-clause*_?_ *generic-where-clause*_?_ *class-body*
->
-> *class-declaration* → *attributes*_?_ **`final`** *access-level-modifier*_?_ **`class`** *class-name* *generic-parameter-clause*_?_ *type-inheritance-clause*_?_ *generic-where-clause*_?_ *class-body*
->
-> *class-name* → *identifier*
->
+> *class-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`final`**_?_ **`class`** *class-name* *generic-parameter-clause*_?_ *type-inheritance-clause*_?_ *generic-where-clause*_?_ *class-body* \
+> *class-declaration* → *attributes*_?_ **`final`** *access-level-modifier*_?_ **`class`** *class-name* *generic-parameter-clause*_?_ *type-inheritance-clause*_?_ *generic-where-clause*_?_ *class-body* \
+> *class-name* → *identifier* \
 > *class-body* → **`{`** *class-members*_?_ **`}`**
 >
->
->
-> *class-members* → *class-member* *class-members*_?_
->
+> *class-members* → *class-member* *class-members*_?_ \
 > *class-member* → *declaration* | *compiler-control-statement*
 
 > Grammar of an actor declaration:
 >
-> *actor-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`actor`** *actor-name* *generic-parameter-clause*_?_ *type-inheritance-clause*_?_ *generic-where-clause*_?_ *actor-body*
->
-> *actor-name* → *identifier*
->
+> *actor-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`actor`** *actor-name* *generic-parameter-clause*_?_ *type-inheritance-clause*_?_ *generic-where-clause*_?_ *actor-body* \
+> *actor-name* → *identifier* \
 > *actor-body* → **`{`** *actor-members*_?_ **`}`**
 >
->
->
-> *actor-members* → *actor-member* *actor-members*_?_
->
+> *actor-members* → *actor-member* *actor-members*_?_ \
 > *actor-member* → *declaration* | *compiler-control-statement*
 
 > Grammar of a protocol declaration:
 >
-> *protocol-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`protocol`** *protocol-name* *type-inheritance-clause*_?_ *generic-where-clause*_?_ *protocol-body*
->
-> *protocol-name* → *identifier*
->
+> *protocol-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`protocol`** *protocol-name* *type-inheritance-clause*_?_ *generic-where-clause*_?_ *protocol-body* \
+> *protocol-name* → *identifier* \
 > *protocol-body* → **`{`** *protocol-members*_?_ **`}`**
 >
->
->
-> *protocol-members* → *protocol-member* *protocol-members*_?_
->
+> *protocol-members* → *protocol-member* *protocol-members*_?_ \
 > *protocol-member* → *protocol-member-declaration* | *compiler-control-statement*
 >
->
->
-> *protocol-member-declaration* → *protocol-property-declaration*
->
-> *protocol-member-declaration* → *protocol-method-declaration*
->
-> *protocol-member-declaration* → *protocol-initializer-declaration*
->
-> *protocol-member-declaration* → *protocol-subscript-declaration*
->
-> *protocol-member-declaration* → *protocol-associated-type-declaration*
->
+> *protocol-member-declaration* → *protocol-property-declaration* \
+> *protocol-member-declaration* → *protocol-method-declaration* \
+> *protocol-member-declaration* → *protocol-initializer-declaration* \
+> *protocol-member-declaration* → *protocol-subscript-declaration* \
+> *protocol-member-declaration* → *protocol-associated-type-declaration* \
 > *protocol-member-declaration* → *typealias-declaration*
 
 > Grammar of a protocol property declaration:
@@ -1415,8 +905,7 @@ make the same change here also.
 
 > Grammar of a protocol initializer declaration:
 >
-> *protocol-initializer-declaration* → *initializer-head* *generic-parameter-clause*_?_ *parameter-clause* **`throws`**_?_ *generic-where-clause*_?_
->
+> *protocol-initializer-declaration* → *initializer-head* *generic-parameter-clause*_?_ *parameter-clause* **`throws`**_?_ *generic-where-clause*_?_ \
 > *protocol-initializer-declaration* → *initializer-head* *generic-parameter-clause*_?_ *parameter-clause* **`rethrows`** *generic-where-clause*_?_
 
 > Grammar of a protocol subscript declaration:
@@ -1429,16 +918,11 @@ make the same change here also.
 
 > Grammar of an initializer declaration:
 >
-> *initializer-declaration* → *initializer-head* *generic-parameter-clause*_?_ *parameter-clause* **`async`**_?_ **`throws`**_?_ *generic-where-clause*_?_ *initializer-body*
->
-> *initializer-declaration* → *initializer-head* *generic-parameter-clause*_?_ *parameter-clause* **`async`**_?_ **`rethrows`** *generic-where-clause*_?_ *initializer-body*
->
-> *initializer-head* → *attributes*_?_ *declaration-modifiers*_?_ **`init`**
->
-> *initializer-head* → *attributes*_?_ *declaration-modifiers*_?_ **`init`** **`?`**
->
-> *initializer-head* → *attributes*_?_ *declaration-modifiers*_?_ **`init`** **`!`**
->
+> *initializer-declaration* → *initializer-head* *generic-parameter-clause*_?_ *parameter-clause* **`async`**_?_ **`throws`**_?_ *generic-where-clause*_?_ *initializer-body* \
+> *initializer-declaration* → *initializer-head* *generic-parameter-clause*_?_ *parameter-clause* **`async`**_?_ **`rethrows`** *generic-where-clause*_?_ *initializer-body* \
+> *initializer-head* → *attributes*_?_ *declaration-modifiers*_?_ **`init`** \
+> *initializer-head* → *attributes*_?_ *declaration-modifiers*_?_ **`init`** **`?`** \
+> *initializer-head* → *attributes*_?_ *declaration-modifiers*_?_ **`init`** **`!`** \
 > *initializer-body* → *code-block*
 
 > Grammar of a deinitializer declaration:
@@ -1447,53 +931,35 @@ make the same change here also.
 
 > Grammar of an extension declaration:
 >
-> *extension-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`extension`** *type-identifier* *type-inheritance-clause*_?_ *generic-where-clause*_?_ *extension-body*
->
+> *extension-declaration* → *attributes*_?_ *access-level-modifier*_?_ **`extension`** *type-identifier* *type-inheritance-clause*_?_ *generic-where-clause*_?_ *extension-body* \
 > *extension-body* → **`{`** *extension-members*_?_ **`}`**
 >
->
->
-> *extension-members* → *extension-member* *extension-members*_?_
->
+> *extension-members* → *extension-member* *extension-members*_?_ \
 > *extension-member* → *declaration* | *compiler-control-statement*
 
 > Grammar of a subscript declaration:
 >
-> *subscript-declaration* → *subscript-head* *subscript-result* *generic-where-clause*_?_ *code-block*
->
-> *subscript-declaration* → *subscript-head* *subscript-result* *generic-where-clause*_?_ *getter-setter-block*
->
-> *subscript-declaration* → *subscript-head* *subscript-result* *generic-where-clause*_?_ *getter-setter-keyword-block*
->
-> *subscript-head* → *attributes*_?_ *declaration-modifiers*_?_ **`subscript`** *generic-parameter-clause*_?_ *parameter-clause*
->
+> *subscript-declaration* → *subscript-head* *subscript-result* *generic-where-clause*_?_ *code-block* \
+> *subscript-declaration* → *subscript-head* *subscript-result* *generic-where-clause*_?_ *getter-setter-block* \
+> *subscript-declaration* → *subscript-head* *subscript-result* *generic-where-clause*_?_ *getter-setter-keyword-block* \
+> *subscript-head* → *attributes*_?_ *declaration-modifiers*_?_ **`subscript`** *generic-parameter-clause*_?_ *parameter-clause* \
 > *subscript-result* → **`->`** *attributes*_?_ *type*
 
 > Grammar of a macro declaration:
 >
-> *macro-declaration* → *macro-head* *identifier* *generic-parameter-clause*_?_ *macro-signature* *macro-definition*_?_ *generic-where-clause*
->
-> *macro-head* → *attributes*_?_ *declaration-modifiers*_?_ **`macro`** 
->
-> *macro-signature* → *parameter-clause* *macro-function-signature-result*_?_
->
-> *macro-function-signature-result* → **`->`** *type*
->
+> *macro-declaration* → *macro-head* *identifier* *generic-parameter-clause*_?_ *macro-signature* *macro-definition*_?_ *generic-where-clause* \
+> *macro-head* → *attributes*_?_ *declaration-modifiers*_?_ **`macro`**  \
+> *macro-signature* → *parameter-clause* *macro-function-signature-result*_?_ \
+> *macro-function-signature-result* → **`->`** *type* \
 > *macro-definition* → **`=`** *expression*
 
 > Grammar of an operator declaration:
 >
 > *operator-declaration* → *prefix-operator-declaration* | *postfix-operator-declaration* | *infix-operator-declaration*
 >
->
->
-> *prefix-operator-declaration* → **`prefix`** **`operator`** *operator*
->
-> *postfix-operator-declaration* → **`postfix`** **`operator`** *operator*
->
+> *prefix-operator-declaration* → **`prefix`** **`operator`** *operator* \
+> *postfix-operator-declaration* → **`postfix`** **`operator`** *operator* \
 > *infix-operator-declaration* → **`infix`** **`operator`** *operator* *infix-operator-group*_?_
->
->
 >
 > *infix-operator-group* → **`:`** *precedence-group-name*
 
@@ -1501,69 +967,38 @@ make the same change here also.
 >
 > *precedence-group-declaration* → **`precedencegroup`** *precedence-group-name* **`{`** *precedence-group-attributes*_?_ **`}`**
 >
->
->
-> *precedence-group-attributes* → *precedence-group-attribute* *precedence-group-attributes*_?_
->
-> *precedence-group-attribute* → *precedence-group-relation*
->
-> *precedence-group-attribute* → *precedence-group-assignment*
->
+> *precedence-group-attributes* → *precedence-group-attribute* *precedence-group-attributes*_?_ \
+> *precedence-group-attribute* → *precedence-group-relation* \
+> *precedence-group-attribute* → *precedence-group-assignment* \
 > *precedence-group-attribute* → *precedence-group-associativity*
 >
->
->
-> *precedence-group-relation* → **`higherThan`** **`:`** *precedence-group-names*
->
+> *precedence-group-relation* → **`higherThan`** **`:`** *precedence-group-names* \
 > *precedence-group-relation* → **`lowerThan`** **`:`** *precedence-group-names*
->
->
 >
 > *precedence-group-assignment* → **`assignment`** **`:`** *boolean-literal*
 >
->
->
-> *precedence-group-associativity* → **`associativity`** **`:`** **`left`**
->
-> *precedence-group-associativity* → **`associativity`** **`:`** **`right`**
->
+> *precedence-group-associativity* → **`associativity`** **`:`** **`left`** \
+> *precedence-group-associativity* → **`associativity`** **`:`** **`right`** \
 > *precedence-group-associativity* → **`associativity`** **`:`** **`none`**
 >
->
->
-> *precedence-group-names* → *precedence-group-name* | *precedence-group-name* **`,`** *precedence-group-names*
->
+> *precedence-group-names* → *precedence-group-name* | *precedence-group-name* **`,`** *precedence-group-names* \
 > *precedence-group-name* → *identifier*
 
 > Grammar of a declaration modifier:
 >
-> *declaration-modifier* → **`class`** | **`convenience`** | **`dynamic`** | **`final`** | **`infix`** | **`lazy`** | **`optional`** | **`override`** | **`postfix`** | **`prefix`** | **`required`** | **`static`** | **`unowned`** | **`unowned`** **`(`** **`safe`** **`)`** | **`unowned`** **`(`** **`unsafe`** **`)`** | **`weak`**
->
-> *declaration-modifier* → *access-level-modifier*
->
-> *declaration-modifier* → *mutation-modifier*
->
-> *declaration-modifier* → *actor-isolation-modifier*
->
+> *declaration-modifier* → **`class`** | **`convenience`** | **`dynamic`** | **`final`** | **`infix`** | **`lazy`** | **`optional`** | **`override`** | **`postfix`** | **`prefix`** | **`required`** | **`static`** | **`unowned`** | **`unowned`** **`(`** **`safe`** **`)`** | **`unowned`** **`(`** **`unsafe`** **`)`** | **`weak`** \
+> *declaration-modifier* → *access-level-modifier* \
+> *declaration-modifier* → *mutation-modifier* \
+> *declaration-modifier* → *actor-isolation-modifier* \
 > *declaration-modifiers* → *declaration-modifier* *declaration-modifiers*_?_
 >
->
->
-> *access-level-modifier* → **`private`** | **`private`** **`(`** **`set`** **`)`**
->
-> *access-level-modifier* → **`fileprivate`** | **`fileprivate`** **`(`** **`set`** **`)`**
->
-> *access-level-modifier* → **`internal`** | **`internal`** **`(`** **`set`** **`)`**
->
-> *access-level-modifier* → **`public`** | **`public`** **`(`** **`set`** **`)`**
->
+> *access-level-modifier* → **`private`** | **`private`** **`(`** **`set`** **`)`** \
+> *access-level-modifier* → **`fileprivate`** | **`fileprivate`** **`(`** **`set`** **`)`** \
+> *access-level-modifier* → **`internal`** | **`internal`** **`(`** **`set`** **`)`** \
+> *access-level-modifier* → **`public`** | **`public`** **`(`** **`set`** **`)`** \
 > *access-level-modifier* → **`open`** | **`open`** **`(`** **`set`** **`)`**
 >
->
->
 > *mutation-modifier* → **`mutating`** | **`nonmutating`**
->
->
 >
 > *actor-isolation-modifier* → **`nonisolated`**
 
@@ -1571,46 +1006,29 @@ make the same change here also.
 
 > Grammar of an attribute:
 >
-> *attribute* → **`@`** *attribute-name* *attribute-argument-clause*_?_
->
-> *attribute-name* → *identifier*
->
-> *attribute-argument-clause* → **`(`** *balanced-tokens*_?_ **`)`**
->
+> *attribute* → **`@`** *attribute-name* *attribute-argument-clause*_?_ \
+> *attribute-name* → *identifier* \
+> *attribute-argument-clause* → **`(`** *balanced-tokens*_?_ **`)`** \
 > *attributes* → *attribute* *attributes*_?_
 >
->
->
-> *balanced-tokens* → *balanced-token* *balanced-tokens*_?_
->
-> *balanced-token* → **`(`** *balanced-tokens*_?_ **`)`**
->
-> *balanced-token* → **`[`** *balanced-tokens*_?_ **`]`**
->
-> *balanced-token* → **`{`** *balanced-tokens*_?_ **`}`**
->
-> *balanced-token* → Any identifier, keyword, literal, or operator
->
+> *balanced-tokens* → *balanced-token* *balanced-tokens*_?_ \
+> *balanced-token* → **`(`** *balanced-tokens*_?_ **`)`** \
+> *balanced-token* → **`[`** *balanced-tokens*_?_ **`]`** \
+> *balanced-token* → **`{`** *balanced-tokens*_?_ **`}`** \
+> *balanced-token* → Any identifier, keyword, literal, or operator \
 > *balanced-token* → Any punctuation except  **`(`**,  **`)`**,  **`[`**,  **`]`**,  **`{`**, or  **`}`**
 
 ## Patterns
 
 > Grammar of a pattern:
 >
-> *pattern* → *wildcard-pattern* *type-annotation*_?_
->
-> *pattern* → *identifier-pattern* *type-annotation*_?_
->
-> *pattern* → *value-binding-pattern*
->
-> *pattern* → *tuple-pattern* *type-annotation*_?_
->
-> *pattern* → *enum-case-pattern*
->
-> *pattern* → *optional-pattern*
->
-> *pattern* → *type-casting-pattern*
->
+> *pattern* → *wildcard-pattern* *type-annotation*_?_ \
+> *pattern* → *identifier-pattern* *type-annotation*_?_ \
+> *pattern* → *value-binding-pattern* \
+> *pattern* → *tuple-pattern* *type-annotation*_?_ \
+> *pattern* → *enum-case-pattern* \
+> *pattern* → *optional-pattern* \
+> *pattern* → *type-casting-pattern* \
 > *pattern* → *expression-pattern*
 
 > Grammar of a wildcard pattern:
@@ -1627,10 +1045,8 @@ make the same change here also.
 
 > Grammar of a tuple pattern:
 >
-> *tuple-pattern* → **`(`** *tuple-pattern-element-list*_?_ **`)`**
->
-> *tuple-pattern-element-list* → *tuple-pattern-element* | *tuple-pattern-element* **`,`** *tuple-pattern-element-list*
->
+> *tuple-pattern* → **`(`** *tuple-pattern-element-list*_?_ **`)`** \
+> *tuple-pattern-element-list* → *tuple-pattern-element* | *tuple-pattern-element* **`,`** *tuple-pattern-element-list* \
 > *tuple-pattern-element* → *pattern* | *identifier* **`:`** *pattern*
 
 > Grammar of an enumeration case pattern:
@@ -1643,10 +1059,8 @@ make the same change here also.
 
 > Grammar of a type casting pattern:
 >
-> *type-casting-pattern* → *is-pattern* | *as-pattern*
->
-> *is-pattern* → **`is`** *type*
->
+> *type-casting-pattern* → *is-pattern* | *as-pattern* \
+> *is-pattern* → **`is`** *type* \
 > *as-pattern* → *pattern* **`as`** *type*
 
 > Grammar of an expression pattern:
@@ -1657,38 +1071,24 @@ make the same change here also.
 
 > Grammar of a generic parameter clause:
 >
-> *generic-parameter-clause* → **`<`** *generic-parameter-list* **`>`**
->
-> *generic-parameter-list* → *generic-parameter* | *generic-parameter* **`,`** *generic-parameter-list*
->
-> *generic-parameter* → *type-name*
->
-> *generic-parameter* → *type-name* **`:`** *type-identifier*
->
+> *generic-parameter-clause* → **`<`** *generic-parameter-list* **`>`** \
+> *generic-parameter-list* → *generic-parameter* | *generic-parameter* **`,`** *generic-parameter-list* \
+> *generic-parameter* → *type-name* \
+> *generic-parameter* → *type-name* **`:`** *type-identifier* \
 > *generic-parameter* → *type-name* **`:`** *protocol-composition-type*
 >
->
->
-> *generic-where-clause* → **`where`** *requirement-list*
->
-> *requirement-list* → *requirement* | *requirement* **`,`** *requirement-list*
->
+> *generic-where-clause* → **`where`** *requirement-list* \
+> *requirement-list* → *requirement* | *requirement* **`,`** *requirement-list* \
 > *requirement* → *conformance-requirement* | *same-type-requirement*
 >
->
->
-> *conformance-requirement* → *type-identifier* **`:`** *type-identifier*
->
-> *conformance-requirement* → *type-identifier* **`:`** *protocol-composition-type*
->
+> *conformance-requirement* → *type-identifier* **`:`** *type-identifier* \
+> *conformance-requirement* → *type-identifier* **`:`** *protocol-composition-type* \
 > *same-type-requirement* → *type-identifier* **`==`** *type*
 
 > Grammar of a generic argument clause:
 >
-> *generic-argument-clause* → **`<`** *generic-argument-list* **`>`**
->
-> *generic-argument-list* → *generic-argument* | *generic-argument* **`,`** *generic-argument-list*
->
+> *generic-argument-clause* → **`<`** *generic-argument-list* **`>`** \
+> *generic-argument-list* → *generic-argument* | *generic-argument* **`,`** *generic-argument-list* \
 > *generic-argument* → *type*
 
 > Beta Software:

--- a/TSPL.docc/ReferenceManual/Types.md
+++ b/TSPL.docc/ReferenceManual/Types.md
@@ -36,32 +36,19 @@ and describes the type inference behavior of Swift.
 
 > Grammar of a type:
 >
-> *type* → *function-type*
->
-> *type* → *array-type*
->
-> *type* → *dictionary-type*
->
-> *type* → *type-identifier*
->
-> *type* → *tuple-type*
->
-> *type* → *optional-type*
->
-> *type* → *implicitly-unwrapped-optional-type*
->
-> *type* → *protocol-composition-type*
->
-> *type* → *boxed-protocol-type*
->
-> *type* → *opaque-type*
->
-> *type* → *metatype-type*
->
-> *type* → *any-type*
->
-> *type* → *self-type*
->
+> *type* → *function-type* \
+> *type* → *array-type* \
+> *type* → *dictionary-type* \
+> *type* → *type-identifier* \
+> *type* → *tuple-type* \
+> *type* → *optional-type* \
+> *type* → *implicitly-unwrapped-optional-type* \
+> *type* → *protocol-composition-type* \
+> *type* → *boxed-protocol-type* \
+> *type* → *opaque-type* \
+> *type* → *metatype-type* \
+> *type* → *any-type* \
+> *type* → *self-type* \
 > *type* → **`(`** *type* **`)`**
 
 ## Type Annotation
@@ -147,8 +134,7 @@ var someValue: ExampleModule.MyType
 
 > Grammar of a type identifier:
 >
-> *type-identifier* → *type-name* *generic-argument-clause*_?_ | *type-name* *generic-argument-clause*_?_ **`.`** *type-identifier*
->
+> *type-identifier* → *type-name* *generic-argument-clause*_?_ | *type-name* *generic-argument-clause*_?_ **`.`** *type-identifier* \
 > *type-name* → *identifier*
 
 ## Tuple Type
@@ -191,12 +177,9 @@ except for `Void` which is a type alias for the empty tuple type, `()`.
 
 > Grammar of a tuple type:
 >
-> *tuple-type* → **`(`** **`)`** | **`(`** *tuple-type-element* **`,`** *tuple-type-element-list* **`)`**
->
-> *tuple-type-element-list* → *tuple-type-element* | *tuple-type-element* **`,`** *tuple-type-element-list*
->
-> *tuple-type-element* → *element-name* *type-annotation* | *type*
->
+> *tuple-type* → **`(`** **`)`** | **`(`** *tuple-type-element* **`,`** *tuple-type-element-list* **`)`** \
+> *tuple-type-element-list* → *tuple-type-element* | *tuple-type-element* **`,`** *tuple-type-element-list* \
+> *tuple-type-element* → *element-name* *type-annotation* | *type* \
 > *element-name* → *identifier*
 
 ## Function Type
@@ -495,18 +478,11 @@ see <doc:MemorySafety>.
 >
 > *function-type* → *attributes*_?_ *function-type-argument-clause* **`async`**_?_ **`throws`**_?_ **`->`** *type*
 >
->
->
-> *function-type-argument-clause* → **`(`** **`)`**
->
+> *function-type-argument-clause* → **`(`** **`)`** \
 > *function-type-argument-clause* → **`(`** *function-type-argument-list* **`...`**_?_ **`)`**
 >
->
->
-> *function-type-argument-list* → *function-type-argument* | *function-type-argument* **`,`** *function-type-argument-list*
->
-> *function-type-argument* → *attributes*_?_ **`inout`**_?_ *type* | *argument-label* *type-annotation*
->
+> *function-type-argument-list* → *function-type-argument* | *function-type-argument* **`,`** *function-type-argument-list* \
+> *function-type-argument* → *attributes*_?_ **`inout`**_?_ *type* | *argument-label* *type-annotation* \
 > *argument-label* → *identifier*
 
 <!--
@@ -844,8 +820,7 @@ typealias PQR = PQ & Q & R
 
 > Grammar of a protocol composition type:
 >
-> *protocol-composition-type* → *type-identifier* **`&`** *protocol-composition-continuation*
->
+> *protocol-composition-type* → *type-identifier* **`&`** *protocol-composition-continuation* \
 > *protocol-composition-continuation* → *type-identifier* | *protocol-composition-type*
 
 ## Opaque Type
@@ -1300,8 +1275,7 @@ to specify the type of its raw values, see <doc:Enumerations#Raw-Values>.
 
 > Grammar of a type inheritance clause:
 >
-> *type-inheritance-clause* → **`:`** *type-inheritance-list*
->
+> *type-inheritance-clause* → **`:`** *type-inheritance-list* \
 > *type-inheritance-list* → *attributes*_?_ *type-identifier* | *attributes*_?_ *type-identifier* **`,`** *type-inheritance-list*
 
 ## Type Inference


### PR DESCRIPTION
The formatting of the grammar changes as follows:

- Delete single blank lines.
- Collapse multiple blank lines into a single blank line.
- Add a hard break (` \`) except before blank or at the end.

Fixes: rdar://112146913
Fixes: https://github.com/apple/swift-book/issues/54