### PR TITLE
Emphasize type erasure in  buildLimitedAvailability

### DIFF
--- a/TSPL.docc/ReferenceManual/Attributes.md
+++ b/TSPL.docc/ReferenceManual/Attributes.md
@@ -1640,11 +1640,9 @@ The additional result-building methods are as follows:
   or to perform other postprocessing on a result before returning it.
 
 - term `static func buildLimitedAvailability(_ component: Component) -> Component`:
-  Builds a partial result that propagates or erases type information
+  Builds a partial result that erases type information for
   outside a compiler-control statement
   that performs an availability check.
-  You can use this to erase type information
-  that varies between the conditional branches.
 
 For example, the code below defines a simple result builder
 that builds an array of integers.
@@ -1743,7 +1741,7 @@ into code that calls the static methods of the result builder type:
   You can define an overload of `buildExpression(_:)`
   that takes an argument of type `()` to handle assignments specifically.
 - A branch statement that checks an availability condition
-  becomes a call to the `buildLimitedAvailability(_:)` method.
+  becomes a call to the `buildLimitedAvailability(_:)` method if one is defined.
   This transformation happens before the transformation into a call to
   `buildEither(first:)`, `buildEither(second:)`, or `buildOptional(_:)`.
   You use the `buildLimitedAvailability(_:)` method to erase type information
@@ -1830,7 +1828,7 @@ into code that calls the static methods of the result builder type:
       func draw() -> String { return content.draw() }
   }
   extension DrawingBuilder {
-      static func buildLimitedAvailability(_ content: Drawable) -> AnyDrawable {
+      static func buildLimitedAvailability(_ content: some Drawable) -> AnyDrawable {
           return AnyDrawable(content: content)
       }
   }
@@ -1846,6 +1844,11 @@ into code that calls the static methods of the result builder type:
   ```
 
   <!-- Comment block with swifttest for the code listing above is after the end of this bulleted list, due to tooling limitations. -->
+
+  Note that the above code compiled before
+  implementing the `buildLimitedAvailability` method,
+  as its role is not to enable the `if #available` syntax, but to
+  return a type that's always available.
 
 - A branch statement becomes a series of nested calls to the
   `buildEither(first:)` and `buildEither(second:)` methods.
@@ -2222,7 +2225,7 @@ into code that calls the static methods of the result builder type:
          func draw() -> String { return content.draw() }
      }
   -> extension DrawingBuilder {
-         static func buildLimitedAvailability(_ content: Drawable) -> AnyDrawable {
+         static func buildLimitedAvailability(_ content: some Drawable) -> AnyDrawable {
              return AnyDrawable(content: content)
          }
      }

--- a/TSPL.docc/ReferenceManual/Attributes.md
+++ b/TSPL.docc/ReferenceManual/Attributes.md
@@ -1640,8 +1640,9 @@ The additional result-building methods are as follows:
   or to perform other postprocessing on a result before returning it.
 
 - term `static func buildLimitedAvailability(_ component: Component) -> Component`:
-  Builds a partial result that erases type information for
-  outside a compiler-control statement
+  Builds a partial result that erases type information.
+  You can implement this method to prevent type information
+  from propagating outside a compiler-control statement
   that performs an availability check.
 
 For example, the code below defines a simple result builder
@@ -1741,9 +1742,14 @@ into code that calls the static methods of the result builder type:
   You can define an overload of `buildExpression(_:)`
   that takes an argument of type `()` to handle assignments specifically.
 - A branch statement that checks an availability condition
-  becomes a call to the `buildLimitedAvailability(_:)` method if one is defined.
+  becomes a call to the `buildLimitedAvailability(_:)` method,
+  if that method is implemented.
+  If you don't implement `buildLimitedAvailability(_:)`,
+  then branch statements that check availability
+  use the same transformations as other branch statements.
   This transformation happens before the transformation into a call to
   `buildEither(first:)`, `buildEither(second:)`, or `buildOptional(_:)`.
+
   You use the `buildLimitedAvailability(_:)` method to erase type information
   that changes depending on which branch is taken.
   For example,
@@ -1818,7 +1824,7 @@ into code that calls the static methods of the result builder type:
 
   To solve this problem,
   implement a `buildLimitedAvailability(_:)` method
-  to erase type information.
+  to erase type information by returning a type that's always available.
   For example, the code below builds an `AnyDrawable` value
   from its availability check.
 
@@ -1844,11 +1850,6 @@ into code that calls the static methods of the result builder type:
   ```
 
   <!-- Comment block with swifttest for the code listing above is after the end of this bulleted list, due to tooling limitations. -->
-
-  Note that the above code compiled before
-  implementing the `buildLimitedAvailability` method,
-  as its role is not to enable the `if #available` syntax, but to
-  return a type that's always available.
 
 - A branch statement becomes a series of nested calls to the
   `buildEither(first:)` and `buildEither(second:)` methods.


### PR DESCRIPTION
<!-- What's in this pull request? -->

A common misconception that people have about `buildLimitedAvailability` is that it enables the following syntax in result builders:

```swift
@DrawingBuilder var x: Drawable {
    if #available(macOS 99, *) {
        FutureText("Inside.future")
    } else {
        Text("Inside.present")
    }
}
```

and would implement `buildLimitedAvailability` as follows:

```swift
static func buildLimitedAvailability(component: some Drawable) -> some Drawable {
    component
}
```

However, the above code will still result in a crash in an earlier OS where `FutureText` is not available. 

**This change calls out the importance and need to perform type erasure in `buildLimitedAvailability`.**