### PR TITLE
End "prints" comments with a period

### DIFF
--- a/TSPL.docc/GuidedTour/GuidedTour.md
+++ b/TSPL.docc/GuidedTour/GuidedTour.md
@@ -271,7 +271,7 @@ Arrays automatically grow as you add elements.
 ```swift
 fruits.append("blueberries")
 print(fruits)
-// Prints "["strawberries", "grapes", "tangerines", "blueberries"]"
+// Prints "["strawberries", "grapes", "tangerines", "blueberries"]".
 ```
 
 <!--
@@ -342,7 +342,7 @@ for score in individualScores {
     }
 }
 print(teamScore)
-// Prints "11"
+// Prints "11".
 ```
 
 <!--
@@ -393,7 +393,7 @@ let scoreDecoration = if teamScore > 10 {
     ""
 }
 print("Score:", teamScore, scoreDecoration)
-// Prints "Score: 11 🎉"
+// Prints "Score: 11 🎉".
 ```
 
 You can use `if` and `let` together
@@ -416,7 +416,7 @@ to mark the value as optional.
 ```swift
 var optionalString: String? = "Hello"
 print(optionalString == nil)
-// Prints "false"
+// Prints "false".
 
 var optionalName: String? = "John Appleseed"
 var greeting = "Hello!"
@@ -593,7 +593,7 @@ for (_, numbers) in interestingNumbers {
     }
 }
 print(largest)
-// Prints "25"
+// Prints "25".
 ```
 
 <!--
@@ -638,14 +638,14 @@ while n < 100 {
     n *= 2
 }
 print(n)
-// Prints "128"
+// Prints "128".
 
 var m = 2
 repeat {
     m *= 2
 } while m < 100
 print(m)
-// Prints "128"
+// Prints "128".
 ```
 
 <!--
@@ -682,7 +682,7 @@ for i in 0..<4 {
     total += i
 }
 print(total)
-// Prints "6"
+// Prints "6".
 ```
 
 <!--
@@ -800,9 +800,9 @@ func calculateStatistics(scores: [Int]) -> (min: Int, max: Int, sum: Int) {
 }
 let statistics = calculateStatistics(scores: [5, 3, 100, 3, 9])
 print(statistics.sum)
-// Prints "120"
+// Prints "120".
 print(statistics.2)
-// Prints "120"
+// Prints "120".
 ```
 
 <!--
@@ -990,7 +990,7 @@ of their only statement.
 ```swift
 let mappedNumbers = numbers.map({ number in 3 * number })
 print(mappedNumbers)
-// Prints "[60, 57, 21, 36]"
+// Prints "[60, 57, 21, 36]".
 ```
 
 <!--
@@ -1013,7 +1013,7 @@ you can omit the parentheses entirely.
 ```swift
 let sortedNumbers = numbers.sorted { $0 > $1 }
 print(sortedNumbers)
-// Prints "[20, 19, 12, 7]"
+// Prints "[20, 19, 12, 7]".
 ```
 
 <!--
@@ -1264,10 +1264,10 @@ class EquilateralTriangle: NamedShape {
 }
 var triangle = EquilateralTriangle(sideLength: 3.1, name: "a triangle")
 print(triangle.perimeter)
-// Prints "9.3"
+// Prints "9.3".
 triangle.perimeter = 9.9
 print(triangle.sideLength)
-// Prints "3.3000000000000003"
+// Prints "3.3000000000000003".
 ```
 
 <!--
@@ -1352,12 +1352,12 @@ class TriangleAndSquare {
 }
 var triangleAndSquare = TriangleAndSquare(size: 10, name: "another test shape")
 print(triangleAndSquare.square.sideLength)
-// Prints "10.0"
+// Prints "10.0".
 print(triangleAndSquare.triangle.sideLength)
-// Prints "10.0"
+// Prints "10.0".
 triangleAndSquare.square = Square(sideLength: 50, name: "larger square")
 print(triangleAndSquare.triangle.sideLength)
-// Prints "50.0"
+// Prints "50.0".
 ```
 
 <!--
@@ -1826,7 +1826,7 @@ without waiting for them to return.
 Task {
     await connectUser(to: "primary")
 }
-// Prints "Hello Guest, user ID 97"
+// Prints "Hello Guest, user ID 97".
 ```
 
 <!--
@@ -2024,7 +2024,7 @@ extension Int: ExampleProtocol {
     }
  }
 print(7.simpleDescription)
-// Prints "The number 7"
+// Prints "The number 7".
 ```
 
 <!--
@@ -2165,7 +2165,7 @@ do {
 } catch {
     print(error)
 }
-// Prints "Job sent"
+// Prints "Job sent".
 ```
 
 <!--
@@ -2224,7 +2224,7 @@ do {
 } catch {
     print(error)
 }
-// Prints "Job sent"
+// Prints "Job sent".
 ```
 
 <!--
@@ -2299,7 +2299,7 @@ if fridgeContains("banana") {
     print("Found a banana")
 }
 print(fridgeIsOpen)
-// Prints "false"
+// Prints "false".
 ```
 
 <!--

--- a/TSPL.docc/LanguageGuide/AccessControl.md
+++ b/TSPL.docc/LanguageGuide/AccessControl.md
@@ -870,7 +870,7 @@ stringToEdit.value = "This string will be tracked."
 stringToEdit.value += " This edit will increment numberOfEdits."
 stringToEdit.value += " So will this one."
 print("The number of edits is \(stringToEdit.numberOfEdits)")
-// Prints "The number of edits is 3"
+// Prints "The number of edits is 3".
 ```
 
 <!--

--- a/TSPL.docc/LanguageGuide/AdvancedOperators.md
+++ b/TSPL.docc/LanguageGuide/AdvancedOperators.md
@@ -1224,7 +1224,7 @@ let manualDrawing = Line(elements: [
      Stars(length: 2),
 ])
 print(manualDrawing.draw())
-// Prints "***Hello RAVI PATEL!**"
+// Prints "***Hello RAVI PATEL!**".
 ```
 
 <!--
@@ -1332,11 +1332,11 @@ func makeGreeting(for name: String? = nil) -> Drawable {
 }
 let genericGreeting = makeGreeting()
 print(genericGreeting.draw())
-// Prints "***Hello WORLD!**"
+// Prints "***Hello WORLD!**".
 
 let personalGreeting = makeGreeting(for: "Ravi Patel")
 print(personalGreeting.draw())
-// Prints "***Hello RAVI PATEL!**"
+// Prints "***Hello RAVI PATEL!**".
 ```
 
 <!--

--- a/TSPL.docc/LanguageGuide/AutomaticReferenceCounting.md
+++ b/TSPL.docc/LanguageGuide/AutomaticReferenceCounting.md
@@ -122,7 +122,7 @@ and assign it to one of these three variables:
 
 ```swift
 reference1 = Person(name: "John Appleseed")
-// Prints "John Appleseed is being initialized"
+// Prints "John Appleseed is being initialized".
 ```
 
 <!--
@@ -187,7 +187,7 @@ at which point it's clear that you are no longer using the `Person` instance:
 
 ```swift
 reference3 = nil
-// Prints "John Appleseed is being deinitialized"
+// Prints "John Appleseed is being deinitialized".
 ```
 
 <!--
@@ -526,7 +526,7 @@ there are no more strong references to the `Person` instance:
 
 ```swift
 john = nil
-// Prints "John Appleseed is being deinitialized"
+// Prints "John Appleseed is being deinitialized".
 ```
 
 <!--
@@ -551,7 +551,7 @@ there are no more strong references to the `Apartment` instance:
 
 ```swift
 unit4A = nil
-// Prints "Apartment 4A is being deinitialized"
+// Prints "Apartment 4A is being deinitialized".
 ```
 
 <!--
@@ -746,8 +746,8 @@ and it too is deallocated:
 
 ```swift
 john = nil
-// Prints "John Appleseed is being deinitialized"
-// Prints "Card #1234567890123456 is being deinitialized"
+// Prints "John Appleseed is being deinitialized".
+// Prints "Card #1234567890123456 is being deinitialized".
 ```
 
 <!--
@@ -1061,7 +1061,7 @@ without needing to use an exclamation point to unwrap its optional value:
 ```swift
 var country = Country(name: "Canada", capitalName: "Ottawa")
 print("\(country.name)'s capital city is called \(country.capitalCity.name)")
-// Prints "Canada's capital city is called Ottawa"
+// Prints "Canada's capital city is called Ottawa".
 ```
 
 <!--
@@ -1209,7 +1209,7 @@ heading.asHTML = {
     return "<\(heading.name)>\(heading.text ?? defaultText)</\(heading.name)>"
 }
 print(heading.asHTML())
-// Prints "<h1>some default text</h1>"
+// Prints "<h1>some default text</h1>".
 ```
 
 <!--
@@ -1245,7 +1245,7 @@ Here's how you use the `HTMLElement` class to create and print a new instance:
 ```swift
 var paragraph: HTMLElement? = HTMLElement(name: "p", text: "hello, world")
 print(paragraph!.asHTML())
-// Prints "<p>hello, world</p>"
+// Prints "<p>hello, world</p>".
 ```
 
 <!--
@@ -1472,7 +1472,7 @@ You can create and print an `HTMLElement` instance as before:
 ```swift
 var paragraph: HTMLElement? = HTMLElement(name: "p", text: "hello, world")
 print(paragraph!.asHTML())
-// Prints "<p>hello, world</p>"
+// Prints "<p>hello, world</p>".
 ```
 
 <!--
@@ -1497,7 +1497,7 @@ as can be seen from the printing of its deinitializer message in the example bel
 
 ```swift
 paragraph = nil
-// Prints "p is being deinitialized"
+// Prints "p is being deinitialized".
 ```
 
 <!--

--- a/TSPL.docc/LanguageGuide/BasicOperators.md
+++ b/TSPL.docc/LanguageGuide/BasicOperators.md
@@ -1037,7 +1037,7 @@ let allowedEntry = false
 if !allowedEntry {
     print("ACCESS DENIED")
 }
-// Prints "ACCESS DENIED"
+// Prints "ACCESS DENIED".
 ```
 
 <!--
@@ -1084,7 +1084,7 @@ if enteredDoorCode && passedRetinaScan {
 } else {
     print("ACCESS DENIED")
 }
-// Prints "ACCESS DENIED"
+// Prints "ACCESS DENIED".
 ```
 
 <!--

--- a/TSPL.docc/LanguageGuide/ClassesAndStructures.md
+++ b/TSPL.docc/LanguageGuide/ClassesAndStructures.md
@@ -197,7 +197,7 @@ separated by a period (`.`), without any spaces:
 
 ```swift
 print("The width of someResolution is \(someResolution.width)")
-// Prints "The width of someResolution is 0"
+// Prints "The width of someResolution is 0".
 ```
 
 <!--
@@ -218,7 +218,7 @@ such as the `width` property in the `resolution` property of a `VideoMode`:
 
 ```swift
 print("The width of someVideoMode is \(someVideoMode.resolution.width)")
-// Prints "The width of someVideoMode is 0"
+// Prints "The width of someVideoMode is 0".
 ```
 
 <!--
@@ -235,7 +235,7 @@ You can also use dot syntax to assign a new value to a variable property:
 ```swift
 someVideoMode.resolution.width = 1280
 print("The width of someVideoMode is now \(someVideoMode.resolution.width)")
-// Prints "The width of someVideoMode is now 1280"
+// Prints "The width of someVideoMode is now 1280".
 ```
 
 <!--
@@ -367,7 +367,7 @@ shows that it has indeed changed to be `2048`:
 
 ```swift
 print("cinema is now \(cinema.width) pixels wide")
-// Prints "cinema is now 2048 pixels wide"
+// Prints "cinema is now 2048 pixels wide".
 ```
 
 <!--
@@ -384,7 +384,7 @@ still has the old value of `1920`:
 
 ```swift
 print("hd is still \(hd.width) pixels wide")
-// Prints "hd is still 1920 pixels wide"
+// Prints "hd is still 1920 pixels wide".
 ```
 
 <!--
@@ -422,8 +422,8 @@ currentDirection.turnNorth()
 
 print("The current direction is \(currentDirection)")
 print("The remembered direction is \(rememberedDirection)")
-// Prints "The current direction is north"
-// Prints "The remembered direction is west"
+// Prints "The current direction is north".
+// Prints "The remembered direction is west".
 ```
 
 <!--
@@ -522,7 +522,7 @@ from the underlying `VideoMode` instance:
 
 ```swift
 print("The frameRate property of tenEighty is now \(tenEighty.frameRate)")
-// Prints "The frameRate property of tenEighty is now 30.0"
+// Prints "The frameRate property of tenEighty is now 30.0".
 ```
 
 <!--

--- a/TSPL.docc/LanguageGuide/Closures.md
+++ b/TSPL.docc/LanguageGuide/Closures.md
@@ -964,11 +964,11 @@ class SomeClass {
 let instance = SomeClass()
 instance.doSomething()
 print(instance.x)
-// Prints "200"
+// Prints "200".
 
 completionHandlers.first?()
 print(instance.x)
-// Prints "100"
+// Prints "100".
 ```
 
 <!--
@@ -1154,16 +1154,16 @@ The code below shows how a closure delays evaluation.
 ```swift
 var customersInLine = ["Chris", "Alex", "Ewa", "Barry", "Daniella"]
 print(customersInLine.count)
-// Prints "5"
+// Prints "5".
 
 let customerProvider = { customersInLine.remove(at: 0) }
 print(customersInLine.count)
-// Prints "5"
+// Prints "5".
 
 print("Now serving \(customerProvider())!")
 // Prints "Now serving Chris!"
 print(customersInLine.count)
-// Prints "4"
+// Prints "4".
 ```
 
 <!--

--- a/TSPL.docc/LanguageGuide/Concurrency.md
+++ b/TSPL.docc/LanguageGuide/Concurrency.md
@@ -1235,7 +1235,7 @@ For example:
 ```swift
 let logger = TemperatureLogger(label: "Outdoors", measurement: 25)
 print(await logger.max)
-// Prints "25"
+// Prints "25".
 ```
 
 In this example,

--- a/TSPL.docc/LanguageGuide/ControlFlow.md
+++ b/TSPL.docc/LanguageGuide/ControlFlow.md
@@ -157,7 +157,7 @@ for _ in 1...power {
     answer *= base
 }
 print("\(base) to the power of \(power) is \(answer)")
-// Prints "3 to the power of 10 is 59049"
+// Prints "3 to the power of 10 is 59049".
 ```
 
 <!--
@@ -936,7 +936,7 @@ case "z":
 default:
     print("Some other character")
 }
-// Prints "The last letter of the Latin alphabet"
+// Prints "The last letter of the Latin alphabet".
 ```
 
 <!--
@@ -980,7 +980,7 @@ default:
 }
 
 print(message)
-// Prints "The first letter of the Latin alphabet"
+// Prints "The first letter of the Latin alphabet".
 ```
 
 In this example,
@@ -1070,7 +1070,7 @@ case "a", "A":
 default:
     print("Not the letter A")
 }
-// Prints "The letter A"
+// Prints "The letter A".
 ```
 
 <!--
@@ -1188,7 +1188,7 @@ case (-2...2, -2...2):
 default:
     print("\(somePoint) is outside of the box")
 }
-// Prints "(1, 1) is inside the box"
+// Prints "(1, 1) is inside the box".
 ```
 
 <!--
@@ -1249,7 +1249,7 @@ case (0, let y):
 case let (x, y):
     print("somewhere else at (\(x), \(y))")
 }
-// Prints "on the x-axis with an x value of 2"
+// Prints "on the x-axis with an x value of 2".
 ```
 
 <!--
@@ -1312,7 +1312,7 @@ case let (x, y) where x == -y:
 case let (x, y):
     print("(\(x), \(y)) is just some arbitrary point")
 }
-// Prints "(1, -1) is on the line x == -y"
+// Prints "(1, -1) is on the line x == -y".
 ```
 
 <!--
@@ -1369,7 +1369,7 @@ case "b", "c", "d", "f", "g", "h", "j", "k", "l", "m",
 default:
     print("\(someCharacter) isn't a vowel or a consonant")
 }
-// Prints "e is a vowel"
+// Prints "e is a vowel".
 ```
 
 <!--
@@ -1414,7 +1414,7 @@ case (let distance, 0), (0, let distance):
 default:
     print("Not on an axis")
 }
-// Prints "On an axis, 9 from the origin"
+// Prints "On an axis, 9 from the origin".
 ```
 
 <!--
@@ -1452,7 +1452,7 @@ let somePoint = (12, 100)
 if case (let x, 100) = somePoint {
     print("Found a point on the y=100 line, at \(x)")
 }
-// Prints "Found a point on the y=100 line, at 12"
+// Prints "Found a point on the y=100 line, at 12".
 ```
 
 In this code,
@@ -1476,8 +1476,8 @@ for (x, y) in points {
         print("Found a point on the x-axis at \(x)")
     }
 }
-// Prints "Found a point on the x-axis at 10"
-// Prints "Found a point on the x-axis at -20"
+// Prints "Found a point on the x-axis at 10".
+// Prints "Found a point on the x-axis at -20".
 ```
 
 The `for`-`in` loop above iterates over an array of tuples,
@@ -1494,8 +1494,8 @@ The code below has the same behavior as the `for`-`in` loop above:
 for case (let x, 0) in points {
     print("Found a point on the x-axis at \(x)")
 }
-// Prints "Found a point on the x-axis at 10"
-// Prints "Found a point on the x-axis at -20"
+// Prints "Found a point on the x-axis at 10".
+// Prints "Found a point on the x-axis at -20".
 ```
 
 In this code,
@@ -1516,7 +1516,7 @@ For example:
 for case let (x, y) in points where x == y || x == -y  {
     print("Found (\(x), \(y)) along a line through the origin")
 }
-// Prints "Found (30, -30) along a line through the origin"
+// Prints "Found (30, -30) along a line through the origin".
 ```
 
 This code binds the first and second elements of the tuple
@@ -1568,7 +1568,7 @@ for character in puzzleInput {
     puzzleOutput.append(character)
 }
 print(puzzleOutput)
-// Prints "grtmndsthnklk"
+// Prints "grtmndsthnklk".
 ```
 
 <!--
@@ -2092,7 +2092,7 @@ if score < 10 {
     }
     score += 5
 }
-// Prints "6"
+// Prints "6".
 ```
 
 <!--
@@ -2143,7 +2143,7 @@ if score < 100 {
     // Other code that uses the score with its bonus goes here.
     print(score)
 }
-// Prints "103"
+// Prints "103".
 ```
 
 <!--
@@ -2176,8 +2176,8 @@ if score < 10 {
     }
     score += 5
 }
-// Prints "The score is:"
-// Prints "6"
+// Prints "The score is:".
+// Prints "6".
 ```
 
 <!--

--- a/TSPL.docc/LanguageGuide/Deinitialization.md
+++ b/TSPL.docc/LanguageGuide/Deinitialization.md
@@ -162,9 +162,9 @@ Here, the deinitializer simply returns all of the player's coins to the bank:
 ```swift
 var playerOne: Player? = Player(coins: 100)
 print("A new player has joined the game with \(playerOne!.coinsInPurse) coins")
-// Prints "A new player has joined the game with 100 coins"
+// Prints "A new player has joined the game with 100 coins".
 print("There are now \(Bank.coinsInBank) coins left in the bank")
-// Prints "There are now 9900 coins left in the bank"
+// Prints "There are now 9900 coins left in the bank".
 ```
 
 <!--
@@ -191,9 +191,9 @@ and whenever its `win(coins:)` method is called:
 ```swift
 playerOne!.win(coins: 2_000)
 print("PlayerOne won 2000 coins & now has \(playerOne!.coinsInPurse) coins")
-// Prints "PlayerOne won 2000 coins & now has 2100 coins"
+// Prints "PlayerOne won 2000 coins & now has 2100 coins".
 print("The bank now only has \(Bank.coinsInBank) coins left")
-// Prints "The bank now only has 7900 coins left"
+// Prints "The bank now only has 7900 coins left".
 ```
 
 <!--
@@ -215,9 +215,9 @@ and the bank has only 7,900 coins left.
 ```swift
 playerOne = nil
 print("PlayerOne has left the game")
-// Prints "PlayerOne has left the game"
+// Prints "PlayerOne has left the game".
 print("The bank now has \(Bank.coinsInBank) coins")
-// Prints "The bank now has 10000 coins"
+// Prints "The bank now has 10000 coins".
 ```
 
 <!--

--- a/TSPL.docc/LanguageGuide/Enumerations.md
+++ b/TSPL.docc/LanguageGuide/Enumerations.md
@@ -171,7 +171,7 @@ case .east:
 case .west:
     print("Where the skies are blue")
 }
-// Prints "Watch out for penguins"
+// Prints "Watch out for penguins".
 ```
 
 <!--
@@ -221,7 +221,7 @@ case .earth:
 default:
     print("Not a safe place for humans")
 }
-// Prints "Mostly harmless"
+// Prints "Mostly harmless".
 ```
 
 <!--
@@ -255,7 +255,7 @@ enum Beverage: CaseIterable {
 }
 let numberOfChoices = Beverage.allCases.count
 print("\(numberOfChoices) beverages available")
-// Prints "3 beverages available"
+// Prints "3 beverages available".
 ```
 
 <!--
@@ -686,7 +686,7 @@ if let somePlanet = Planet(rawValue: positionToFind) {
 } else {
     print("There isn't a planet at position \(positionToFind)")
 }
-// Prints "There isn't a planet at position 11"
+// Prints "There isn't a planet at position 11".
 ```
 
 <!--
@@ -824,7 +824,7 @@ func evaluate(_ expression: ArithmeticExpression) -> Int {
 }
 
 print(evaluate(product))
-// Prints "18"
+// Prints "18".
 ```
 
 <!--

--- a/TSPL.docc/LanguageGuide/ErrorHandling.md
+++ b/TSPL.docc/LanguageGuide/ErrorHandling.md
@@ -853,7 +853,7 @@ do throws(StatisticsError) {
         print("Invalid rating: \(rating)")
     }
 }
-// Prints "No ratings available"
+// Prints "No ratings available".
 ```
 
 In this code,
@@ -897,7 +897,7 @@ do {
         print("Invalid rating: \(rating)")
     }
 }
-// Prints "No ratings available"
+// Prints "No ratings available".
 ```
 
 Even though the `do`-`catch` block above

--- a/TSPL.docc/LanguageGuide/Extensions.md
+++ b/TSPL.docc/LanguageGuide/Extensions.md
@@ -147,10 +147,10 @@ extension Double {
 }
 let oneInch = 25.4.mm
 print("One inch is \(oneInch) meters")
-// Prints "One inch is 0.0254 meters"
+// Prints "One inch is 0.0254 meters".
 let threeFeet = 3.ft
 print("Three feet is \(threeFeet) meters")
-// Prints "Three feet is 0.914399970739201 meters"
+// Prints "Three feet is 0.914399970739201 meters".
 ```
 
 <!--
@@ -200,7 +200,7 @@ and can be used within mathematical calculations wherever a `Double` is accepted
 ```swift
 let aMarathon = 42.km + 195.m
 print("A marathon is \(aMarathon) meters long")
-// Prints "A marathon is 42195.0 meters long"
+// Prints "A marathon is 42195.0 meters long".
 ```
 
 <!--
@@ -641,7 +641,7 @@ func printIntegerKinds(_ numbers: [Int]) {
     print("")
 }
 printIntegerKinds([3, 19, -27, 0, -6, 0, 7])
-// Prints "+ + - 0 - 0 + "
+// Prints "+ + - 0 - 0 + ".
 ```
 
 <!--
@@ -663,7 +663,7 @@ printIntegerKinds([3, 19, -27, 0, -6, 0, 7])
      }
   -> printIntegerKinds([3, 19, -27, 0, -6, 0, 7])
   << + + - 0 - 0 +
-  // Prints "+ + - 0 - 0 + "
+  // Prints "+ + - 0 - 0 + ".
   ```
 -->
 

--- a/TSPL.docc/LanguageGuide/Functions.md
+++ b/TSPL.docc/LanguageGuide/Functions.md
@@ -161,7 +161,7 @@ func sayHelloWorld() -> String {
     return "hello, world"
 }
 print(sayHelloWorld())
-// Prints "hello, world"
+// Prints "hello, world".
 ```
 
 <!--
@@ -393,7 +393,7 @@ they can be accessed with dot syntax to retrieve the minimum and maximum found v
 ```swift
 let bounds = minMax(array: [8, -6, 2, 109, 3, 71])
 print("min is \(bounds.min) and max is \(bounds.max)")
-// Prints "min is -6 and max is 109"
+// Prints "min is -6 and max is 109".
 ```
 
 <!--
@@ -479,7 +479,7 @@ returns an actual tuple value or `nil`:
 if let bounds = minMax(array: [8, -6, 2, 109, 3, 71]) {
     print("min is \(bounds.min) and max is \(bounds.max)")
 }
-// Prints "min is -6 and max is 109"
+// Prints "min is -6 and max is 109".
 ```
 
 <!--
@@ -892,7 +892,7 @@ var someInt = 3
 var anotherInt = 107
 swapTwoInts(&someInt, &anotherInt)
 print("someInt is now \(someInt), and anotherInt is now \(anotherInt)")
-// Prints "someInt is now 107, and anotherInt is now 3"
+// Prints "someInt is now 107, and anotherInt is now 3".
 ```
 
 <!--
@@ -1023,7 +1023,7 @@ You can now call the assigned function with the name `mathFunction`:
 
 ```swift
 print("Result: \(mathFunction(2, 3))")
-// Prints "Result: 5"
+// Prints "Result: 5".
 ```
 
 <!--
@@ -1041,7 +1041,7 @@ in the same way as for nonfunction types:
 ```swift
 mathFunction = multiplyTwoInts
 print("Result: \(mathFunction(2, 3))")
-// Prints "Result: 6"
+// Prints "Result: 6".
 ```
 
 <!--
@@ -1092,7 +1092,7 @@ func printMathResult(_ mathFunction: (Int, Int) -> Int, _ a: Int, _ b: Int) {
     print("Result: \(mathFunction(a, b))")
 }
 printMathResult(addTwoInts, 3, 5)
-// Prints "Result: 8"
+// Prints "Result: 8".
 ```
 
 <!--

--- a/TSPL.docc/LanguageGuide/Generics.md
+++ b/TSPL.docc/LanguageGuide/Generics.md
@@ -56,7 +56,7 @@ var someInt = 3
 var anotherInt = 107
 swapTwoInts(&someInt, &anotherInt)
 print("someInt is now \(someInt), and anotherInt is now \(anotherInt)")
-// Prints "someInt is now 107, and anotherInt is now 3"
+// Prints "someInt is now 107, and anotherInt is now 3".
 ```
 
 <!--
@@ -672,7 +672,7 @@ let strings = ["cat", "dog", "llama", "parakeet", "terrapin"]
 if let foundIndex = findIndex(ofString: "llama", in: strings) {
     print("The index of llama is \(foundIndex)")
 }
-// Prints "The index of llama is 2"
+// Prints "The index of llama is 2".
 ```
 
 <!--
@@ -1583,7 +1583,7 @@ extension Container where Item == Double {
     }
 }
 print([1260.0, 1200.0, 98.6, 37.0].average())
-// Prints "648.9"
+// Prints "648.9".
 ```
 
 <!--
@@ -1651,9 +1651,9 @@ extension Container {
 }
 let numbers = [1260, 1200, 98, 37]
 print(numbers.average())
-// Prints "648.75"
+// Prints "648.75".
 print(numbers.endsWith(37))
-// Prints "true"
+// Prints "true".
 ```
 
 <!--

--- a/TSPL.docc/LanguageGuide/Inheritance.md
+++ b/TSPL.docc/LanguageGuide/Inheritance.md
@@ -322,7 +322,7 @@ you can see that the `Train` subclass version of the method is called:
 ```swift
 let train = Train()
 train.makeNoise()
-// Prints "Choo Choo"
+// Prints "Choo Choo".
 ```
 
 <!--

--- a/TSPL.docc/LanguageGuide/Initialization.md
+++ b/TSPL.docc/LanguageGuide/Initialization.md
@@ -73,7 +73,7 @@ struct Fahrenheit {
 }
 var f = Fahrenheit()
 print("The default temperature is \(f.temperature)° Fahrenheit")
-// Prints "The default temperature is 32.0° Fahrenheit"
+// Prints "The default temperature is 32.0° Fahrenheit".
 ```
 
 <!--
@@ -650,11 +650,11 @@ For example:
 ```swift
 let zeroByTwo = Size(height: 2.0)
 print(zeroByTwo.width, zeroByTwo.height)
-// Prints "0.0 2.0"
+// Prints "0.0 2.0".
 
 let zeroByZero = Size()
 print(zeroByZero.width, zeroByZero.height)
-// Prints "0.0 0.0"
+// Prints "0.0 0.0".
 ```
 
 <!--
@@ -1836,7 +1836,7 @@ let pi = 3.14159
 if let valueMaintained = Int(exactly: wholeNumber) {
     print("\(wholeNumber) conversion to Int maintains value of \(valueMaintained)")
 }
-// Prints "12345.0 conversion to Int maintains value of 12345"
+// Prints "12345.0 conversion to Int maintains value of 12345".
 
 let valueChanged = Int(exactly: pi)
 // valueChanged is of type Int?, not Int
@@ -1844,7 +1844,7 @@ let valueChanged = Int(exactly: pi)
 if valueChanged == nil {
     print("\(pi) conversion to Int doesn't maintain value")
 }
-// Prints "3.14159 conversion to Int doesn't maintain value"
+// Prints "3.14159 conversion to Int doesn't maintain value".
 ```
 
 <!--
@@ -1911,7 +1911,7 @@ let someCreature = Animal(species: "Giraffe")
 if let giraffe = someCreature {
     print("An animal was initialized with a species of \(giraffe.species)")
 }
-// Prints "An animal was initialized with a species of Giraffe"
+// Prints "An animal was initialized with a species of Giraffe".
 ```
 
 <!--
@@ -1938,7 +1938,7 @@ let anonymousCreature = Animal(species: "")
 if anonymousCreature == nil {
     print("The anonymous creature couldn't be initialized")
 }
-// Prints "The anonymous creature couldn't be initialized"
+// Prints "The anonymous creature couldn't be initialized".
 ```
 
 <!--
@@ -2233,7 +2233,7 @@ initialization succeeds:
 if let twoSocks = CartItem(name: "sock", quantity: 2) {
     print("Item: \(twoSocks.name), quantity: \(twoSocks.quantity)")
 }
-// Prints "Item: sock, quantity: 2"
+// Prints "Item: sock, quantity: 2".
 ```
 
 <!--
@@ -2256,7 +2256,7 @@ if let zeroShirts = CartItem(name: "shirt", quantity: 0) {
 } else {
     print("Unable to initialize zero shirts")
 }
-// Prints "Unable to initialize zero shirts"
+// Prints "Unable to initialize zero shirts".
 ```
 
 <!--
@@ -2281,7 +2281,7 @@ if let oneUnnamed = CartItem(name: "", quantity: 1) {
 } else {
     print("Unable to initialize one unnamed product")
 }
-// Prints "Unable to initialize one unnamed product"
+// Prints "Unable to initialize one unnamed product".
 ```
 
 <!--
@@ -2936,9 +2936,9 @@ and can be queried with the `squareIsBlackAt(row:column:)` utility function:
 ```swift
 let board = Chessboard()
 print(board.squareIsBlackAt(row: 0, column: 1))
-// Prints "true"
+// Prints "true".
 print(board.squareIsBlackAt(row: 7, column: 7))
-// Prints "false"
+// Prints "false".
 ```
 
 <!--

--- a/TSPL.docc/LanguageGuide/MemorySafety.md
+++ b/TSPL.docc/LanguageGuide/MemorySafety.md
@@ -183,7 +183,7 @@ func oneMore(than number: Int) -> Int {
 var myNumber = 1
 myNumber = oneMore(than: myNumber)
 print(myNumber)
-// Prints "2"
+// Prints "2".
 ```
 
 <!--

--- a/TSPL.docc/LanguageGuide/Methods.md
+++ b/TSPL.docc/LanguageGuide/Methods.md
@@ -174,7 +174,7 @@ let somePoint = Point(x: 4.0, y: 5.0)
 if somePoint.isToTheRightOf(x: 1.0) {
     print("This point is to the right of the line where x == 1.0")
 }
-// Prints "This point is to the right of the line where x == 1.0"
+// Prints "This point is to the right of the line where x == 1.0".
 ```
 
 <!--
@@ -230,7 +230,7 @@ struct Point {
 var somePoint = Point(x: 1.0, y: 1.0)
 somePoint.moveBy(x: 2.0, y: 3.0)
 print("The point is now at (\(somePoint.x), \(somePoint.y))")
-// Prints "The point is now at (3.0, 4.0)"
+// Prints "The point is now at (3.0, 4.0)".
 ```
 
 <!--
@@ -592,7 +592,7 @@ and see what happens when the player completes level one:
 var player = Player(name: "Argyrios")
 player.complete(level: 1)
 print("highest unlocked level is now \(LevelTracker.highestUnlockedLevel)")
-// Prints "highest unlocked level is now 2"
+// Prints "highest unlocked level is now 2".
 ```
 
 <!--
@@ -617,7 +617,7 @@ if player.tracker.advance(to: 6) {
 } else {
     print("level 6 hasn't yet been unlocked")
 }
-// Prints "level 6 hasn't yet been unlocked"
+// Prints "level 6 hasn't yet been unlocked".
 ```
 
 <!--

--- a/TSPL.docc/LanguageGuide/NestedTypes.md
+++ b/TSPL.docc/LanguageGuide/NestedTypes.md
@@ -148,7 +148,7 @@ You can use this initializer to initialize a new constant called `theAceOfSpades
 ```swift
 let theAceOfSpades = BlackjackCard(rank: .ace, suit: .spades)
 print("theAceOfSpades: \(theAceOfSpades.description)")
-// Prints "theAceOfSpades: suit is ♠, value is 1 or 11"
+// Prints "theAceOfSpades: suit is ♠, value is 1 or 11".
 ```
 
 <!--

--- a/TSPL.docc/LanguageGuide/OpaqueTypes.md
+++ b/TSPL.docc/LanguageGuide/OpaqueTypes.md
@@ -616,7 +616,7 @@ For example:
 if let downcastTriangle = vertical.shapes[0] as? Triangle {
     print(downcastTriangle.size)
 }
-// Prints "5"
+// Prints "5".
 ```
 
 For more information, see <doc:TypeCasting#Downcasting>.
@@ -860,7 +860,7 @@ func makeOpaqueContainer<T>(item: T) -> some Container {
 let opaqueContainer = makeOpaqueContainer(item: 12)
 let twelve = opaqueContainer[0]
 print(type(of: twelve))
-// Prints "Int"
+// Prints "Int".
 ```
 
 <!--

--- a/TSPL.docc/LanguageGuide/Properties.md
+++ b/TSPL.docc/LanguageGuide/Properties.md
@@ -282,7 +282,7 @@ such as when its `filename` property is queried:
 ```swift
 print(manager.importer.filename)
 // the DataImporter instance for the importer property has now been created
-// Prints "data.txt"
+// Prints "data.txt".
 ```
 
 <!--
@@ -361,7 +361,7 @@ let initialSquareCenter = square.center
 // initialSquareCenter is at (5.0, 5.0)
 square.center = Point(x: 15.0, y: 15.0)
 print("square.origin is now at (\(square.origin.x), \(square.origin.y))")
-// Prints "square.origin is now at (10.0, 10.0)"
+// Prints "square.origin is now at (10.0, 10.0)".
 ```
 
 <!--
@@ -577,7 +577,7 @@ struct Cuboid {
 }
 let fourByFiveByTwo = Cuboid(width: 4.0, height: 5.0, depth: 2.0)
 print("the volume of fourByFiveByTwo is \(fourByFiveByTwo.volume)")
-// Prints "the volume of fourByFiveByTwo is 40.0"
+// Prints "the volume of fourByFiveByTwo is 40.0".
 ```
 
 <!--
@@ -1004,15 +1004,15 @@ struct SmallRectangle {
 
 var rectangle = SmallRectangle()
 print(rectangle.height)
-// Prints "0"
+// Prints "0".
 
 rectangle.height = 10
 print(rectangle.height)
-// Prints "10"
+// Prints "10".
 
 rectangle.height = 24
 print(rectangle.height)
-// Prints "12"
+// Prints "12".
 ```
 
 <!--
@@ -1200,7 +1200,7 @@ struct ZeroRectangle {
 
 var zeroRectangle = ZeroRectangle()
 print(zeroRectangle.height, zeroRectangle.width)
-// Prints "0 0"
+// Prints "0 0".
 ```
 
 <!--
@@ -1263,7 +1263,7 @@ struct UnitRectangle {
 
 var unitRectangle = UnitRectangle()
 print(unitRectangle.height, unitRectangle.width)
-// Prints "1 1"
+// Prints "1 1".
 ```
 
 <!--
@@ -1323,12 +1323,12 @@ struct NarrowRectangle {
 
 var narrowRectangle = NarrowRectangle()
 print(narrowRectangle.height, narrowRectangle.width)
-// Prints "2 3"
+// Prints "2 3".
 
 narrowRectangle.height = 100
 narrowRectangle.width = 100
 print(narrowRectangle.height, narrowRectangle.width)
-// Prints "5 4"
+// Prints "5 4".
 ```
 
 <!--
@@ -1403,11 +1403,11 @@ struct MixedRectangle {
 
 var mixedRectangle = MixedRectangle()
 print(mixedRectangle.height)
-// Prints "1"
+// Prints "1".
 
 mixedRectangle.height = 20
 print(mixedRectangle.height)
-// Prints "12"
+// Prints "12".
 ```
 
 <!--
@@ -1485,11 +1485,11 @@ var someStructure = SomeStructure()
 
 someStructure.someNumber = 4
 print(someStructure.$someNumber)
-// Prints "false"
+// Prints "false".
 
 someStructure.someNumber = 55
 print(someStructure.$someNumber)
-// Prints "true"
+// Prints "true".
 ```
 
 <!--
@@ -1883,9 +1883,9 @@ SomeStructure.storedTypeProperty = "Another value."
 print(SomeStructure.storedTypeProperty)
 // Prints "Another value."
 print(SomeEnumeration.computedTypeProperty)
-// Prints "6"
+// Prints "6".
 print(SomeClass.computedTypeProperty)
-// Prints "27"
+// Prints "27".
 ```
 
 <!--
@@ -2018,9 +2018,9 @@ is updated to equal `7`:
 ```swift
 leftChannel.currentLevel = 7
 print(leftChannel.currentLevel)
-// Prints "7"
+// Prints "7".
 print(AudioChannel.maxInputLevelForAllChannels)
-// Prints "7"
+// Prints "7".
 ```
 
 <!--
@@ -2043,9 +2043,9 @@ and the `maxInputLevelForAllChannels` type property is updated to equal `10`:
 ```swift
 rightChannel.currentLevel = 11
 print(rightChannel.currentLevel)
-// Prints "10"
+// Prints "10".
 print(AudioChannel.maxInputLevelForAllChannels)
-// Prints "10"
+// Prints "10".
 ```
 
 <!--

--- a/TSPL.docc/LanguageGuide/Protocols.md
+++ b/TSPL.docc/LanguageGuide/Protocols.md
@@ -346,9 +346,9 @@ class LinearCongruentialGenerator: RandomNumberGenerator {
 }
 let generator = LinearCongruentialGenerator()
 print("Here's a random number: \(generator.random())")
-// Prints "Here's a random number: 0.3746499199817101"
+// Prints "Here's a random number: 0.3746499199817101".
 print("And another one: \(generator.random())")
-// Prints "And another one: 0.729023776863283"
+// Prints "And another one: 0.729023776863283".
 ```
 
 <!--
@@ -1091,7 +1091,7 @@ Any `Dice` instance can now be treated as `TextRepresentable`:
 ```swift
 let d12 = Dice(sides: 12, generator: LinearCongruentialGenerator())
 print(d12.textualDescription)
-// Prints "A 12-sided dice"
+// Prints "A 12-sided dice".
 ```
 
 <!--
@@ -1114,7 +1114,7 @@ extension SnakesAndLadders: TextRepresentable {
     }
 }
 print(game.textualDescription)
-// Prints "A game of Snakes and Ladders with 25 squares"
+// Prints "A game of Snakes and Ladders with 25 squares".
 ```
 
 <!--
@@ -1155,7 +1155,7 @@ extension Array: TextRepresentable where Element: TextRepresentable {
 }
 let myDice = [d6, d12]
 print(myDice.textualDescription)
-// Prints "[A 6-sided dice, A 12-sided dice]"
+// Prints "[A 6-sided dice, A 12-sided dice]".
 ```
 
 <!--
@@ -1210,7 +1210,7 @@ Instances of `Hamster` can now be used wherever `TextRepresentable` is the requi
 let simonTheHamster = Hamster(name: "Simon")
 let somethingTextRepresentable: TextRepresentable = simonTheHamster
 print(somethingTextRepresentable.textualDescription)
-// Prints "A hamster named Simon"
+// Prints "A hamster named Simon".
 ```
 
 <!--
@@ -1356,10 +1356,10 @@ var levels = [SkillLevel.intermediate, SkillLevel.beginner,
 for level in levels.sorted() {
     print(level)
 }
-// Prints "beginner"
-// Prints "intermediate"
-// Prints "expert(stars: 3)"
-// Prints "expert(stars: 5)"
+// Prints "beginner".
+// Prints "intermediate".
+// Prints "expert(stars: 3)".
+// Prints "expert(stars: 5)".
 ```
 
 <!--
@@ -2426,9 +2426,9 @@ without any additional modification.
 ```swift
 let generator = LinearCongruentialGenerator()
 print("Here's a random number: \(generator.random())")
-// Prints "Here's a random number: 0.3746499199817101"
+// Prints "Here's a random number: 0.3746499199817101".
 print("And here's a random Boolean: \(generator.randomBool())")
-// Prints "And here's a random Boolean: true"
+// Prints "And here's a random Boolean: true".
 ```
 
 <!--
@@ -2594,9 +2594,9 @@ and integers conform to `Equatable`,
 
 ```swift
 print(equalNumbers.allEqual())
-// Prints "true"
+// Prints "true".
 print(differentNumbers.allEqual())
-// Prints "false"
+// Prints "false".
 ```
 
 <!--

--- a/TSPL.docc/LanguageGuide/StringsAndCharacters.md
+++ b/TSPL.docc/LanguageGuide/StringsAndCharacters.md
@@ -378,7 +378,7 @@ by checking its Boolean `isEmpty` property:
 if emptyString.isEmpty {
     print("Nothing to see here")
 }
-// Prints "Nothing to see here"
+// Prints "Nothing to see here".
 ```
 
 <!--
@@ -525,7 +525,7 @@ as an argument to its initializer:
 let catCharacters: [Character] = ["C", "a", "t", "!", "🐱"]
 let catString = String(catCharacters)
 print(catString)
-// Prints "Cat!🐱"
+// Prints "Cat!🐱".
 ```
 
 <!--
@@ -898,7 +898,7 @@ use the `count` property of the string:
 ```swift
 let unusualMenagerie = "Koala 🐨, Snail 🐌, Penguin 🐧, Dromedary 🐪"
 print("unusualMenagerie has \(unusualMenagerie.count) characters")
-// Prints "unusualMenagerie has 40 characters"
+// Prints "unusualMenagerie has 40 characters".
 ```
 
 <!--
@@ -923,12 +923,12 @@ with a fourth character of `é`, not `e`:
 ```swift
 var word = "cafe"
 print("the number of characters in \(word) is \(word.count)")
-// Prints "the number of characters in cafe is 4"
+// Prints "the number of characters in cafe is 4".
 
 word += "\u{301}"    // COMBINING ACUTE ACCENT, U+0301
 
 print("the number of characters in \(word) is \(word.count)")
-// Prints "the number of characters in café is 4"
+// Prints "the number of characters in café is 4".
 ```
 
 <!--
@@ -1074,7 +1074,7 @@ indices of individual characters in a string.
 for index in greeting.indices {
     print("\(greeting[index]) ", terminator: "")
 }
-// Prints "G u t e n   T a g ! "
+// Prints "G u t e n   T a g ! ".
 ```
 
 <!--
@@ -1086,7 +1086,7 @@ for index in greeting.indices {
      }
   >> print("")
   << G u t e n   T a g !
-  // Prints "G u t e n   T a g ! "
+  // Prints "G u t e n   T a g ! ".
   ```
 -->
 
@@ -1273,7 +1273,7 @@ let sameQuotation = "We're a lot alike, you and I."
 if quotation == sameQuotation {
     print("These two strings are considered equal")
 }
-// Prints "These two strings are considered equal"
+// Prints "These two strings are considered equal".
 ```
 
 <!--
@@ -1341,7 +1341,7 @@ let combinedEAcuteQuestion = "Voulez-vous un caf\u{65}\u{301}?"
 if eAcuteQuestion == combinedEAcuteQuestion {
     print("These two strings are considered equal")
 }
-// Prints "These two strings are considered equal"
+// Prints "These two strings are considered equal".
 ```
 
 <!--
@@ -1500,7 +1500,7 @@ for scene in romeoAndJuliet {
     }
 }
 print("There are \(act1SceneCount) scenes in Act 1")
-// Prints "There are 5 scenes in Act 1"
+// Prints "There are 5 scenes in Act 1".
 ```
 
 <!--
@@ -1532,7 +1532,7 @@ for scene in romeoAndJuliet {
     }
 }
 print("\(mansionCount) mansion scenes; \(cellCount) cell scenes")
-// Prints "6 mansion scenes; 2 cell scenes"
+// Prints "6 mansion scenes; 2 cell scenes".
 ```
 
 <!--
@@ -1614,7 +1614,7 @@ for codeUnit in dogString.utf8 {
     print("\(codeUnit) ", terminator: "")
 }
 print("")
-// Prints "68 111 103 226 128 188 240 159 144 182 "
+// Prints "68 111 103 226 128 188 240 159 144 182 ".
 ```
 
 <!--
@@ -1626,7 +1626,7 @@ print("")
      }
   -> print("")
   << 68 111 103 226 128 188 240 159 144 182
-  // Prints "68 111 103 226 128 188 240 159 144 182 "
+  // Prints "68 111 103 226 128 188 240 159 144 182 ".
   ```
 -->
 
@@ -1668,7 +1668,7 @@ for codeUnit in dogString.utf16 {
     print("\(codeUnit) ", terminator: "")
 }
 print("")
-// Prints "68 111 103 8252 55357 56374 "
+// Prints "68 111 103 8252 55357 56374 ".
 ```
 
 <!--
@@ -1680,7 +1680,7 @@ print("")
      }
   -> print("")
   << 68 111 103 8252 55357 56374
-  // Prints "68 111 103 8252 55357 56374 "
+  // Prints "68 111 103 8252 55357 56374 ".
   ```
 -->
 
@@ -1722,7 +1722,7 @@ for scalar in dogString.unicodeScalars {
     print("\(scalar.value) ", terminator: "")
 }
 print("")
-// Prints "68 111 103 8252 128054 "
+// Prints "68 111 103 8252 128054 ".
 ```
 
 <!--
@@ -1734,7 +1734,7 @@ print("")
      }
   -> print("")
   << 68 111 103 8252 128054
-  // Prints "68 111 103 8252 128054 "
+  // Prints "68 111 103 8252 128054 ".
   ```
 -->
 

--- a/TSPL.docc/LanguageGuide/Subscripts.md
+++ b/TSPL.docc/LanguageGuide/Subscripts.md
@@ -103,7 +103,7 @@ struct TimesTable {
 }
 let threeTimesTable = TimesTable(multiplier: 3)
 print("six times three is \(threeTimesTable[6])")
-// Prints "six times three is 18"
+// Prints "six times three is 18".
 ```
 
 <!--

--- a/TSPL.docc/LanguageGuide/TheBasics.md
+++ b/TSPL.docc/LanguageGuide/TheBasics.md
@@ -460,7 +460,7 @@ if you want to write multiple separate statements on a single line:
 
 ```swift
 let cat = "🐱"; print(cat)
-// Prints "🐱"
+// Prints "🐱".
 ```
 
 <!--
@@ -1143,9 +1143,9 @@ which you then access as usual:
 ```swift
 let (statusCode, statusMessage) = http404Error
 print("The status code is \(statusCode)")
-// Prints "The status code is 404"
+// Prints "The status code is 404".
 print("The status message is \(statusMessage)")
-// Prints "The status message is Not Found"
+// Prints "The status message is Not Found".
 ```
 
 <!--
@@ -1167,7 +1167,7 @@ when you decompose the tuple:
 ```swift
 let (justTheStatusCode, _) = http404Error
 print("The status code is \(justTheStatusCode)")
-// Prints "The status code is 404"
+// Prints "The status code is 404".
 ```
 
 <!--
@@ -1185,9 +1185,9 @@ access the individual element values in a tuple using index numbers starting at 
 
 ```swift
 print("The status code is \(http404Error.0)")
-// Prints "The status code is 404"
+// Prints "The status code is 404".
 print("The status message is \(http404Error.1)")
-// Prints "The status message is Not Found"
+// Prints "The status message is Not Found".
 ```
 
 <!--
@@ -1220,9 +1220,9 @@ you can use the element names to access the values of those elements:
 
 ```swift
 print("The status code is \(http200Status.statusCode)")
-// Prints "The status code is 200"
+// Prints "The status code is 200".
 print("The status message is \(http200Status.description)")
-// Prints "The status message is OK"
+// Prints "The status message is OK".
 ```
 
 <!--
@@ -1433,7 +1433,7 @@ if let actualNumber = Int(possibleNumber) {
 } else {
     print("The string \"\(possibleNumber)\" couldn't be converted to an integer")
 }
-// Prints "The string "123" has an integer value of 123"
+// Prints "The string "123" has an integer value of 123".
 ```
 
 <!--
@@ -1473,7 +1473,7 @@ if let myNumber = myNumber {
     // Here, myNumber is a non-optional integer
     print("My number is \(myNumber)")
 }
-// Prints "My number is 123"
+// Prints "My number is 123".
 ```
 
 <!--
@@ -1509,7 +1509,7 @@ implicitly uses the same name as the optional value.
 if let myNumber {
     print("My number is \(myNumber)")
 }
-// Prints "My number is 123"
+// Prints "My number is 123".
 ```
 
 <!--
@@ -1546,7 +1546,7 @@ The following `if` statements are equivalent:
 if let firstNumber = Int("4"), let secondNumber = Int("42"), firstNumber < secondNumber && secondNumber < 100 {
     print("\(firstNumber) < \(secondNumber) < 100")
 }
-// Prints "4 < 42 < 100"
+// Prints "4 < 42 < 100".
 
 if let firstNumber = Int("4") {
     if let secondNumber = Int("42") {
@@ -1555,7 +1555,7 @@ if let firstNumber = Int("4") {
         }
     }
 }
-// Prints "4 < 42 < 100"
+// Prints "4 < 42 < 100".
 ```
 
 <!--

--- a/TSPL.docc/LanguageGuide/TypeCasting.md
+++ b/TSPL.docc/LanguageGuide/TypeCasting.md
@@ -166,7 +166,7 @@ for item in library {
 }
 
 print("Media library contains \(movieCount) movies and \(songCount) songs")
-// Prints "Media library contains 2 movies and 3 songs"
+// Prints "Media library contains 2 movies and 3 songs".
 ```
 
 <!--

--- a/TSPL.docc/ReferenceManual/Attributes.md
+++ b/TSPL.docc/ReferenceManual/Attributes.md
@@ -539,10 +539,10 @@ let dial = TelephoneExchange()
 
 // Use a dynamic method call.
 dial(4, 1, 1)
-// Prints "Get Swift help on forums.swift.org"
+// Prints "Get Swift help on forums.swift.org".
 
 dial(8, 6, 7, 5, 3, 0, 9)
-// Prints "Unrecognized number"
+// Prints "Unrecognized number".
 
 // Call the underlying method directly.
 dial.dynamicallyCall(withArguments: [4, 1, 1])
@@ -729,12 +729,12 @@ let s = DynamicStruct()
 // Use dynamic member lookup.
 let dynamic = s.someDynamicMember
 print(dynamic)
-// Prints "325"
+// Prints "325".
 
 // Call the underlying subscript directly.
 let equivalent = s[dynamicMember: "someDynamicMember"]
 print(dynamic == equivalent)
-// Prints "true"
+// Prints "true".
 ```
 
 <!--

--- a/TSPL.docc/ReferenceManual/Declarations.md
+++ b/TSPL.docc/ReferenceManual/Declarations.md
@@ -451,9 +451,9 @@ class New: Superclass {
 }
 let new = New()
 new.x = 100
-// Prints "Setter was called"
-// Prints "Getter was called"
-// Prints "New value 100"
+// Prints "Setter was called".
+// Prints "Getter was called".
+// Prints "New value 100".
 
 // This subclass refers to oldValue in its observer, so the superclass's
 // getter is called once before the setter, and again to print the value.
@@ -464,10 +464,10 @@ class NewAndOld: Superclass {
 }
 let newAndOld = NewAndOld()
 newAndOld.x = 200
-// Prints "Getter was called"
-// Prints "Setter was called"
-// Prints "Getter was called"
-// Prints "Old value 12 - new value 200"
+// Prints "Getter was called".
+// Prints "Setter was called".
+// Prints "Getter was called".
+// Prints "Old value 12 - new value 200".
 ```
 
 <!--
@@ -3155,7 +3155,7 @@ the specialized version containing the title string is used.
 ```swift
 let oneAndTwo = Pair(first: "one", second: "two")
 oneAndTwo.log()
-// Prints "Pair of 'String': (one, two)"
+// Prints "Pair of 'String': (one, two)".
 ```
 
 <!--
@@ -3181,7 +3181,7 @@ func doSomething<T: Loggable>(with x: T) {
     x.log()
 }
 doSomething(with: oneAndTwo)
-// Prints "(one, two)"
+// Prints "(one, two)".
 ```
 
 <!--

--- a/TSPL.docc/ReferenceManual/Expressions.md
+++ b/TSPL.docc/ReferenceManual/Expressions.md
@@ -463,14 +463,14 @@ func f(_ any: Any) { print("Function for Any") }
 func f(_ int: Int) { print("Function for Int") }
 let x = 10
 f(x)
-// Prints "Function for Int"
+// Prints "Function for Int".
 
 let y: Any = x
 f(y)
-// Prints "Function for Any"
+// Prints "Function for Any".
 
 f(x as Any)
-// Prints "Function for Any"
+// Prints "Function for Any".
 ```
 
 <!--
@@ -1038,7 +1038,7 @@ let closure = { [a] in
 a = 10
 b = 10
 closure()
-// Prints "0 10"
+// Prints "0 10".
 ```
 
 <!--
@@ -1104,7 +1104,7 @@ let closure = { [x] in
 x.value = 10
 y.value = 10
 closure()
-// Prints "10 10"
+// Prints "10 10".
 ```
 
 <!--
@@ -1823,18 +1823,18 @@ let path = \[String].[index]
 let fn: ([String]) -> String = { strings in strings[index] }
 
 print(greetings[keyPath: path])
-// Prints "bonjour"
+// Prints "bonjour".
 print(fn(greetings))
-// Prints "bonjour"
+// Prints "bonjour".
 
 // Setting 'index' to a new value doesn't affect 'path'
 index += 1
 print(greetings[keyPath: path])
-// Prints "bonjour"
+// Prints "bonjour".
 
 // Because 'fn' closes over 'index', it uses the new value
 print(fn(greetings))
-// Prints "안녕"
+// Prints "안녕".
 ```
 
 <!--
@@ -1868,12 +1868,12 @@ to access a property of an optional string:
 ```swift
 let firstGreeting: String? = greetings.first
 print(firstGreeting?.count as Any)
-// Prints "Optional(5)"
+// Prints "Optional(5)".
 
 // Do the same thing using a key path.
 let count = greetings[keyPath: \[String].first?.count]
 print(count as Any)
-// Prints "Optional(5)"
+// Prints "Optional(5)".
 ```
 
 <!--
@@ -1908,13 +1908,13 @@ let interestingNumbers = ["prime": [2, 3, 5, 7, 11, 13, 17],
                           "triangular": [1, 3, 6, 10, 15, 21, 28],
                           "hexagonal": [1, 6, 15, 28, 45, 66, 91]]
 print(interestingNumbers[keyPath: \[String: [Int]].["prime"]] as Any)
-// Prints "Optional([2, 3, 5, 7, 11, 13, 17])"
+// Prints "Optional([2, 3, 5, 7, 11, 13, 17])".
 print(interestingNumbers[keyPath: \[String: [Int]].["prime"]![0]])
-// Prints "2"
+// Prints "2".
 print(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count])
-// Prints "7"
+// Prints "7".
 print(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count.bitWidth])
-// Prints "64"
+// Prints "64".
 ```
 
 <!--
@@ -2000,7 +2000,7 @@ func makeIndex() -> Int {
 }
 // The line below calls makeIndex().
 let taskKeyPath = \[Task][makeIndex()]
-// Prints "Made an index"
+// Prints "Made an index".
 
 // Using taskKeyPath doesn't call makeIndex() again.
 let someTask = toDoList[keyPath: taskKeyPath]
@@ -2187,7 +2187,7 @@ let keyPath = #keyPath(SomeClass.someProperty)
 if let value = c.value(forKey: keyPath) {
     print(value)
 }
-// Prints "12"
+// Prints "12".
 ```
 
 <!--
@@ -2223,7 +2223,7 @@ extension SomeClass {
     }
 }
 print(keyPath == c.getSomeKeyPath())
-// Prints "true"
+// Prints "true".
 ```
 
 <!--
@@ -2698,7 +2698,7 @@ For example:
 let initializer: (Int) -> String = String.init
 let oneTwoThree = [1, 2, 3].map(initializer).reduce("", +)
 print(oneTwoThree)
-// Prints "123"
+// Prints "123".
 ```
 
 <!--

--- a/TSPL.docc/ReferenceManual/LexicalStructure.md
+++ b/TSPL.docc/ReferenceManual/LexicalStructure.md
@@ -802,9 +802,9 @@ that create equivalent string values:
 let string = #"\(x) \ " \u{2603}"#
 let escaped = "\\(x) \\ \" \\u{2603}"
 print(string)
-// Prints "\(x) \ " \u{2603}"
+// Prints "\(x) \ " \u{2603}".
 print(string == escaped)
-// Prints "true"
+// Prints "true".
 ```
 
 <!--

--- a/TSPL.docc/ReferenceManual/Patterns.md
+++ b/TSPL.docc/ReferenceManual/Patterns.md
@@ -269,7 +269,7 @@ case .right:
 case nil:
     print("Keep going straight")
 }
-// Prints "Turn left"
+// Prints "Turn left".
 ```
 
 <!--

--- a/TSPL.docc/ReferenceManual/Statements.md
+++ b/TSPL.docc/ReferenceManual/Statements.md
@@ -776,10 +776,10 @@ func f(x: Int) {
   print("End of function")
 }
 f(x: 5)
-// Prints "End of if"
-// Prints "Second defer"
-// Prints "End of function"
-// Prints "First defer"
+// Prints "End of if".
+// Prints "Second defer".
+// Prints "End of function".
+// Prints "First defer".
 ```
 
 <!--
@@ -821,9 +821,9 @@ func f() {
     print("End of function")
 }
 f()
-// Prints "End of function"
-// Prints "Second defer"
-// Prints "First defer"
+// Prints "End of function".
+// Prints "Second defer".
+// Prints "First defer".
 ```
 
 <!--
@@ -1054,9 +1054,9 @@ print("Compiled in Swift 4.2 mode or later")
 #if compiler(>=5) && swift(<5)
 print("Compiled with the Swift 5 compiler or later in a Swift mode earlier than 5")
 #endif
-// Prints "Compiled with the Swift 5 compiler or later"
-// Prints "Compiled in Swift 4.2 mode or later"
-// Prints "Compiled with the Swift 5 compiler or later in a Swift mode earlier than 5"
+// Prints "Compiled with the Swift 5 compiler or later".
+// Prints "Compiled in Swift 4.2 mode or later".
+// Prints "Compiled with the Swift 5 compiler or later in a Swift mode earlier than 5".
 ```
 
 <!--
@@ -1072,7 +1072,7 @@ print("Compiled with the Swift 5 compiler or later in a Swift mode earlier than 
      #endif
   <- Compiled with the Swift 5 compiler or later
   <- Compiled in Swift 4.2 mode or later
-  // Prints "Compiled with the Swift 5 compiler or later in a Swift mode earlier than 5"
+  // Prints "Compiled with the Swift 5 compiler or later in a Swift mode earlier than 5".
   ```
 -->
 

--- a/TSPL.docc/ReferenceManual/Types.md
+++ b/TSPL.docc/ReferenceManual/Types.md
@@ -1056,7 +1056,7 @@ let someInstance: SomeBaseClass = SomeSubClass()
 // The compile-time type of someInstance is SomeBaseClass,
 // and the runtime type of someInstance is SomeSubClass
 type(of: someInstance).printClassName()
-// Prints "SomeSubClass"
+// Prints "SomeSubClass".
 ```
 
 <!--
@@ -1257,16 +1257,16 @@ class Superclass {
 }
 let x = Superclass()
 print(type(of: x.f()))
-// Prints "Superclass"
+// Prints "Superclass".
 
 class Subclass: Superclass { }
 let y = Subclass()
 print(type(of: y.f()))
-// Prints "Subclass"
+// Prints "Subclass".
 
 let z: Superclass = Subclass()
 print(type(of: z.f()))
-// Prints "Subclass"
+// Prints "Subclass".
 ```
 
 <!--


### PR DESCRIPTION
Per discussion with Colleen, "prints" comments that don't include a full sentence in the printed text should end with a period, following the normal punctuation conventions.  Under the pre-DocC publication pipeline, we didn't have a special case for the "prints" comments to include/omit the period as needed, but always omitted it to avoid `.".` at the end of a comment.

Commit 64fc4784d07cfced0971605f00f31ad3357f329a adds this information to the TSPL style guide, and will be part of a future PR that collect all style guide updates.

Fixes: rdar://162537831
