### PR TITLE
Fixed a typo in the Swift 6.2 Document Revision History

### DIFF
--- a/TSPL.docc/RevisionHistory/RevisionHistory.md
+++ b/TSPL.docc/RevisionHistory/RevisionHistory.md
@@ -12,7 +12,7 @@ Review the recent changes to this book.
 - Added information about the main actor, isolation, and global actors
   to the <doc:Concurrency> chapter.
 - Added the <doc:Protocols#Implicit-Conformance-to-a-Protocol> section
-  with information information about conforming to common protocols,
+  with information about conforming to common protocols,
   without writing the conformance explicitly,
   and suppressing implicit conformance.
 - Added the <doc:Generics#Implicit-Constraints> section


### PR DESCRIPTION
Fixed a duplicated word "information" in the description of the "Implicit Conformance to a Protocol" section.