### PR TITLE
Standardize ordering of pieces in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,8 @@
+<!-- If this pull request incorporates language changes from a Swift Evolution proposal, add the SE number in square brackets at the end of the PR title. -->
+
 <!-- What's in this pull request? -->
 Replace this paragraph with your rationale and a brief summary of what changed.
 
-<!-- If this pull request fixes a bug tracked in GitHub issues, provide the link. -->
+<!-- Link to the issue that this pull request fixes, if applicable. -->
 Fixes: https://github.com/apple/swift-book/issues/####
+Fixes: rdar://####


### PR DESCRIPTION
Most of the pull requests so far have used this ordering, and I occasionally have to look back at Git history to follow precedent, so it's worth just writing this down explicitly.