### PR TITLE
Fix grammar error in The Basics

### DIFF
--- a/TSPL.docc/LanguageGuide/TheBasics.md
+++ b/TSPL.docc/LanguageGuide/TheBasics.md
@@ -1610,7 +1610,7 @@ see <doc:BasicOperators#Nil-Coalescing-Operator>.
 ### Force Unwrapping
 
 When `nil` represents an unrecoverable failure,
-such a programmer error or corrupted state,
+such as a programmer error or corrupted state,
 you can access the underlying value
 by adding an exclamation mark (`!`) to the end of the optional's name.
 This is known as *force unwrapping* the optional's value.


### PR DESCRIPTION
<!-- What's in this pull request? -->
In the sentence contained between lines 1612 and 1615 of "The Basics", a grammatical error before the word "programmer" can be found:

> When nil represents an unrecoverable failure, such **_a_** programmer error or corrupted state, you can access the underlying value by adding an exclamation mark (!) to the end of the optional’s name.

By adding the word "as" before "a", the sentence becomes grammatically correct:

> When nil represents an unrecoverable failure, such **_as a_** programmer error or corrupted state, you can access the underlying value by adding an exclamation mark (!) to the end of the optional’s name.