### PR TITLE
Fix typo in description of convertFarenheitToCelsius()

### DIFF
--- a/TSPL.docc/LanguageGuide/Concurrency.md
+++ b/TSPL.docc/LanguageGuide/Concurrency.md
@@ -1113,7 +1113,7 @@ while unit conversion is in progress.
 In addition to writing code in an actor
 that protects temporary invalid state by omitting potential suspension points,
 you can move that code into a synchronous method.
-The `convertFarenheitToCelsius()` method above is method,
+The `convertFarenheitToCelsius()` method above is a synchronous method,
 so it's guaranteed to *never* contain potential suspension points.
 This function encapsulates the code
 that temporarily makes the data model inconsistent,


### PR DESCRIPTION
This typo came from ac5ce6a7b5337521fa4b3715ffb335511cd3103e.