### PR TITLE
Consistently use "the Swift standard library"

### DIFF
--- a/Style.md
+++ b/Style.md
@@ -247,6 +247,17 @@ By design, actors specifically *avoid* having shared mutable state —
 their mutable state is private,
 and accessible only through the actor's (async) methods.
 
+## standard library
+
+Spell out in full as “the Swift standard library“ on the first use.
+If context already makes it clear
+and repeating the full name becomes wordy,
+you can shorted it to just “the standard library”
+in continued discussion.
+(We currently don‘t have any examples of doing that.)
+
+Not “stdlib“ or “the stdlib“.
+
 ## spawn, start
 
 Use “add” instead to refer to creating a new task,

--- a/Style.md
+++ b/Style.md
@@ -26,7 +26,7 @@ just surface level syntax for concepts they already know from other languages.
 commonly referred to as “the guide”,
 leads you through the Swift language in a pedagogically useful, linear order.
 It doesn't promise to show you every feature of
-the language or the standard library,
+the language or the Swift standard library,
 and it hand-waves over the exact details
 of some of the more complicated underlying bits.
 The guide leans on the reference to resolve the nitty-gritty detail questions
@@ -44,12 +44,12 @@ are already discussed in previous chapters.
 that the early chapters of the guide need
 — many topics from “The Basics” are covered again later in the guide in more detail.
 
-The guide includes types from the standard library for two reasons:
+The guide includes types from the Swift standard library for two reasons:
 they’re needed by an explanation of a language concept,
 or they’re so common that readers wouldn’t
 be able to build anything useful without them.
 The latter reason includes a judgement call.
-When new types are introduced in the standard library,
+When new types are introduced in the Swift standard library,
 we usually need to discuss whether & where to add them to TSPL.
 
 The guide can be broken down into three major chunks:
@@ -169,7 +169,7 @@ For example:
 > custom classes and structures don’t have an implementation of
 > the *equal to* operator (`==`) or *not equal to* operator (`!=`).
 > You usually implement the `==` operator,
-> and use the standard library’s default implementation of the `!=` operator
+> and use the Swift standard library’s default implementation of the `!=` operator
 > that negates the result of the `==` operator.
 > There are two ways to implement the `==` operator.
 

--- a/TSPL.docc/LanguageGuide/AdvancedOperators.md
+++ b/TSPL.docc/LanguageGuide/AdvancedOperators.md
@@ -905,14 +905,14 @@ By default, custom classes and structures don't have an implementation of
 the *equivalence operators*,
 known as the *equal to* operator (`==`) and *not equal to* operator (`!=`).
 You usually implement the `==` operator,
-and use the standard library's default implementation of the `!=` operator
+and use the Swift standard library's default implementation of the `!=` operator
 that negates the result of the `==` operator.
 There are two ways to implement the `==` operator:
 You can implement it yourself,
 or for many types, you can ask Swift to synthesize
 an implementation for you.
 In both cases,
-you add conformance to the standard library's `Equatable` protocol.
+you add conformance to the Swift standard library's `Equatable` protocol.
 
 You provide an implementation of the `==` operator
 in the same way as you implement other infix operators:
@@ -1488,7 +1488,7 @@ see <doc:Attributes#resultBuilder>.
    only if there's an implementation of the operator for that type.
    You use ``Self`` to refer to the type that will conform to the protocol,
    just like you do in other protocol requirements.
-   For example, the standard library defines the ``Equatable`` protocol
+   For example, the Swift standard library defines the ``Equatable`` protocol
    which requires the ``==`` operator:
 
    .. testcode:: protocolOperator

--- a/TSPL.docc/LanguageGuide/ClassesAndStructures.md
+++ b/TSPL.docc/LanguageGuide/ClassesAndStructures.md
@@ -306,7 +306,7 @@ This means that any structure and enumeration instances you create ---
 and any value types they have as properties ---
 are always copied when they're passed around in your code.
 
-> Note: Collections defined by the standard library
+> Note: Collections defined by the Swift standard library
 > like arrays, dictionaries, and strings
 > use an optimization to reduce the performance cost of copying.
 > Instead of making a copy immediately,
@@ -694,7 +694,7 @@ but isn't a direct pointer to an address in memory,
 and doesn't require you to write an asterisk (`*`)
 to indicate that you are creating a reference.
 Instead, these references are defined like any other constant or variable in Swift.
-The standard library provides pointer and buffer types
+The Swift standard library provides pointer and buffer types
 that you can use if you need to interact with pointers directly ---
 see [Manual Memory Management](https://developer.apple.com/documentation/swift/swift_standard_library/manual_memory_management).
 

--- a/TSPL.docc/LanguageGuide/Generics.md
+++ b/TSPL.docc/LanguageGuide/Generics.md
@@ -1733,7 +1733,7 @@ but requires one extension per requirement.
 You can include a generic `where` clause on an associated type.
 For example, suppose you want to make a version of `Container`
 that includes an iterator,
-like what the `Sequence` protocol uses in the standard library.
+like what the `Sequence` protocol uses in the Swift standard library.
 Here's how you write that:
 
 ```swift
@@ -1781,7 +1781,7 @@ The `makeIterator()` function provides access to a container's iterator.
 
    that accepts a ranged of indexes it its subscript
    and returns a subcontainer ---
-   similar to how ``Collection`` works in the standard library.
+   similar to how ``Collection`` works in the Swift standard library.
 
    .. testcode:: associatedTypes-subcontainer
 
@@ -1942,7 +1942,7 @@ This generic subscript is constrained as follows:
 
 - The generic parameter `Indices` in angle brackets
   has to be a type that conforms to the `Sequence` protocol
-  from the standard library.
+  from the Swift standard library.
 - The subscript takes a single parameter, `indices`,
   which is an instance of that `Indices` type.
 - The generic `where` clause requires

--- a/TSPL.docc/LanguageGuide/Protocols.md
+++ b/TSPL.docc/LanguageGuide/Protocols.md
@@ -2512,7 +2512,7 @@ you can define an extension to the `Collection` protocol
 that applies to any collection whose elements conform
 to the `Equatable` protocol.
 By constraining a collection's elements to the `Equatable` protocol,
-a part of the standard library,
+a part of the Swift standard library,
 you can use the `==` and `!=` operators to check for equality and inequality between two elements.
 
 ```swift

--- a/TSPL.docc/LanguageGuide/StringsAndCharacters.md
+++ b/TSPL.docc/LanguageGuide/StringsAndCharacters.md
@@ -1161,7 +1161,7 @@ welcome.removeSubrange(range)
 -->
 
 <!--
-  TODO: Find and Replace section, once the standard library supports finding substrings
+  TODO: Find and Replace section, once the Swift standard library supports finding substrings
 -->
 
 > Note: You can use the `insert(_:at:)`, `insert(contentsOf:at:)`,

--- a/TSPL.docc/ReferenceManual/Declarations.md
+++ b/TSPL.docc/ReferenceManual/Declarations.md
@@ -3486,7 +3486,7 @@ binds more tightly to its operands.
 > can't be used next to each other without grouping parentheses.
 
 Swift defines numerous precedence groups to go along
-with the operators provided by the standard library.
+with the operators provided by the Swift standard library.
 For example, the addition (`+`) and subtraction (`-`) operators
 belong to the `AdditionPrecedence` group,
 and the multiplication (`*`) and division (`/`) operators
@@ -3518,7 +3518,7 @@ The *assignment* of a precedence group specifies the precedence of an operator
 when used in an operation that includes optional chaining.
 When set to `true`, an operator in the corresponding precedence group
 uses the same grouping rules during optional chaining
-as the assignment operators from the standard library.
+as the assignment operators from the Swift standard library.
 Otherwise, when set to `false` or omitted,
 operators in the precedence group follows the same optional chaining rules
 as operators that don't perform assignment.

--- a/TSPL.docc/ReferenceManual/Statements.md
+++ b/TSPL.docc/ReferenceManual/Statements.md
@@ -422,7 +422,7 @@ they reserve the right to add new enumeration cases,
 and any code that interacts with that enumeration
 *must* be able to handle those future cases without being recompiled.
 Code that's compiled in library evolution mode,
-code in the standard library,
+code in the Swift standard library,
 Swift overlays for Apple frameworks,
 and C and Objective-C code can declare nonfrozen enumerations.
 For information about frozen and nonfrozen enumerations,
@@ -442,7 +442,7 @@ added a new case to the enumeration
 that doesn't have a corresponding switch case.
 
 The following example switches over all three existing cases of
-the standard library's [`Mirror.AncestorRepresentation`](https://developer.apple.com/documentation/swift/mirror/ancestorrepresentation)
+the Swift standard library's [`Mirror.AncestorRepresentation`](https://developer.apple.com/documentation/swift/mirror/ancestorrepresentation)
 enumeration.
 If you add additional cases in the future,
 the compiler generates a warning to indicate


### PR DESCRIPTION
In context, there's only one "standard library" for Swift, so it's unlikely someone would misread that to meaning anything other than "the Swift standard library".  But it's still worthwhile to be consistent.

Per discussion with Chuck in another edit, circa May 2023.

Fixes: rdar://110033045
