### PR TITLE
Intro update

### DIFF
--- a/TSPL.docc/GuidedTour/AboutSwift.md
+++ b/TSPL.docc/GuidedTour/AboutSwift.md
@@ -3,22 +3,19 @@
 Understand the high-level goals of the language.
 
 Swift is a fantastic way to write software,
-whether it’s for phones, desktops, servers,
+whether it’s for phones, tablets, desktops, servers,
 or anything else that runs code.
-It's a safe, fast, and interactive programming language
+It's a safe and fast programming language
 that combines the best in modern language thinking
-with wisdom from the wider Apple engineering culture
-and the diverse contributions from its open-source community.
-The compiler is optimized for performance
-and the language is optimized for development,
-without compromising on either.
+with wisdom from Apple engineers
+and a diverse open source community.
 
 Swift is friendly to new programmers.
 It's an industrial-quality programming language
 that's as expressive and enjoyable as a scripting language.
-Writing Swift code in a playground
-lets you experiment with code and see the results immediately,
-without the overhead of building and running an app.
+The compiler is optimized for performance
+and the language is optimized for development,
+without compromising on either.
 
 Swift defines away large classes of common programming errors
 by adopting modern programming patterns:

--- a/TSPL.docc/GuidedTour/AboutSwift.md
+++ b/TSPL.docc/GuidedTour/AboutSwift.md
@@ -2,13 +2,12 @@
 
 Understand the high-level goals of the language.
 
-Swift is a fantastic way to write software,
-whether it’s for phones, tablets, desktops, servers,
+Swift is a fantastic way to write software
+for phones, tablets, desktops, servers,
 or anything else that runs code.
 It's a safe and fast programming language
 that combines the best in modern language thinking
-with wisdom from Apple engineers
-and a diverse open source community.
+with wisdom from a diverse open source community.
 
 Swift is friendly to new programmers.
 It's an industrial-quality programming language
@@ -40,9 +39,8 @@ allowing complex ideas to be expressed in a clear and concise manner.
 As a result, code is not just easier to write,
 but easier to read and maintain as well.
 
-Swift has been years in the making,
-and it continues to evolve with new features and capabilities.
-Our goals for Swift are ambitious.
+Swift continues to evolve with thoughtful new features and powerful capabilities.
+The goals for Swift are ambitious.
 We can’t wait to see what you create with it.
 
 <!--

--- a/TSPL.docc/GuidedTour/GuidedTour.md
+++ b/TSPL.docc/GuidedTour/GuidedTour.md
@@ -25,8 +25,7 @@ print("Hello, world!")
   ```
 -->
 
-If you have written code in C or Objective-C,
-this syntax looks familiar to you ---
+This syntax should look familiar if you know another language---
 in Swift, this line of code is a complete program.
 You don't need to import a separate library for functionality like
 input/output or string handling.

--- a/TSPL.docc/LanguageGuide/TheBasics.md
+++ b/TSPL.docc/LanguageGuide/TheBasics.md
@@ -2,7 +2,7 @@
 
 Work with common kinds of data and write basic syntax.
 
-Swift is a programming language designed for developing mobile and desktop apps, as well as server and system software.
+Swift is a programming language designed for developing many types of software, from mobile and desktop apps, to server, system, and embedded software.
 Many parts of Swift will be familiar if you have experience developing in other popular languages.
 
 Swift provides its own versions of fundamental types,

--- a/TSPL.docc/LanguageGuide/TheBasics.md
+++ b/TSPL.docc/LanguageGuide/TheBasics.md
@@ -2,25 +2,23 @@
 
 Work with common kinds of data and write basic syntax.
 
-Swift is a programming language for iOS, macOS, watchOS, and tvOS app development.
-If you have experience developing in C or Objective-C,
-many parts of Swift will be familiar to you.
+Swift is a programming language designed for developing mobile and desktop apps, as well as server and system software.
+Many parts of Swift will be familiar if you have experience developing in other popular languages.
 
-Swift provides its own versions of all fundamental C and Objective-C types,
+Swift provides its own versions of fundamental types,
 including `Int` for integers, `Double` and `Float` for floating-point values,
 `Bool` for Boolean values, and `String` for textual data.
 Swift also provides powerful versions of the three primary collection types,
 `Array`, `Set`, and `Dictionary`,
 as described in <doc:CollectionTypes>.
 
-Like C, Swift uses variables to store and refer to values by an identifying name.
+Swift uses variables to store and refer to values by an identifying name.
 Swift also makes extensive use of variables whose values can't be changed.
-These are known as constants, and are much more powerful than constants in C.
-Constants are used throughout Swift to make code safer and clearer in intent
+These are known as constants, and are used throughout Swift to make code safer and clearer in intent
 when you work with values that don't need to change.
 
 In addition to familiar types,
-Swift introduces advanced types not found in Objective-C, such as tuples.
+Swift introduces advanced types such as tuples.
 Tuples enable you to create and pass around groupings of values.
 You can use a tuple to return multiple values from a function as a single compound value.
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
This paragraph lightly updates parts of the TSPL that introduce or frame Swift to remove comparisons to C and Objective-C, as those comparisons are not as relevant to newcomers in 2023 as they were in 2014.

<!-- If this pull request fixes a bug tracked in GitHub issues, provide the link. -->
N/A