### PR TITLE
Fix broken and old links

### DIFF
--- a/TSPL.docc/LanguageGuide/Macros.md
+++ b/TSPL.docc/LanguageGuide/Macros.md
@@ -117,8 +117,15 @@ The macro reads the list of cases in the private enumeration,
 generates the list of constants for each option,
 and adds a conformance to the [`OptionSet`][] protocol.
 
+[`OptionSet`]: https://developer.apple.com/documentation/swift/optionset
+
+<!--
+When the @OptionSet macro comes back, change both links back:
+
 [`@OptionSet`]: https://developer.apple.com/documentation/swift/optionset-swift.macro
 [`OptionSet`]: https://developer.apple.com/documentation/swift/optionset-swift.protocol
+-->
+
 
 For comparison,
 here's what the expanded version of the `@OptionSet` macro looks like.

--- a/TSPL.docc/LanguageGuide/Macros.md
+++ b/TSPL.docc/LanguageGuide/Macros.md
@@ -53,7 +53,7 @@ func myFunction() {
 ```
 
 In the first line,
-`#function` calls the [`function`][] macro from the Swift standard library.
+`#function` calls the [`function()`][] macro from the Swift standard library.
 When you compile this code,
 Swift calls that macro's implementation,
 which replaces `#function` with the name of the current function.
@@ -63,7 +63,7 @@ In the second line,
 `#warning` calls the [`warning(_:)`][] macro from the Swift standard library
 to produce a custom compile-time warning.
 
-[`function`]: https://developer.apple.com/documentation/swift/function
+[`function()`]: https://developer.apple.com/documentation/swift/function()
 [`warning(_:)`]: https://developer.apple.com/documentation/swift/warning(_:)
 
 Freestanding macros can produce a value, like `#function` does,

--- a/TSPL.docc/ReferenceManual/Expressions.md
+++ b/TSPL.docc/ReferenceManual/Expressions.md
@@ -583,13 +583,13 @@ or a playground literal.
 > `#function`,
 > and `#line`.
 > These are now implemented as macros in the Swift standard library:
-> [`column`](https://developer.apple.com/documentation/swift/column()),
-> [`dsohandle`](https://developer.apple.com/documentation/swift/dsohandle()),
-> [`fileID`](https://developer.apple.com/documentation/swift/fileID()),
-> [`filePath`](https://developer.apple.com/documentation/swift/filePath()),
-> [`file`](https://developer.apple.com/documentation/swift/file()),
-> [`function`](https://developer.apple.com/documentation/swift/function()),
-> and [`line`](https://developer.apple.com/documentation/swift/line()).
+> [`column()`](https://developer.apple.com/documentation/swift/column()),
+> [`dsohandle()`](https://developer.apple.com/documentation/swift/dsohandle()),
+> [`fileID()`](https://developer.apple.com/documentation/swift/fileID()),
+> [`filePath()`](https://developer.apple.com/documentation/swift/filePath()),
+> [`file()`](https://developer.apple.com/documentation/swift/file()),
+> [`function()`](https://developer.apple.com/documentation/swift/function()),
+> and [`line()`](https://developer.apple.com/documentation/swift/line()).
 
 <!--
   - test: `pound-file-flavors`
@@ -1518,13 +1518,13 @@ A macro-expansion expression omits the parentheses
 if the macro doesn't take any arguments.
 
 A macro expression can't appear as the default value for a parameter,
-except for the [`file`][] and [`line`][] macros from the Swift standard library.
+except for the [`file()`][] and [`line()`][] macros from the Swift standard library.
 When used as the default value of a function or method parameter,
 These macros' value is determined
 when the default value expression is evaluated at the call site.
 
-[`file`]: http://developer.apple.com/documentation/swift/documentation/swift/file
-[`line`]: http://developer.apple.com/documentation/swift/documentation/swift/line
+[`file()`]: https://developer.apple.com/documentation/swift/file()
+[`line()`]: https://developer.apple.com/documentation/swift/line()
 
 > Grammar of a macro-expansion expression:
 >

--- a/bin/preflight
+++ b/bin/preflight
@@ -39,4 +39,19 @@ then
     exit_status=1
 fi
 
+echo "Checking links..."
+cmark --to xml TSPL.docc/*/*.md |
+xpath -q -n -e '//link/@destination' |
+sort -u | cut -f2 -d= | grep -v '^"doc:' | sed 's/^"//; s/"$//' |
+while read url
+do
+    if curl --silent --output /dev/null --fail --head $url
+    then
+        echo "     $url"
+    else
+        echo "BAD: $url"
+        exit_status=1
+    fi
+done
+
 exit $exit_status


### PR DESCRIPTION
Identified broken links by running the commands that I added to the `preflight` script.  Confirmed there aren't any broken links remaining.

Someone more familiar with XPath might be able to rewrite that bit to print only the attribute name, removing the `cut` and `sed` post-processing steps.  When I changed the query to `string(//link/@destination)`, which I would have expected to do that, I get only the first link's destination instead of all of them..