### PR TITLE
Add missing "Protocol" to the title

### DIFF
--- a/TSPL.docc/LanguageGuide/OpaqueTypes.md
+++ b/TSPL.docc/LanguageGuide/OpaqueTypes.md
@@ -1,4 +1,4 @@
-# Opaque and Boxed Types
+# Opaque and Boxed Protocol Types
 
 Hide implementation details about a value's type.
 


### PR DESCRIPTION
In the content, "boxed protocol types" is used, but it's not used in the title.
I'm not sure if it's intended or not, but it looks missing "Protocol".

<!-- If this pull request incorporates language changes from a Swift Evolution proposal, add the SE number in square brackets at the end of the PR title. -->

<!-- What's in this pull request? -->