### PR TITLE
Remove unreachable 'declarations' grammar production

### DIFF
--- a/TSPL.docc/ReferenceManual/Declarations.md
+++ b/TSPL.docc/ReferenceManual/Declarations.md
@@ -34,7 +34,6 @@ the term *declaration* covers both declarations and definitions.
 > *declaration* → *macro-declaration* \
 > *declaration* → *operator-declaration* \
 > *declaration* → *precedence-group-declaration* \
-> *declarations* → *declaration* *declarations*_?_
 
 ## Top-Level Code
 

--- a/TSPL.docc/ReferenceManual/Declarations.md
+++ b/TSPL.docc/ReferenceManual/Declarations.md
@@ -1807,21 +1807,6 @@ as described in <doc:Patterns#Enumeration-Case-Pattern>.
   and they behave differently.
 -->
 
-<!--
-  old-grammar
-  Grammar of an enumeration declaration
-
-  enum-declaration -> attribute-list-OPT ``enum`` enum-name generic-parameter-clause-OPT type-inheritance-clause-OPT enum-body
-  enum-name -> identifier
-  enum-body -> ``{`` declarations-OPT ``}``
-
-  enum-member-declaration -> attribute-list-OPT ``case`` enumerator-list
-  enumerator-list -> enumerator raw-value-assignment-OPT | enumerator raw-value-assignment-OPT ``,`` enumerator-list
-  enumerator -> enumerator-name tuple-type-OPT
-  enumerator-name -> identifier
-  raw-value-assignment -> ``=`` literal
--->
-
 ## Structure Declaration
 
 A *structure declaration* introduces a named structure type into your program.

--- a/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
+++ b/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
@@ -748,7 +748,6 @@ make the same change here also.
 > *declaration* → *subscript-declaration* \
 > *declaration* → *operator-declaration* \
 > *declaration* → *precedence-group-declaration* \
-> *declarations* → *declaration* *declarations*_?_
 
 > Grammar of a top-level declaration:
 >


### PR DESCRIPTION
This production used to be part of the old approach to enum grammar — see commit 0f8a59f46999c7815fbf932743368e6146e2cb0d.  Brian, can you think of any reasons we might want to keep the old approach around?  (You committed it, but most likely you and I wrote it together.)

Fixes: https://github.com/apple/swift-book/issues/187
