### PR TITLE
Example of constant with deferred assignment

### DIFF
--- a/Style.md
+++ b/Style.md
@@ -111,6 +111,11 @@ Spelled as two words, not closed up or hyphenated.
 
 See entry for *Swift*.
 
+## definite initialization
+
+Not “definitive initialization”.
+Don‘t abbreviate as DI.
+
 ## function
 
 In the reference,

--- a/TSPL.docc/LanguageGuide/TheBasics.md
+++ b/TSPL.docc/LanguageGuide/TheBasics.md
@@ -117,8 +117,12 @@ if environment == "development" {
   ```
 -->
 
-In this example, the maximum number of login attemts is set
-to 100 for development environment, or to 10 for any other environments.
+In this example, the maximum number of login attemts is set to 100 for
+development environment, or to 10 for any other environments. Swift verifies
+that all code paths assign a value to the constant at compile time.
+In the example above, it's important that both branches of the `if` statement
+assign a value to `maximumNumberOfLoginAttempts`. If one of the branches did not
+assign a value, that code would raise a compilation error.
 
 You can declare multiple constants or multiple variables on a single line,
 separated by commas:

--- a/TSPL.docc/LanguageGuide/TheBasics.md
+++ b/TSPL.docc/LanguageGuide/TheBasics.md
@@ -93,7 +93,7 @@ Use variables only for storing values that change.
 When you declare a constant or a variable,
 you can give it a value as part of that declaration,
 like the examples above.
-Alternately,
+Alternatively,
 you can assign its initial value later in the program,
 as long as it's guaranteed to have a value
 before the first time you read from it.

--- a/TSPL.docc/LanguageGuide/TheBasics.md
+++ b/TSPL.docc/LanguageGuide/TheBasics.md
@@ -88,7 +88,7 @@ because this value must be incremented after each failed login attempt.
 
 If a stored value in your code won't change,
 always declare it as a constant with the `let` keyword.
-Use variables only for storing values that need to be able to change.
+Use variables only for storing values that change.
 
 When you declare a constant or a variable,
 you can give it a value as part of that declaration,
@@ -135,28 +135,14 @@ it has a value of 100;
 in any other environment, its value is 10.
 Both branches of the `if` statement
 initialize `maximumNumberOfLoginAttempts` with some value,
-which guarantees that the constant always gets a value.
+guaranteeing that the constant always gets a value.
 
 When you define a constant or variable
 without giving it a value,
-Swift analyzes your code at compile time
-and confirms that all possible paths of execution
-are guaranteed to set a value before reading a value.
-This analysis is called *definitive initialization*.
-
-> Note:
-> Definitive initialization
-> can't construct proofs that require domain knowledge,
-> and its ability to track state across conditionals is finite.
-> If you can determine that a value is always set,
-> but Swift can't prove this is the case,
-> try simplifying the conditionals or use a variable instead.
-
-<!--
-In the most general case,
-DI reduces to the halting problem,
-as shown by Rice's theorem.
--->
+Swift analyzes your code to make sure you set a value
+before the first time you read its value.
+For more information about this analysis,
+see <doc:Declarations#Constant-Declaration>.
 
 You can declare multiple constants or multiple variables on a single line,
 separated by commas:

--- a/TSPL.docc/LanguageGuide/TheBasics.md
+++ b/TSPL.docc/LanguageGuide/TheBasics.md
@@ -74,14 +74,16 @@ var currentLoginAttempt = 0
 
 This code can be read as:
 
-“Declare a new constant called `maximumNumberOfLoginAttempts`, and give it
-a value of `10`. Then, declare a new variable called `currentLoginAttempt`,
+“Declare a new constant called `maximumNumberOfLoginAttempts`,
+and give it a value of `10`.
+Then, declare a new variable called `currentLoginAttempt`,
 and give it an initial value of `0`.”
 
-In this example, the maximum number of allowed login attempts is declared as
-a constant, because the maximum value never changes. The current login attempt
-counter is declared as a variable, because this value must be incremented after
-each failed login attempt.
+In this example,
+the maximum number of allowed login attempts is declared as a constant,
+because the maximum value never changes.
+The current login attempt counter is declared as a variable,
+because this value must be incremented after each failed login attempt.
 
 You can declare a constant or a variable without assigning a value to it
 immediately, as long as you're initializing them with a value before they're

--- a/TSPL.docc/LanguageGuide/TheBasics.md
+++ b/TSPL.docc/LanguageGuide/TheBasics.md
@@ -136,12 +136,8 @@ in any other environment, its value is 10.
 Both branches of the `if` statement
 initialize `maximumNumberOfLoginAttempts` with some value,
 guaranteeing that the constant always gets a value.
-
-When you define a constant or variable
-without giving it a value,
-Swift analyzes your code to make sure you set a value
-before the first time you read its value.
-For more information about this analysis,
+For information about how Swift checks your code
+when you set an initial value this way,
 see <doc:Declarations#Constant-Declaration>.
 
 You can declare multiple constants or multiple variables on a single line,

--- a/TSPL.docc/LanguageGuide/TheBasics.md
+++ b/TSPL.docc/LanguageGuide/TheBasics.md
@@ -108,9 +108,9 @@ if environment == "development" {
   -> var environment = "development"
   -> let maximumNumberOfLoginAttempts: Int
   -> if environment == "development" {
-      maximumNumberOfLoginAttempts = 100
+         maximumNumberOfLoginAttempts = 100
      } else {
-      maximumNumberOfLoginAttempts = 10
+         maximumNumberOfLoginAttempts = 10
      }
   >> print(maxNumberOfLoginAttempts)
   << 100

--- a/TSPL.docc/LanguageGuide/TheBasics.md
+++ b/TSPL.docc/LanguageGuide/TheBasics.md
@@ -53,7 +53,7 @@ whereas a *variable* can be set to a different value in the future.
 
 ### Declaring Constants and Variables
 
-Constants and variables must be declared before they're used.
+Constants and variables must be declared and initialized with a value before they're used.
 You declare constants with the `let` keyword
 and variables with the `var` keyword.
 Here's an example of how constants and variables can be used
@@ -85,6 +85,40 @@ the maximum number of allowed login attempts is declared as a constant,
 because the maximum value never changes.
 The current login attempt counter is declared as a variable,
 because this value must be incremented after each failed login attempt.
+
+You can declare a constant or a variable without assigning a value to it
+immediately, as long as you're initializing them with a value before they're used:
+
+```swift
+var environment = "development"
+let maximumNumberOfLoginAttempts: Int
+
+if environment == "development" {
+    maximumNumberOfLoginAttempts = 100
+} else {
+    maximumNumberOfLoginAttempts = 10
+}
+
+// You can use maximumNumberOfLoginAttempts here.
+```
+<!--
+  - test: `constantsWithDeferredInitialization`
+
+  ```swifttest
+  -> var environment = "development"
+  -> let maximumNumberOfLoginAttempts: Int
+  -> if environment == "development" {
+      maximumNumberOfLoginAttempts = 100
+     } else {
+      maximumNumberOfLoginAttempts = 10
+     }
+  >> print(maxNumberOfLoginAttempts)
+  << 100
+  ```
+-->
+
+In this example, the maximum number of login attemts is set
+to 100 for development environment, or to 10 for any other environments.
 
 You can declare multiple constants or multiple variables on a single line,
 separated by commas:

--- a/TSPL.docc/LanguageGuide/TheBasics.md
+++ b/TSPL.docc/LanguageGuide/TheBasics.md
@@ -53,6 +53,7 @@ whereas a *variable* can be set to a different value in the future.
 
 ### Declaring Constants and Variables
 
+Constants and variables must be declared before they're used.
 You declare constants with the `let` keyword
 and variables with the `var` keyword.
 Here's an example of how constants and variables can be used
@@ -85,22 +86,31 @@ because the maximum value never changes.
 The current login attempt counter is declared as a variable,
 because this value must be incremented after each failed login attempt.
 
-You can declare a constant or a variable without assigning a value to it
-immediately, as long as you're initializing them with a value before they're
-used.
+If a stored value in your code won't change,
+always declare it as a constant with the `let` keyword.
+Use variables only for storing values that need to be able to change.
+
+When you declare a constant or a variable,
+you can give it a value as part of that declaration,
+like the examples above.
+Alternately,
+you can assign its initial value later in the program,
+as long as it's guaranteed to have a value
+before the first time you read from it.
 
 ```swift
 var environment = "development"
 let maximumNumberOfLoginAttempts: Int
+// maximumNumberOfLoginAttempts has no value yet.
 
 if environment == "development" {
     maximumNumberOfLoginAttempts = 100
 } else {
     maximumNumberOfLoginAttempts = 10
 }
-
-// You can use maximumNumberOfLoginAttempts here.
+// Now maximumNumberOfLoginAttempts has a value, and can be read.
 ```
+
 <!--
   - test: `constantsWithDeferredInitialization`
 
@@ -117,18 +127,30 @@ if environment == "development" {
   ```
 -->
 
-In this example, the maximum number of login attemts is set to 100 for
-development environment, or to 10 for any other environments.
+In this example,
+the maximum number of login attempts is constant,
+and its value depends on the environment.
+In the development environment,
+it has a value of 100;
+in any other environment, its value is 10.
+Both branches of the `if` statement
+initialize `maximumNumberOfLoginAttempts` with some value,
+which guarantees that the constant always gets a value.
 
-In Swift, variables and constants don't have an implicit default value.
-When Swift compiles your code, it performs a dataflow analysis and verifies that
-all constants and variables are defined and initialized with a value before
-they are used. This technique is referred to as
-[definitive initialization](http://en.wikipedia.org/wiki/Definite_assignment_analysis)
+When you define a constant or variable
+without giving it a value,
+Swift analyzes your code at compile time
+and confirms that all possible paths of execution
+are guaranteed to set a value before reading a value.
+This analysis is called *definitive initialization*.
 
-The example above is valid, because both branches of the `if` statement
-initialize `maximumNumberOfLoginAttempts` with some value. If one of the
-branches did not assign a value, Swift would return a compilation error.
+> Note:
+> Definitive initialization
+> can't construct proofs that require domain knowledge,
+> and its ability to track state across conditionals is finite.
+> If you can determine that a value is always set,
+> but Swift can't prove this is the case,
+> try simplifying the conditionals or use a variable instead.
 
 You can declare multiple constants or multiple variables on a single line,
 separated by commas:
@@ -146,10 +168,6 @@ var x = 0.0, y = 0.0, z = 0.0
   << 0.0 0.0 0.0
   ```
 -->
-
-> Note: If a stored value in your code won't change,
-> always declare it as a constant with the `let` keyword.
-> Use variables only for storing values that need to be able to change.
 
 ### Type Annotations
 

--- a/TSPL.docc/LanguageGuide/TheBasics.md
+++ b/TSPL.docc/LanguageGuide/TheBasics.md
@@ -53,7 +53,6 @@ whereas a *variable* can be set to a different value in the future.
 
 ### Declaring Constants and Variables
 
-Constants and variables must be declared and initialized with a value before they're used.
 You declare constants with the `let` keyword
 and variables with the `var` keyword.
 Here's an example of how constants and variables can be used
@@ -75,19 +74,18 @@ var currentLoginAttempt = 0
 
 This code can be read as:
 
-“Declare a new constant called `maximumNumberOfLoginAttempts`,
-and give it a value of `10`.
-Then, declare a new variable called `currentLoginAttempt`,
+“Declare a new constant called `maximumNumberOfLoginAttempts`, and give it
+a value of `10`. Then, declare a new variable called `currentLoginAttempt`,
 and give it an initial value of `0`.”
 
-In this example,
-the maximum number of allowed login attempts is declared as a constant,
-because the maximum value never changes.
-The current login attempt counter is declared as a variable,
-because this value must be incremented after each failed login attempt.
+In this example, the maximum number of allowed login attempts is declared as
+a constant, because the maximum value never changes. The current login attempt
+counter is declared as a variable, because this value must be incremented after
+each failed login attempt.
 
 You can declare a constant or a variable without assigning a value to it
-immediately, as long as you're initializing them with a value before they're used:
+immediately, as long as you're initializing them with a value before they're
+used.
 
 ```swift
 var environment = "development"
@@ -118,11 +116,17 @@ if environment == "development" {
 -->
 
 In this example, the maximum number of login attemts is set to 100 for
-development environment, or to 10 for any other environments. Swift verifies
-that all code paths assign a value to the constant at compile time.
-In the example above, it's important that both branches of the `if` statement
-assign a value to `maximumNumberOfLoginAttempts`. If one of the branches did not
-assign a value, that code would raise a compilation error.
+development environment, or to 10 for any other environments.
+
+In Swift, variables and constants don't have an implicit default value.
+When Swift compiles your code, it performs a dataflow analysis and verifies that
+all constants and variables are defined and initialized with a value before
+they are used. This technique is referred to as
+[definitive initialization](http://en.wikipedia.org/wiki/Definite_assignment_analysis)
+
+The example above is valid, because both branches of the `if` statement
+initialize `maximumNumberOfLoginAttempts` with some value. If one of the
+branches did not assign a value, Swift would return a compilation error.
 
 You can declare multiple constants or multiple variables on a single line,
 separated by commas:

--- a/TSPL.docc/LanguageGuide/TheBasics.md
+++ b/TSPL.docc/LanguageGuide/TheBasics.md
@@ -152,6 +152,12 @@ This analysis is called *definitive initialization*.
 > but Swift can't prove this is the case,
 > try simplifying the conditionals or use a variable instead.
 
+<!--
+In the most general case,
+DI reduces to the halting problem,
+as shown by Rice's theorem.
+-->
+
 You can declare multiple constants or multiple variables on a single line,
 separated by commas:
 

--- a/TSPL.docc/ReferenceManual/Declarations.md
+++ b/TSPL.docc/ReferenceManual/Declarations.md
@@ -156,6 +156,24 @@ as long as it's guaranteed to have a value set
 before the first time its value is read.
 If the compiler can prove that the constant's value is never read,
 the constant isn't required to have a value set at all.
+This analysis is called *definite initialization* ---
+the compiler proves that a value is definitely set before being read.
+
+> Note:
+> Definite initialization
+> can't construct proofs that require domain knowledge,
+> and its ability to track state across conditionals has a limit.
+> If you can determine that constant always has a value set,
+> but the compiler can't prove this is the case,
+> try simplifying the code paths that set the value,
+> or use a variable declaration instead.
+
+<!--
+In the most general case,
+DI reduces to the halting problem,
+as shown by Rice's theorem.
+-->
+
 When a constant declaration occurs in the context of a class or structure
 declaration, it's considered a *constant property*.
 Constant declarations aren't computed properties and therefore don't have getters
@@ -277,6 +295,9 @@ That said, if no initializer *expression* is present,
 the variable declaration must include an explicit type annotation (`:` *type*).
 
 As with constant declarations,
+if a variable declaration omits the initializer *expression*,
+the variable must have a value set before the first time it is read.
+Also like constant declarations,
 if the *variable name* is a tuple pattern,
 the name of each item in the tuple is bound to the corresponding value
 in the initializer *expression*.


### PR DESCRIPTION
## What

This pull request adds an example of defining a constant without assigning a value to it immediately, and then setting a value based on a condition. 

Fixes: https://github.com/apple/swift-book/issues/139
Fixes: rdar://114058607

## Checklist

- I'm just getting started and learning — I _think_ I got the `swifttest` syntax right? 

/cc @amartini51. How does that look? Are small contributions like this one useful at all? 🙃 