### PR TITLE
Align comments vertically

### DIFF
--- a/TSPL.docc/LanguageGuide/AccessControl.md
+++ b/TSPL.docc/LanguageGuide/AccessControl.md
@@ -231,25 +231,25 @@ the default access level of the type's members will be internal.
 > and avoids presenting the internal workings of a type as public API by mistake.
 
 ```swift
-public class SomePublicClass {                  // explicitly public class
+public class SomePublicClass {                   // explicitly public class
     public var somePublicProperty = 0            // explicitly public class member
     var someInternalProperty = 0                 // implicitly internal class member
     fileprivate func someFilePrivateMethod() {}  // explicitly file-private class member
     private func somePrivateMethod() {}          // explicitly private class member
 }
 
-class SomeInternalClass {                       // implicitly internal class
+class SomeInternalClass {                        // implicitly internal class
     var someInternalProperty = 0                 // implicitly internal class member
     fileprivate func someFilePrivateMethod() {}  // explicitly file-private class member
     private func somePrivateMethod() {}          // explicitly private class member
 }
 
-fileprivate class SomeFilePrivateClass {        // explicitly file-private class
+fileprivate class SomeFilePrivateClass {         // explicitly file-private class
     func someFilePrivateMethod() {}              // implicitly file-private class member
     private func somePrivateMethod() {}          // explicitly private class member
 }
 
-private class SomePrivateClass {                // explicitly private class
+private class SomePrivateClass {                 // explicitly private class
     func somePrivateMethod() {}                  // implicitly private class member
 }
 ```

--- a/TSPL.docc/ReferenceManual/Attributes.md
+++ b/TSPL.docc/ReferenceManual/Attributes.md
@@ -1762,8 +1762,8 @@ into code that calls the static methods of the result builder type:
       func draw() -> String { return content }
   }
   struct Line<D: Drawable>: Drawable {
-        var elements: [D]
-        func draw() -> String {
+      var elements: [D]
+      func draw() -> String {
           return elements.map { $0.draw() }.joined(separator: "")
       }
   }


### PR DESCRIPTION
This got incorrectly changed as part of normalizing indentation in code listings to 4 spaces.

Reviewed the changes in 28a4aafbf9dd153fe96473e9b08c885a32cd7fc1 and I don't see any remaining indentation problems that weren't already fixed by a130dfcd8ad50390dc2ee510059cfb0a0abf78eb or fixed by this PR.