### PR TITLE
Reword extensions in access control

### DIFF
--- a/TSPL.docc/ReferenceManual/Declarations.md
+++ b/TSPL.docc/ReferenceManual/Declarations.md
@@ -3940,14 +3940,21 @@ Access control is discussed in detail in <doc:AccessControl>.
   only by code within the declaration's immediate enclosing scope.
 
 For the purpose of access control,
-extensions to the same type that are in the same file
-share an access-control scope.
-If the type they extend is also in the same file,
-they share the type's access-control scope.
-Private members declared in the type's declaration
-can be accessed from extensions,
-and private members declared in one extension
-can be accessed from other extensions and from the type's declaration.
+extensions behave as follows:
+
+- If there are multiple extensions in the same file,
+  and those extensions all extend the same type,
+  then all of those extensions have the same access-control scope.
+  The extensions and the type they extend can be in different files.
+
+- If there are extensions in the same file as the type they extend,
+  the extensions have the same access-control scope as the type they extend.
+
+- Private members declared in a type's declaration
+  can be accessed from extensions to that type.
+  Private members declared in one extension
+  can be accessed from other extensions
+  and from the extended type's declaration.
 
 Each access-level modifier above optionally accepts a single argument,
 which consists of the `set` keyword enclosed in parentheses ---


### PR DESCRIPTION
Breaking this up into bullets and rewording it should make it easier to read.