### PR TITLE
Fix unused result warning for `defer` example

### DIFF
--- a/TSPL.docc/GuidedTour/GuidedTour.md
+++ b/TSPL.docc/GuidedTour/GuidedTour.md
@@ -2227,9 +2227,8 @@ func fridgeContains(_ food: String) -> Bool {
     let result = fridgeContent.contains(food)
     return result
 }
-let fridgeContainsBanana = fridgeContains("banana")
-if fridgeContainsBanana {
-    print("Banana found!")
+if fridgeContains("banana") {
+    print("Found a banana")
 }
 print(fridgeIsOpen)
 // Prints "false"

--- a/TSPL.docc/GuidedTour/GuidedTour.md
+++ b/TSPL.docc/GuidedTour/GuidedTour.md
@@ -2227,7 +2227,10 @@ func fridgeContains(_ food: String) -> Bool {
     let result = fridgeContent.contains(food)
     return result
 }
-fridgeContains("banana")
+let fridgeContainsBanana = fridgeContains("banana")
+if fridgeContainsBanana {
+    print("Banana found!")
+}
 print(fridgeIsOpen)
 // Prints "false"
 ```


### PR DESCRIPTION

<!-- What's in this pull request? -->
Fix unused result warning for `defer` example in GuidedTour.md for Guided Tour Section

<!-- If this pull request fixes a bug tracked in GitHub issues, provide the link. -->
Fixes: https://github.com/apple/swift-book/issues/157
