### PR TITLE
Corrected variable type in 'Optional Binding' section of TheBasics.md.

### DIFF
--- a/TSPL.docc/LanguageGuide/TheBasics.md
+++ b/TSPL.docc/LanguageGuide/TheBasics.md
@@ -1394,7 +1394,7 @@ the `actualNumber` constant becomes available for use within
 the first branch of the `if` statement.
 It has already been initialized with the value contained within the optional,
 and has the corresponding non-optional type.
-In this case, the type of `possibleNumber` is `Int?`,
+In this case, the type of `Int(possibleNumber)` is `Int?`,
 so the type of `actualNumber` is `Int`.
 
 If you don't need to refer to the original, optional constant or variable


### PR DESCRIPTION
<!-- What's in this pull request? -->
In this section, I noticed a small inaccuracy in the documentation. It mentioned that the type of possibleNumber is Int?, but it should correctly state that the type of Int(possibleNumber) is Int?. I have made the necessary correction for accuracy.