### PR TITLE
Replace conformance macros with extension macros

### DIFF
--- a/TSPL.docc/LanguageGuide/Macros.md
+++ b/TSPL.docc/LanguageGuide/Macros.md
@@ -218,7 +218,7 @@ including the attributes for its roles:
 
 ```swift
 @attached(member)
-@attached(conformance)
+@attached(extension)
 public macro OptionSet<RawType>() =
         #externalMacro(module: "SwiftMacros", type: "OptionSetMacro")
 ```
@@ -230,7 +230,7 @@ adds new members to the type you apply it to.
 The `@OptionSet` macro adds an `init(rawValue:)` initializer
 that's required by the `OptionSet` protocol,
 as well as some additional members.
-The second use, `@attached(conformance)`, tells you that `@OptionSet`
+The second use, `@attached(extension)`, tells you that `@OptionSet`
 adds one or more protocol conformances.
 The `@OptionSet` macro
 extends the type that you apply the macro to,
@@ -267,7 +267,7 @@ Here's the full declaration of `@OptionSet`:
 ```swift
 @attached(member, names: named(RawValue), named(rawValue),
         named(`init`), arbitrary)
-@attached(conformance)
+@attached(extension)
 public macro OptionSet<RawType>() =
         #externalMacro(module: "SwiftMacros", type: "OptionSetMacro")
 ```

--- a/TSPL.docc/ReferenceManual/Attributes.md
+++ b/TSPL.docc/ReferenceManual/Attributes.md
@@ -80,10 +80,12 @@ indicates the macros role:
   These macros add accessors to the stored property they're attached to,
   turning it into a computed property.
 
-- term Conformance macros:
-  Write `conformance` as the first argument to this attribute.
-  The type that implements the macro conforms to the `ConformanceMacro` protocol.
-  These macros add protocol conformance to the type they're attached to.
+- term Extension macros:
+  Write `extension` as the first argument to this attribute.
+  The type that implements the macro conforms to the `ExtensionMacro` protocol.
+  These macros can add protocol conformance,
+  a `where` clause,
+  and new declarations that are members of the type the macro is attached to.
 
 The peer, member, and accessor macro roles require a `named:` argument,
 listing the names of the symbols that the macro generates.


### PR DESCRIPTION
Because SE-0389 and SE-0402 both landed during the beta period for Swift 5.9, conformance macros were removed from the FCS version — so we don't discuss them in the documentation.  I expect to mention this in a revision history entry like:

> Added information about extension macros in (cross reference).  This content replaces discussion of conformance macros, which have been removed from the language.

Fixes: rdar://116429287
