### PR TITLE
GuidedTour: Fixed while and repeat-while experiment description

### DIFF
--- a/TSPL.docc/GuidedTour/GuidedTour.md
+++ b/TSPL.docc/GuidedTour/GuidedTour.md
@@ -671,7 +671,7 @@ print(m)
 > Experiment:
 > Change the condition from `m < 100` to `m < 0`
 > to see how `while` and `repeat`-`while` behave differently
-> when the loop condition is already true.
+> when the loop condition is already false.
 
 You can keep an index in a loop
 by using `..<` to make a range of indexes.


### PR DESCRIPTION
<!-- What's in this pull request? -->
When changing the condition to `m <  0`, it is false from the start, not true from the start.