### PR TITLE
Remove Info.plist keys that are never used by DocC

### DIFF
--- a/TSPL.docc/Info.plist
+++ b/TSPL.docc/Info.plist
@@ -2,26 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleName</key>
-	<string>TSPL</string>
 	<key>CFBundleDisplayName</key>
 	<string>The Swift Programming Language</string>
 	<key>CFBundleIdentifier</key>
 	<string>org.swift.tspl</string>
 	<key>CDDefaultCodeListingLanguage</key>
 	<string>swift</string>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
-	<key>CFBundleIconFile</key>
-	<string>DocumentationIcon</string>
-	<key>CFBundleIconName</key>
-	<string>DocumentationIcon</string>
-	<key>CFBundlePackageType</key>
-	<string>DOCS</string>
-	<key>CFBundleShortVersionString</key>
-	<string>0.1.0</string>
-	<key>CFBundleVersion</key>
-	<string>0.1.0</string>
 	<key>CDDefaultModuleKind</key>
 	<string></string>
 </dict>


### PR DESCRIPTION
This removes a handful of property list keys from the Info.plist file in the documentation catalog that are not used by DocC.

These property list keys have no effect on the documentation build and only distract from the keys that _are_ used by DocC.  