### PR TITLE
Updated StringAndCharacters.md

### DIFF
--- a/TSPL.docc/LanguageGuide/StringsAndCharacters.md
+++ b/TSPL.docc/LanguageGuide/StringsAndCharacters.md
@@ -691,7 +691,7 @@ a pair of parentheses, prefixed by a backslash (`\`):
 
 ```swift
 let multiplier = 3
-let message = "\(multiplier) times 2.5 is \(Double(multiplier) * 2.5)"
+let message = "\(interpolated-text-list(multiplier)) times 2.5 is \(interpolated-text-list(Double(multiplier) * 2.5))"
 // message is "3 times 2.5 is 7.5"
 ```
 


### PR DESCRIPTION
I Updated the grammar rule to allow for a tuple expression after the backslash, as shown in the following line:

interpolated-text-item → \( interpolated-text-list ) | quoted-text-item

<!-- What's in this pull request? -->
The grammar rule for 'interpolated-text-item' specifies a single expression inside parentheses:

```
interpolated-text-item → \( expression ) | quoted-text-item
```

However, I've found that Swift actually accepts the equivalent of a tuple expression after the backslash, something like:

```
interpolated-text-item → \( interpolated-text-list ) | quoted-text-item
interpolated-text-list → interpolated-text-element | interpolated-text-element, interpolated-text-list
interpolated-text-element → expression | identifier : expression
```

I've corrected the grammar rule to allow for a tuple expression after the backslash, as shown in the following line:

```
interpolated-text-item → \( interpolated-text-list ) | quoted-text-item
```

<!-- If this pull request fixes a bug tracked in GitHub issues, provide the link. -->
Fixes: https://github.com/apple/swift-book/issues/282
