### PR TITLE
Remove reference to OptionSet being in the stdlib

### DIFF
--- a/TSPL.docc/LanguageGuide/Macros.md
+++ b/TSPL.docc/LanguageGuide/Macros.md
@@ -112,8 +112,7 @@ struct SundaeToppings {
 }
 ```
 
-This version of `SundaeToppings`
-calls the [`@OptionSet`][] macro from the Swift standard library.
+This version of `SundaeToppings` calls an `@OptionSet` macro.
 The macro reads the list of cases in the private enumeration,
 generates the list of constants for each option,
 and adds a conformance to the [`OptionSet`][] protocol.


### PR DESCRIPTION
`OptionSet` was briefly included in the version of the Swift standard library that shipped with beta 1:

https://github.com/apple/swift/blob/release/5.9-20230510/stdlib/public/core/Macros.swift#L93

However, it has since been reverted:

https://github.com/apple/swift/pull/66403 (merged into 'main')
https://github.com/apple/swift/pull/66404 (cherry pick to 5.9 release branch)

We should watch for it to be approved in the Swift Evolution process, and then re-add the link (assuming it gets approved):

https://forums.swift.org/t/63547
https://github.com/apple/swift-evolution/pull/1968

Fixes: rdar://111109664