### PR TITLE
Fix code in Result example

### DIFF
--- a/TSPL.docc/LanguageGuide/Concurrency.md
+++ b/TSPL.docc/LanguageGuide/Concurrency.md
@@ -334,9 +334,9 @@ from nonthrowing code.
 For example:
 
 ```swift
-func getRainyWeekendPhotos() async -> Result<[String]> {
+func availableRainyWeekendPhotos() -> Result<[String], Error> {
     return Result {
-        try await listPhotos(inGallery: "A Rainy Weekend")
+        try listDownloadedPhotos(inGallery: "A Rainy Weekend")
     }
 }
 ```


### PR DESCRIPTION
I'm reading through the concurrency section, and I stumbled across a code snippet that does not compile. It has two errors:

- It is missing a generic parameter
- It relies on an async override for Result that may one day exist, but does not today

Further I think it is slightly confusing to mix the use of await and throws, when the section is fairly clear about making the distinction between the two.

My solution fixes the syntax, and slightly changes the method being used to remove even a suggestion of concurrency usage.
