### PR TITLE
Update OS and arch grammar according the open source Swift repo

### DIFF
--- a/TSPL.docc/ReferenceManual/Statements.md
+++ b/TSPL.docc/ReferenceManual/Statements.md
@@ -961,8 +961,8 @@ conditions listed in the table below.
 
 | Platform condition | Valid arguments |
 | ------------------ | --------------- |
-| `os()` | `macOS`, `iOS`, `watchOS`, `tvOS`, `visionOS`, `Linux`, `Windows` |
-| `arch()` | `i386`, `x86_64`, `arm`, `arm64` |
+| `os()` | `OSX`, `macOS`, `tvOS`, `watchOS`, `iOS`, `Linux`, `FreeBSD`, `OpenBSD`, `Windows`, `Android`, `PS4`, `Cygwin`, `Haiku`, `WASI` |
+| `arch()` | `arm`, `arm64`, `arm64_32`, `i386`, `x86_64`, `powerpc`, `powerpc64`, `powerpc64le`, `s390x`, `wasm32`, `riscv64` |
 | `swift()` | `>=` or `<` followed by a version number |
 | `compiler()` | `>=` or `<` followed by a version number |
 | `canImport()` | A module name |
@@ -1210,8 +1210,8 @@ see <doc:Expressions#Explicit-Member-Expression>.
 > *platform-condition* → **`canImport`** **`(`** *import-path* **`)`** \
 > *platform-condition* → **`targetEnvironment`** **`(`** *environment* **`)`**
 >
-> *operating-system* → **`macOS`** | **`iOS`** | **`watchOS`** | **`tvOS`** | **`Linux`** | **`Windows`** \
-> *architecture* → **`i386`** | **`x86_64`** | **`arm`** | **`arm64`** \
+> *operating-system* → **`OSX`** | **`macOS`** | **`tvOS`** | **`watchOS`** | **`iOS`** | **`Linux`** | **`FreeBSD`** | **`OpenBSD`** | **`Windows`** | **`Android`** | **`PS4`** | **`Cygwin`** | **`Haiku`** | **`WASI`** \
+> *architecture* → **`arm`** | **`arm64`** | **`arm64_32`** | **`i386`** | **`x86_64`** | **`powerpc`** | **`powerpc64`** | **`powerpc64le`** | **`s390x`** | **`wasm32`** | **`riscv64`** \
 > *swift-version* → *decimal-digits* *swift-version-continuation*_?_ \
 > *swift-version-continuation* → **`.`** *decimal-digits* *swift-version-continuation*_?_ \
 > *environment* → **`simulator`** | **`macCatalyst`**

--- a/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
+++ b/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
@@ -697,8 +697,8 @@ make the same change here also.
 > *platform-condition* → **`canImport`** **`(`** *import-path* **`)`** \
 > *platform-condition* → **`targetEnvironment`** **`(`** *environment* **`)`**
 >
-> *operating-system* → **`macOS`** | **`iOS`** | **`watchOS`** | **`tvOS`** | **`Linux`** | **`Windows`** \
-> *architecture* → **`i386`** | **`x86_64`** | **`arm`** | **`arm64`** \
+> *operating-system* → **`OSX`** | **`macOS`** | **`tvOS`** | **`watchOS`** | **`iOS`** | **`Linux`** | **`FreeBSD`** | **`OpenBSD`** | **`Windows`** | **`Android`** | **`PS4`** | **`Cygwin`** | **`Haiku`** | **`WASI`** \
+> *architecture* → **`arm`** | **`arm64`** | **`arm64_32`** | **`i386`** | **`x86_64`** | **`powerpc`** | **`powerpc64`** | **`powerpc64le`** | **`s390x`** | **`wasm32`** | **`riscv64`** \
 > *swift-version* → *decimal-digits* *swift-version-continuation*_?_ \
 > *swift-version-continuation* → **`.`** *decimal-digits* *swift-version-continuation*_?_ \
 > *environment* → **`simulator`** | **`macCatalyst`**


### PR DESCRIPTION
Context:

I was adding some `#if os(xx)` to detect the pointer size on my package, and they failed to build on watchOS platform. I realized I have missed some arch for it. (eg. `armv7k` and `arm64_32`)

I checked the grammar page on TSPL. They are both not supported according to TSPL grammar here. And actually `arm64_32` is supported and `armv7k` is not which will hit `os(arm)` here.

This PR updates the corresponding grammar rule according to https://github.com/apple/swift

I did not find the exact grammar parsing logic so there may be some missing item. But I have checked what I list here are all supported on Swift 5.9

visionOS is not added on upstream open source Swift yet. And they are only supported on Xcode's Swift toolchain. (eg. Xcode 14.0)

Building the following code on Linux with the latest Swift release(Swift 5.9.2) will give us a warning here.
```
#if os(visionOS)
...
#endif
```

```
DemoKit.swift:12:8: note: did you mean 'iOS'?
#if os(visionOS)
       ^~~~~~~~
       iOS
```

For Arch, I use the following source
- https://github.com/apple/swift/blob/260cec969490db027fa2392c4061c2fe1eba22f6/lib/Basic/LangOptions.cpp#L69-L81
- https://github.com/apple/swift/blob/260cec969490db027fa2392c4061c2fe1eba22f6/stdlib/public/core/AtomicInt.swift.gyb#L85-L91

For OS, I use the following source
- https://github.com/apple/swift/blob/260cec969490db027fa2392c4061c2fe1eba22f6/lib/Basic/LangOptions.cpp#L52-L67
- https://github.com/apple/swift/blob/260cec969490db027fa2392c4061c2fe1eba22f6/stdlib/public/Platform/Platform.swift#L482
