### PR TITLE
Include trailing () in macro URLs.

### DIFF
--- a/TSPL.docc/ReferenceManual/Expressions.md
+++ b/TSPL.docc/ReferenceManual/Expressions.md
@@ -605,13 +605,13 @@ or a playground literal.
 > `#function`,
 > and `#line`.
 > These are now implemented as macros in the Swift standard library:
-> [`column`](https://developer.apple.com/documentation/swift/column),
-> [`dsohandle`](https://developer.apple.com/documentation/swift/dsohandle),
-> [`fileID`](https://developer.apple.com/documentation/swift/fileID),
-> [`filePath`](https://developer.apple.com/documentation/swift/filePath),
-> [`file`](https://developer.apple.com/documentation/swift/file),
-> [`function`](https://developer.apple.com/documentation/swift/function),
-> and [`line`](https://developer.apple.com/documentation/swift/line).
+> [`column`](https://developer.apple.com/documentation/swift/column()),
+> [`dsohandle`](https://developer.apple.com/documentation/swift/dsohandle()),
+> [`fileID`](https://developer.apple.com/documentation/swift/fileID()),
+> [`filePath`](https://developer.apple.com/documentation/swift/filePath()),
+> [`file`](https://developer.apple.com/documentation/swift/file()),
+> [`function`](https://developer.apple.com/documentation/swift/function()),
+> and [`line`](https://developer.apple.com/documentation/swift/line()).
 
 <!--
   - test: `pound-file-flavors`

--- a/TSPL.docc/ReferenceManual/LexicalStructure.md
+++ b/TSPL.docc/ReferenceManual/LexicalStructure.md
@@ -391,14 +391,14 @@ so they must be escaped with backticks in that context.
 > `#line`,
 > and `#warning`.
 > These are now implemented as macros in the Swift standard library:
-> [`column`](https://developer.apple.com/documentation/swift/column),
-> [`dsohandle`](https://developer.apple.com/documentation/swift/dsohandle),
+> [`column`](https://developer.apple.com/documentation/swift/column()),
+> [`dsohandle`](https://developer.apple.com/documentation/swift/dsohandle()),
 > [`error(_:)`](https://developer.apple.com/documentation/swift/error(_:)),
-> [`fileID`](https://developer.apple.com/documentation/swift/fileID),
-> [`filePath`](https://developer.apple.com/documentation/swift/filePath),
-> [`file`](https://developer.apple.com/documentation/swift/file),
-> [`function`](https://developer.apple.com/documentation/swift/function),
-> [`line`](https://developer.apple.com/documentation/swift/line),
+> [`fileID`](https://developer.apple.com/documentation/swift/fileID()),
+> [`filePath`](https://developer.apple.com/documentation/swift/filePath()),
+> [`file`](https://developer.apple.com/documentation/swift/file()),
+> [`function`](https://developer.apple.com/documentation/swift/function()),
+> [`line`](https://developer.apple.com/documentation/swift/line()),
 > and [`warning(_:)`](https://developer.apple.com/documentation/swift/warning(_:)).
 
 <!--


### PR DESCRIPTION
This change matches an [upstream change](https://github.com/apple/swift/pull/66500) in the publication pipeline that will start including the `()` at the end of macro's names.  TSPL started linking to the macros that replace what used to be special literals in commit f2828dd507eeb1e1b733ed24897cd3d838598a1c, which is on 'main' but isn't yet included in the published content.  So if the publication pipeline updates before this PR is merged, that's also ok — the links that would break aren't there yet.

Fixes: rdar://112501547