### PR TITLE
SE-0377: Document the `borrowing` and `consuming` parameter modifiers

### DIFF
--- a/TSPL.docc/ReferenceManual/Declarations.md
+++ b/TSPL.docc/ReferenceManual/Declarations.md
@@ -1045,7 +1045,6 @@ see <doc:Functions#In-Out-Parameters>.
 By default, Swift uses a set of rules
 to automatically manage manage object lifetime across function calls,
 copying values when required.
-<!-- XXX "object lifetime" is a new term -->
 The default rules are designed to minimize overhead in most cases ---
 if you want more specific control,
 you can apply the `borrowing` or `consuming` parameter modifier.
@@ -1058,13 +1057,15 @@ ownership are correctly managed in all cases.
 These parameter modifiers impact only the relative efficiency
 of particular usage patterns, not correctness.
 
-<!-- XXX xref the ARC chapter, for info about the default behavior -->
+<!-- XXX TR:
+Should we describe the default rules somewhere?
+Here or in the ARC chapter?
+-->
 
 The `borrowing` modifier indicates that the function
 does not keep the parameter's value.
-In this case, the caller retains ownership
-and is responsible for ensuring that the object remains alive.
-<!-- XXX we don't use "alive" elsewhere in this sense -->
+In this case, the caller maintains ownership of the object
+and the responsibility for the object's lifetime.
 Using `borrowing` minimizes overhead when the function
 is making only transient use of the object.
 

--- a/TSPL.docc/ReferenceManual/Declarations.md
+++ b/TSPL.docc/ReferenceManual/Declarations.md
@@ -1648,20 +1648,15 @@ but the new method must preserve its return type and nonreturning behavior.
 >
 > *parameter-clause* → **`(`** **`)`** | **`(`** *parameter-list* **`)`** \
 > *parameter-list* → *parameter* | *parameter* **`,`** *parameter-list* \
-> *parameter* → *external-parameter-name*_?_ *local-parameter-name* *type-annotation* *default-argument-clause*_?_ \
-> *parameter* → *external-parameter-name*_?_ *local-parameter-name* *type-annotation* \
-> *parameter* → *external-parameter-name*_?_ *local-parameter-name* *type-annotation* **`...`** \
+> *parameter* → *external-parameter-name*_?_ *local-parameter-name* *parameter-type-annotation* *default-argument-clause*_?_ \
+> *parameter* → *external-parameter-name*_?_ *local-parameter-name* *parameter-type-annotation* \
+> *parameter* → *external-parameter-name*_?_ *local-parameter-name* *parameter-type-annotation* **`...`** \
+>
 > *external-parameter-name* → *identifier* \
 > *local-parameter-name* → *identifier* \
-> *default-argument-clause* → **`=`** *expression*
-
-<!-- XXX merge into the box above -->
-
-> Grammar of a function parameter:
->
-> *parameter* → *external-parameter-name*_?_ *local-parameter-name* **`:`** *attributes*_?_ *parameter-modifier*_?_ *type* \
+> *parameter-type-annotation* → **`:`** *attributes*_?_ *parameter-modifier*_?_ *type*
 > *parameter-modifier* → **`inout`** | **`borrowing`** | **`consuming`**
-
+> *default-argument-clause* → **`=`** *expression*
 
 <!--
   NOTE: Code block is optional in the context of a protocol.

--- a/TSPL.docc/ReferenceManual/Declarations.md
+++ b/TSPL.docc/ReferenceManual/Declarations.md
@@ -1043,7 +1043,7 @@ see <doc:Functions#In-Out-Parameters>.
 #### Borrowing and Consuming Parameters
 
 By default, Swift uses a set of rules
-to automatically manage manage object lifetime across function calls,
+to automatically manage object lifetime across function calls,
 copying values when required.
 The default rules are designed to minimize overhead in most cases ---
 if you want more specific control,

--- a/TSPL.docc/ReferenceManual/Declarations.md
+++ b/TSPL.docc/ReferenceManual/Declarations.md
@@ -833,17 +833,16 @@ repeatGreeting("Hello, world!", count: 2) //  count is labeled, greeting is not
 
 ### Parameter Modifiers
 
-A parameter can also include one of the *parameter modifier*
-keywords `inout`, `borrowing`, or `consuming`
-to modify how the
-argument is passed to the function.
+A *parameter modifier* changes how the argument is passed to the function.
 
 ```swift
 <#argument label#> <#parameter name#>: <#parameter modifier#> <#parameter type#>
 ```
 
-You can specify at most one parameter modifier next to the type
-of the argument:
+To use a parameter modifier,
+write `inout`, `borrowing`, or `consuming`
+before the argument's type.
+
 ```swift
 func someFunction(a: inout A, b: consuming B, c: C) { ... }
 ```
@@ -851,8 +850,10 @@ func someFunction(a: inout A, b: consuming B, c: C) { ... }
 #### In-Out Parameters
 
 By default, function arguments in Swift are passed by value:
-any changes made within the function are not visible in the caller.
-You can change this with the `inout` parameter modifier.
+Any changes made within the function are not visible in the caller.
+To make an in-out parameter instead,
+you apply the `inout` parameter modifier.
+
 
 ```swift
 func someFunction(a: inout Int) {
@@ -860,14 +861,14 @@ func someFunction(a: inout Int) {
 }
 ```
 
-When calling such a function, the `inout` argument is
-prefixed with a `&` symbol to mark that the value may
-be changed by the function call.
+When calling a function that includes in-out parameters,
+the in-out argument prefixed with an ampersand (`&`)
+to mark that the function call can change the argument's value.
 
 ```swift
 var x = 7
 someFunction(&x)
-print(x) // 8
+print(x)  // Prints "8"
 ```
 
 In-out parameters are passed as follows:
@@ -1041,36 +1042,30 @@ see <doc:Functions#In-Out-Parameters>.
 
 #### Borrowing and Consuming Parameters
 
-The Swift compiler has varying ownership rules that it
-can use to manage object lifetimes across function calls.
-The default rules are designed to minimize overhead in most cases,
-but if you want to more carefully control ownership for
-a particular case,
-you can explicitly specify `borrowing`
-or `consuming` behavior for a particular parameter.
+By default, Swift uses a set of rules
+to automatically manage manage object lifetime across function calls,
+copying values when required.
+<!-- XXX "object lifetime" is a new term -->
+The default rules are designed to minimize overhead in most cases ---
+if you want more specific control,
+you can apply the `borrowing` or `consuming` parameter modifier.
+In this case,
+you must use `copy` to explicitly mark copy operations.
 
-Note:
+Regardless of whether you use the default rules,
 Swift guarantees that object lifetime and
-ownership will be correctly managed in all cases,
-with or without one of these modifiers.
-These modifiers only impact the relative efficiency
-for particular patterns of usage.
+ownership are correctly managed in all cases.
+These parameter modifiers impact only the relative efficiency
+of particular usage patterns, not correctness.
 
-Unlike `inout`, neither `borrowing` nor
-`consuming` parameters require any special
-notation when you call the function:
-
-```swift
-func someFunction(a: borrowing A, b: consuming B) { ... }
-
-someFunction(a: someA, b: someB)
-```
+<!-- XXX xref the ARC chapter, for info about the default behavior -->
 
 The `borrowing` modifier indicates that the function
-will not keep the value.
-In this case, the caller will retain ownership
-and will be responsible for ensuring that the object remains alive,
-which minimizes overhead when the function
+does not keep the parameter's value.
+In this case, the caller retains ownership
+and is responsible for ensuring that the object remains alive.
+<!-- XXX we don't use "alive" elsewhere in this sense -->
+Using `borrowing` minimizes overhead when the function
 is making only transient use of the object.
 
 ```swift
@@ -1080,10 +1075,9 @@ func isLessThan(lhs: borrowing A, rhs: borrowing A) -> Bool {
 }
 ```
 
-However,
-if the function does keep the value ---
+If the function needs to keep the parameter's value
 for example, by storing it in a global variable ---
-you will have to make a copy.
+you use `copy` to explicitly copy that value.
 
 ```swift
 // As above, but this `isLessThan` also wants to record the smallest value
@@ -1098,12 +1092,10 @@ func isLessThan(lhs: borrowing A, rhs: borrowing A) -> Bool {
 ```
 
 Conversely,
-the `consuming` modifier indicates
-that the function will take ownership of the
-value,
-accepting responsibility for
-either storing or destroying it before the
-function returns.
+the `consuming` parameter modifier indicates
+that the function takes ownership of the value,
+accepting responsibility for either storing or destroying it
+before the function returns.
 
 ```swift
 // `store` keeps its argument, so we mark it `consuming`
@@ -1112,29 +1104,42 @@ func store(a: consuming A) {
 }
 ```
 
-This minimizes overhead when the caller no longer
-needs to use the object after the call.
+Using `consuming` minimizes overhead when the caller no longer
+needs to use the object after the function call.
 
 ```swift
 // Usually, this is the last thing we do with a value
 store(a: value)
 ```
 
-But if the caller does need to use the object
-after the call,
+If the caller does need to use the object after the function call,
 it might need to make a separate
 copy before calling the function.
+<!-- XXX TR:
+When do you need to explicitly copy?
+When does the compiler implicitly insert a copy, as shown below?
+-->
 
 ```swift
-// The compiler will insert an implicit copy here
-store(a: value) // This consumes the value
-print(value) // This uses the copy
+// The compiler inserts an implicit copy here
+store(a: someValue)  // This function consumes someValue
+print(someValue)  // This uses the copy of someValue
+```
+
+Unlike `inout`, neither `borrowing` nor
+`consuming` parameters require any special
+notation when you call the function:
+
+```swift
+func someFunction(a: borrowing A, b: consuming B) { ... }
+
+someFunction(a: someA, b: someB)
 ```
 
 The explicit use of either `borrowing` or `consuming`
 indicates your intention to more tightly control
 the overhead of runtime ownership management.
-Since copies can trigger unexpected runtime ownership
+Because copies can trigger unexpected runtime ownership
 operations,
 parameters marked with either of these
 modifiers cannot be copied unless you

--- a/TSPL.docc/ReferenceManual/Declarations.md
+++ b/TSPL.docc/ReferenceManual/Declarations.md
@@ -1115,9 +1115,9 @@ needs to use the object after the function call.
 store(a: value)
 ```
 
-If the caller does need to use the object after the function call,
-it might need to make a separate
-copy before calling the function.
+If you keep using a copyable object after the function call,
+the compiler automatically makes a copy of that object
+before the function call.
 
 ```swift
 // The compiler inserts an implicit copy here

--- a/TSPL.docc/ReferenceManual/Declarations.md
+++ b/TSPL.docc/ReferenceManual/Declarations.md
@@ -833,7 +833,7 @@ repeatGreeting("Hello, world!", count: 2) //  count is labeled, greeting is not
 
 ### Parameter Modifiers
 
-A *parameter modifier* changes how the argument is passed to the function.
+A *parameter modifier* changes how an argument is passed to the function.
 
 ```swift
 <#argument label#> <#parameter name#>: <#parameter modifier#> <#parameter type#>
@@ -902,7 +902,7 @@ so that it behaves correctly with or without the optimization.
 Within a function, don't access a value that was passed as an in-out argument,
 even if the original value is available in the current scope.
 Accessing the original is a simultaneous access of the value,
-which violates Swift's memory exclusivity guarantee.
+which violates memory exclusivity.
 
 ```swift
 var someValue: Int
@@ -910,7 +910,7 @@ func someFunction(a: inout Int) {
     a += someValue
 }
 
-// Error: This will cause a runtime exclusivity violation
+// Error: This causes a runtime exclusivity violation
 someFunction(&someValue)
 ```
 
@@ -1069,7 +1069,7 @@ does not keep the parameter's value.
 In this case, the caller maintains ownership of the object
 and the responsibility for the object's lifetime.
 Using `borrowing` minimizes overhead when the function
-is making only transient use of the object.
+uses the object only transiently.
 
 ```swift
 // `isLessThan` does not keep either argument
@@ -1101,7 +1101,7 @@ accepting responsibility for either storing or destroying it
 before the function returns.
 
 ```swift
-// `store` keeps its argument, so we mark it `consuming`
+// `store` keeps its argument, so mark it `consuming`
 func store(a: consuming A) {
     someGlobalVariable = a
 }
@@ -1111,7 +1111,7 @@ Using `consuming` minimizes overhead when the caller no longer
 needs to use the object after the function call.
 
 ```swift
-// Usually, this is the last thing we do with a value
+// Usually, this is the last thing you do with a value
 store(a: value)
 ```
 
@@ -1138,7 +1138,7 @@ someFunction(a: someA, b: someB)
 The explicit use of either `borrowing` or `consuming`
 indicates your intention to more tightly control
 the overhead of runtime ownership management.
-Because copies can trigger unexpected runtime ownership
+Because copies can cause unexpected runtime ownership
 operations,
 parameters marked with either of these
 modifiers cannot be copied unless you

--- a/TSPL.docc/ReferenceManual/Declarations.md
+++ b/TSPL.docc/ReferenceManual/Declarations.md
@@ -862,7 +862,7 @@ func someFunction(a: inout Int) {
 ```
 
 When calling a function that includes in-out parameters,
-the in-out argument prefixed with an ampersand (`&`)
+the in-out argument must be prefixed with an ampersand (`&`)
 to mark that the function call can change the argument's value.
 
 ```swift

--- a/TSPL.docc/ReferenceManual/Declarations.md
+++ b/TSPL.docc/ReferenceManual/Declarations.md
@@ -1118,10 +1118,6 @@ store(a: value)
 If the caller does need to use the object after the function call,
 it might need to make a separate
 copy before calling the function.
-<!-- XXX TR:
-When do you need to explicitly copy?
-When does the compiler implicitly insert a copy, as shown below?
--->
 
 ```swift
 // The compiler inserts an implicit copy here

--- a/TSPL.docc/ReferenceManual/Declarations.md
+++ b/TSPL.docc/ReferenceManual/Declarations.md
@@ -1057,9 +1057,11 @@ ownership are correctly managed in all cases.
 These parameter modifiers impact only the relative efficiency
 of particular usage patterns, not correctness.
 
-<!-- XXX TR:
-Should we describe the default rules somewhere?
-Here or in the ARC chapter?
+<!--
+TODO: Describe the default rules.
+Essentially, inits and property setters are consuming,
+and everything else is borrowing.
+Where are copies implicitly inserted?
 -->
 
 The `borrowing` modifier indicates that the function

--- a/TSPL.docc/ReferenceManual/Declarations.md
+++ b/TSPL.docc/ReferenceManual/Declarations.md
@@ -1049,7 +1049,7 @@ The default rules are designed to minimize overhead in most cases ---
 if you want more specific control,
 you can apply the `borrowing` or `consuming` parameter modifier.
 In this case,
-you must use `copy` to explicitly mark copy operations.
+use `copy` to explicitly mark copy operations.
 
 Regardless of whether you use the default rules,
 Swift guarantees that object lifetime and

--- a/TSPL.docc/ReferenceManual/Declarations.md
+++ b/TSPL.docc/ReferenceManual/Declarations.md
@@ -831,11 +831,6 @@ repeatGreeting("Hello, world!", count: 2) //  count is labeled, greeting is not
   ```
 -->
 
-> Grammar of a function parameter:
->
-> *parameter* → *external-parameter-name*_?_ *local-parameter-name* **`:`** *attributes*_?_ *parameter-modifier*_?_ *type* \
-> *parameter-modifier* → **`inout`** | **`borrowing`** | **`consuming`**
-
 ### Parameter Modifiers
 
 A parameter can also include one of the *parameter modifier*
@@ -1086,9 +1081,9 @@ func isLessThan(lhs: borrowing A, rhs: borrowing A) -> Bool {
 ```
 
 However,
-if the function does keep the value
-- for example, by storing it in a global variable
-- you will have to make a copy.
+if the function does keep the value ---
+for example, by storing it in a global variable ---
+you will have to make a copy.
 
 ```swift
 // As above, but this `isLessThan` also wants to record the smallest value
@@ -1654,6 +1649,14 @@ but the new method must preserve its return type and nonreturning behavior.
 > *external-parameter-name* → *identifier* \
 > *local-parameter-name* → *identifier* \
 > *default-argument-clause* → **`=`** *expression*
+
+<!-- XXX merge into the box above -->
+
+> Grammar of a function parameter:
+>
+> *parameter* → *external-parameter-name*_?_ *local-parameter-name* **`:`** *attributes*_?_ *parameter-modifier*_?_ *type* \
+> *parameter-modifier* → **`inout`** | **`borrowing`** | **`consuming`**
+
 
 <!--
   NOTE: Code block is optional in the context of a protocol.

--- a/TSPL.docc/ReferenceManual/Types.md
+++ b/TSPL.docc/ReferenceManual/Types.md
@@ -80,7 +80,7 @@ Type annotations can contain an optional list of type attributes before the type
 
 > Grammar of a type annotation:
 >
-> *type-annotation* → **`:`** *attributes*_?_ **`inout`**_?_ *type*
+> *type-annotation* → **`:`** *attributes*_?_ *type*
 
 ## Type Identifier
 
@@ -482,7 +482,7 @@ see <doc:MemorySafety>.
 > *function-type-argument-clause* → **`(`** *function-type-argument-list* **`...`**_?_ **`)`**
 >
 > *function-type-argument-list* → *function-type-argument* | *function-type-argument* **`,`** *function-type-argument-list* \
-> *function-type-argument* → *attributes*_?_ **`inout`**_?_ *type* | *argument-label* *type-annotation* \
+> *function-type-argument* → *attributes*_?_ *parameter-modifier*_?_ *type* | *argument-label* *type-annotation* \
 > *argument-label* → *identifier*
 
 <!--


### PR DESCRIPTION
This documents the `borrowing` and `consuming` parameter modifiers introduced by [SE-0377][].

These are comparatively niche, so I'm only documenting them in the "Reference Manual" section for now.

I've structured this by:

* Creating a new "Parameter Modifiers" section with a brief description of the modifiers concept,
* Moving the old "In-Out Parameters" description under it, and
* Adding a new subsection on Borrowing and Consuming Parameters.

I've also adjusted the "In-Out Parameters" introduction so it starts with a code example showing the `inout` syntax and usage.

[SE-0377]: https://github.com/apple/swift-evolution/blob/main/proposals/0377-parameter-ownership-modifiers.md

Fixes: rdar://116031853