### PR TITLE
Add a back-reference for 'defer' as used outside error handling

### DIFF
--- a/TSPL.docc/LanguageGuide/ErrorHandling.md
+++ b/TSPL.docc/LanguageGuide/ErrorHandling.md
@@ -770,8 +770,10 @@ The above example uses a `defer` statement
 to ensure that the `open(_:)` function
 has a corresponding call to `close(_:)`.
 
-> Note: You can use a `defer` statement
-> even when no error handling code is involved.
+You can use a `defer` statement
+even when no error handling code is involved.
+For more information,
+see <doc:ControlFlow#Deferred-Actions>.
 
 <!--
 This source file is part of the Swift.org open source project


### PR DESCRIPTION
Because the discussion of `defer` is divided between the error-handling and non-error-handling use cases, it's helpful to have cross references that go in both directions.  The section in Control Flow already links here at the end.