### PR TITLE
Fix the first letter of a referencing function name in Macros.

### DIFF
--- a/TSPL.docc/LanguageGuide/Macros.md
+++ b/TSPL.docc/LanguageGuide/Macros.md
@@ -588,7 +588,7 @@ In the example above,
 the first `guard` block extracts the string literal from the AST,
 assigning that AST element to `literalSegment`.
 The second `guard` block
-calls the private `FourCharacterCode(for:)` function.
+calls the private `fourCharacterCode(for:)` function.
 Both of these blocks throw an error if the macro is used incorrectly ---
 the error message becomes a compiler error
 at the malformed call site.


### PR DESCRIPTION
In Macro section, a function is referenced as `FourCharacterCode`, but its actual definition is `fourCharacterCode`.
Correcting the reference.
