### PR TITLE
Add 'borrowing' and 'consuming' to list of keywords

### DIFF
--- a/TSPL.docc/ReferenceManual/LexicalStructure.md
+++ b/TSPL.docc/ReferenceManual/LexicalStructure.md
@@ -247,7 +247,9 @@ so they must be escaped with backticks in that context.
 
 - Keywords used in declarations:
   `associatedtype`,
+  `borrowing`,
   `class`,
+  `consuming`,
   `deinit`,
   `enum`,
   `extension`,


### PR DESCRIPTION
Adds consuming and borrowing to the list of keywords
Fixes: [#300](https://github.com/apple/swift-book/issues/300)
