### PR TITLE
Fix in-out grammar underproduction

### DIFF
--- a/TSPL.docc/ReferenceManual/Expressions.md
+++ b/TSPL.docc/ReferenceManual/Expressions.md
@@ -61,7 +61,7 @@ as described in <doc:Expressions#Implicit-Conversion-to-a-Pointer-Type>.
 
 > Grammar of an in-out expression:
 >
-> *in-out-expression* → **`&`** *identifier*
+> *in-out-expression* → **`&`** *primary-expression*
 
 ### Try Operator
 

--- a/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
+++ b/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
@@ -323,7 +323,7 @@ make the same change here also.
 
 > Grammar of an in-out expression:
 >
-> *in-out-expression* → **`&`** *identifier*
+> *in-out-expression* → **`&`** *primary-expression*
 
 > Grammar of a try expression:
 >


### PR DESCRIPTION
The old grammar didn't allow things like f(&x.y) which are legal in Swift.  The new grammar allows a bunch of stuff -- literals, closures, and conditional expressions -- but that's a better problem to have.

See also #194, where we're discussing a more specific fix.

Fixes: https://github.com/apple/swift-book/issues/193 (partially)