### PR TITLE
Add visionOS operating-system

### DIFF
--- a/TSPL.docc/GuidedTour/Compatibility.md
+++ b/TSPL.docc/GuidedTour/Compatibility.md
@@ -33,7 +33,7 @@ Concurrency requires the Swift 5 language mode
 and a version of the Swift standard library
 that provides the corresponding concurrency types.
 On Apple platforms, set a deployment target
-of at least iOS 13, macOS 10.15, tvOS 13, or watchOS 6.
+of at least iOS 13, macOS 10.15, tvOS 13, watchOS 6, or visionOS 1.
 
 A target written in Swift 6 can depend on
 a target that's written in Swift 5, Swift 4.2 or Swift 4,

--- a/TSPL.docc/LanguageGuide/ControlFlow.md
+++ b/TSPL.docc/LanguageGuide/ControlFlow.md
@@ -2159,7 +2159,7 @@ the body of the `if` executes on the minimum deployment target specified by your
 
 In its general form,
 the availability condition takes a list of platform names and versions.
-You use platform names such as `iOS`, `macOS`, `watchOS`, and `tvOS` ---
+You use platform names such as `iOS`, `macOS`, `watchOS`, `tvOS`, and `visionOS` ---
 for the full list, see <doc:Attributes#Declaration-Attributes>.
 In addition to specifying major version numbers like iOS 8 or macOS 10.10,
 you can specify minor versions numbers like iOS 11.2.6 and macOS 10.13.3.

--- a/TSPL.docc/ReferenceManual/Statements.md
+++ b/TSPL.docc/ReferenceManual/Statements.md
@@ -1253,7 +1253,7 @@ see <doc:Expressions#Explicit-Member-Expression>.
 > *platform-condition* → **`canImport`** **`(`** *import-path* **`)`** \
 > *platform-condition* → **`targetEnvironment`** **`(`** *environment* **`)`**
 >
-> *operating-system* → **`macOS`** | **`iOS`** | **`watchOS`** | **`tvOS`** | **`Linux`** | **`Windows`** \
+> *operating-system* → **`macOS`** | **`iOS`** | **`watchOS`** | **`tvOS`** | **`visionOS`** | **`Linux`** | **`Windows`** \
 > *architecture* → **`i386`** | **`x86_64`** | **`arm`** | **`arm64`** \
 > *swift-version* → *decimal-digits* *swift-version-continuation*_?_ \
 > *swift-version-continuation* → **`.`** *decimal-digits* *swift-version-continuation*_?_ \
@@ -1341,7 +1341,7 @@ The compiler uses the information from the availability condition
 when it verifies that the APIs in that block of code are available.
 
 The availability condition takes a comma-separated list of platform names and versions.
-Use `iOS`, `macOS`, `watchOS`, and `tvOS` for the platform names,
+Use `iOS`, `macOS`, `watchOS`, `tvOS` and `visionOS` for the platform names,
 and include the corresponding version numbers.
 The `*` argument is required and specifies that, on any other platform,
 the body of the code block guarded by the availability condition
@@ -1398,7 +1398,8 @@ It has the same meaning as the `*` argument in an availability condition.
   >>               macOS 1, macOSApplicationExtension 1,
   >>               macCatalyst 1, macCatalystApplicationExtension 1,
   >>               watchOS 1, watchOSApplicationExtension 1,
-  >>               tvOS 1, tvOSApplicationExtension 1, *) {
+  >>               tvOS 1, tvOSApplicationExtension 1,
+  >>               visionOS 1, visionOSApplicationExtension 1, *) {
   >>     print("a")
   >> } else {
   >>     print("b")

--- a/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
+++ b/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
@@ -698,7 +698,7 @@ make the same change here also.
 > *platform-condition* → **`canImport`** **`(`** *import-path* **`)`** \
 > *platform-condition* → **`targetEnvironment`** **`(`** *environment* **`)`**
 >
-> *operating-system* → **`macOS`** | **`iOS`** | **`watchOS`** | **`tvOS`** | **`Linux`** | **`Windows`** \
+> *operating-system* → **`macOS`** | **`iOS`** | **`watchOS`** | **`tvOS`** | **`visionOS`** | **`Linux`** | **`Windows`** \
 > *architecture* → **`i386`** | **`x86_64`** | **`arm`** | **`arm64`** \
 > *swift-version* → *decimal-digits* *swift-version-continuation*_?_ \
 > *swift-version-continuation* → **`.`** *decimal-digits* *swift-version-continuation*_?_ \


### PR DESCRIPTION
Add missing visionOS operating-system.

It's defined here:
https://github.com/apple/swift/blob/main/include/swift/AST/PlatformKinds.def#L28

rdar://129595552

---

Also, not addressed here, but it looks like there is an inconsistency between the book and the language regarding:
- swift-book/TSPL.docc/ReferenceManual/Statements.md line 1256 says `Linux`
- swift-book/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md line 701 says `Linux`
- swift/include/swift/AST/PlatformKinds.def line 37 says `OpenBSD`

It could be worth investigating the disparity.