### PR TITLE
Fix prose to match code listing for opaque type

### DIFF
--- a/TSPL.docc/LanguageGuide/OpaqueTypes.md
+++ b/TSPL.docc/LanguageGuide/OpaqueTypes.md
@@ -121,8 +121,8 @@ print(flippedTriangle.draw())
 
 This approach to defining a `JoinedShape<T: Shape, U: Shape>` structure
 that joins two shapes together vertically, like the code below shows,
-results in types like `JoinedShape<FlippedShape<Triangle>, Triangle>`
-from joining a flipped triangle with another triangle.
+results in types like `JoinedShape<Triangle, FlippedShape<Triangle>>`
+from joining a triangle with a flipped triangle.
 
 ```swift
 struct JoinedShape<T: Shape, U: Shape>: Shape {


### PR DESCRIPTION
<!-- What's in this pull request? -->
The third  code block in this [section of the docs](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/opaquetypes#The-Problem-That-Opaque-Types-Solve) has the following declaration.

`let joinedTriangles = JoinedShape(top: smallTriangle, bottom: flippedTriangle)`

In the paragraph above the declaration, the docs mentions the following.

>  results in types like `JoinedShape<FlippedShape<Triangle>, Triangle>`

However, the actual dynamic type is `JoinedShape<Triangle, FlippedShape<Triangle>>`. This PR suggests rephrasing the sentence to match the actual dynamic type.