### PR TITLE
Remove disused grammar production

### DIFF
--- a/TSPL.docc/ReferenceManual/Expressions.md
+++ b/TSPL.docc/ReferenceManual/Expressions.md
@@ -21,7 +21,6 @@ in the sections below.
 > Grammar of an expression:
 >
 > *expression* → *try-operator*_?_ *await-operator*_?_ *prefix-expression* *infix-expressions*_?_ \
-> *expression-list* → *expression* | *expression* **`,`** *expression-list*
 
 ## Prefix Expressions
 

--- a/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
+++ b/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
@@ -314,7 +314,6 @@ make the same change here also.
 > Grammar of an expression:
 >
 > *expression* → *try-operator*_?_ *await-operator*_?_ *prefix-expression* *infix-expressions*_?_ \
-> *expression-list* → *expression* | *expression* **`,`** *expression-list*
 
 > Grammar of a prefix expression:
 >


### PR DESCRIPTION
The grammar around subscripts and C-style for loops used to use this production, but the former now uses function-argument-list (1) and the latter was removed from the Swift language (2).
    
(1) 27491635d9cda7e71208643f16b758302a5016c7
(2) aaff06cb0c83481adc9e6cd0be6fef15542215d7

Fixes: https://github.com/apple/swift-book/issues/274