### PR TITLE
Fix straggler Unicode em dashes to use ASCII spelling

### DIFF
--- a/TSPL.docc/LanguageGuide/Macros.md
+++ b/TSPL.docc/LanguageGuide/Macros.md
@@ -615,7 +615,7 @@ https://github.com/apple/swift-syntax/blob/main/Sources/SwiftSyntaxBuilder/Synta
     + Find a node's location in source
 
 - Macro expansion happens in their surrounding context.
-  A macro can affect that environment if it needs to —
+  A macro can affect that environment if it needs to ---
   and a macro that has bugs can interfere with that environment.
   (Give guidance on when you'd do this.  It should be rare.)
 

--- a/TSPL.docc/LanguageGuide/StringsAndCharacters.md
+++ b/TSPL.docc/LanguageGuide/StringsAndCharacters.md
@@ -947,8 +947,8 @@ print("the number of characters in \(word) is \(word.count)")
 -->
 
 > Note: Extended grapheme clusters can be composed of multiple Unicode scalars.
-> This means that different characters—
-> and different representations of the same character—
+> This means that different characters ---
+> and different representations of the same character ---
 > can require different amounts of memory to store.
 > Because of this, characters in Swift don't each take up
 > the same amount of memory within a string's representation.


### PR DESCRIPTION
The one in "Strings and Characters" must have been missed in a past clean-up.  The one in "Macros" in a comment was probably leftover from my outlining process.