### PR TITLE
Add missing parenthesis in reference for macro names

### DIFF
--- a/TSPL.docc/ReferenceManual/Attributes.md
+++ b/TSPL.docc/ReferenceManual/Attributes.md
@@ -119,7 +119,7 @@ The value for that argument is a list of one or more of the following:
   where *prefix* is prepended to the symbol name,
   for a name that starts with a fixed string.
 
-- `suffixed(<#suffix#>`
+- `suffixed(<#suffix#>)`
   where *suffix* is appended to the symbol name,
   for a name that ends with a fixed string.
 


### PR DESCRIPTION
Adds a missing closing bracket to Attributes in the reference manual