### PR TITLE
Fix typo in macro name

### DIFF
--- a/TSPL.docc/LanguageGuide/Macros.md
+++ b/TSPL.docc/LanguageGuide/Macros.md
@@ -274,7 +274,7 @@ public macro OptionSet<RawType>() =
 ```
 
 In the declaration above,
-the `@attached(member)` macro includes arguments after the `named:` label
+the `@attached(member)` macro includes arguments after the `names:` label
 for each of the symbols that the `@OptionSet` macro generates.
 The macro adds declarations for symbols named
 `RawValue`, `rawValue`, and `init` ---


### PR DESCRIPTION
<!-- What's in this pull request? -->


Code
```swift
@attached(member, names: named(RawValue), named(rawValue),
        named(`init`), arbitrary)
```
Prose
```
the `@attached(member)` macro includes arguments after the `named:` label
```

In the code the label is referred to as "`names`", but the prose refers to it as "`named`". This PR suggests a doc fix that uses the correct label ("`names`") in the prose.