### PR TITLE
Remove redundant sentence

### DIFF
--- a/TSPL.docc/ReferenceManual/Declarations.md
+++ b/TSPL.docc/ReferenceManual/Declarations.md
@@ -3905,13 +3905,13 @@ Access control is discussed in detail in <doc:AccessControl>.
   Apply this modifier to a declaration to indicate the declaration can be accessed
   only by code within the declaration's immediate enclosing scope.
 
-For the purpose of access control,
-extensions to the same type that are in the same file
-share an access-control scope.
-Private members declared in the type's declaration
-can be accessed from extensions,
-and private members declared in one extension
-can be accessed from other extensions and from the type's declaration.
+Extensions to the same type and the type itself share the
+same access-control scope as long as they are in the same file.
+That is, they can access each other's private members.
+The scope is bound to a single file, however.
+Extensions to the same type in another file also share a common, but different, scope.
+They can access each other but they cannot access the private or
+file-private members defined in extensions or the type residing in another file.
 
 Each access-level modifier above optionally accepts a single argument,
 which consists of the `set` keyword enclosed in parentheses (for example, `private(set)`).

--- a/TSPL.docc/ReferenceManual/Declarations.md
+++ b/TSPL.docc/ReferenceManual/Declarations.md
@@ -3908,8 +3908,6 @@ Access control is discussed in detail in <doc:AccessControl>.
 For the purpose of access control,
 extensions to the same type that are in the same file
 share an access-control scope.
-If the type they extend is also in the same file,
-they share the type's access-control scope.
 Private members declared in the type's declaration
 can be accessed from extensions,
 and private members declared in one extension


### PR DESCRIPTION
Seems like the message of the previous sentence is pretty much the same.