### PR TITLE
The type `FourCC` is incorrectly used in the test code of Macros.

### DIFF
--- a/TSPL.docc/LanguageGuide/Macros.md
+++ b/TSPL.docc/LanguageGuide/Macros.md
@@ -704,7 +704,7 @@ let file = BasicMacroExpansionContext.KnownSourceFile(
 let context = BasicMacroExpansionContext(sourceFiles: [source: file])
 
 let transformedSF = source.expand(
-    macros:["fourCharacterCode": FourCC.self],
+    macros:["fourCharacterCode": FourCharacterCode.self],
     in: context
 )
 


### PR DESCRIPTION
Fixed a test code referencing a non-existent type `FourCC`. Changed it to `FourCharacterCode`.
