### PR TITLE
Match a variable name change in the tour

### DIFF
--- a/TSPL.docc/GuidedTour/GuidedTour.md
+++ b/TSPL.docc/GuidedTour/GuidedTour.md
@@ -1845,15 +1845,15 @@ Task {
 Use task groups to structure concurrent code.
 
 ```swift
-let userIDs = await withTaskGroup(of: Int.self) { taskGroup in
+let userIDs = await withTaskGroup(of: Int.self) { group in
     for server in ["primary", "secondary", "development"] {
-        taskGroup.addTask {
+        group.addTask {
             return await fetchUserID(from: server)
         }
     }
 
     var results: [Int] = []
-    for await result in taskGroup {
+    for await result in group {
         results.append(result)
     }
     return results


### PR DESCRIPTION
See commit b7cdc2ffa38ad1c5b9278e68a071cdccf8fa1946 which changed this throughout the Concurrency chapter.  The new content in the tour wasn't on the branch where we made that  fix.