### PR TITLE
Add info about macro entry point

### DIFF
--- a/TSPL.docc/LanguageGuide/Macros.md
+++ b/TSPL.docc/LanguageGuide/Macros.md
@@ -552,6 +552,19 @@ private func fourCharacterCode(for characters: String) -> UInt32? {
 enum CustomError: Error { case message(String) }
 ```
 
+If you're adding this macro to an existing Swift Package Manager project,
+add a type that acts as the entry point for the macro target
+and lists the macros that the target defines:
+
+```swift
+import SwiftCompilerPlugin
+
+@main
+struct MyProjectMacros: CompilerPlugin {
+    var providingMacros: [Macro.Type] = [FourCharacterCode.self]
+}
+```
+
 The `#fourCharacterCode` macro
 is a freestanding macro that produces an expression,
 so the `FourCharacterCode` type that implements it


### PR DESCRIPTION
When trying to add a macro to an existing project, I ran into some inscrutable errors without the macro entry point type. This type is added when you create a new macro project, but I didn't find any documentation about this requirement elsewhere.