### PR TITLE
Make use of existing syntactic category name

### DIFF
--- a/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
+++ b/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
@@ -69,7 +69,7 @@ make the same change here also.
 > *identifier-head* → U+90000–U+9FFFD, U+A0000–U+AFFFD, U+B0000–U+BFFFD, or U+C0000–U+CFFFD \
 > *identifier-head* → U+D0000–U+DFFFD or U+E0000–U+EFFFD
 >
-> *identifier-character* → Digit 0 through 9 \
+> *identifier-character* → *decimal-digit* \
 > *identifier-character* → U+0300–U+036F, U+1DC0–U+1DFF, U+20D0–U+20FF, or U+FE20–U+FE2F \
 > *identifier-character* → *identifier-head* \
 > *identifier-characters* → *identifier-character* *identifier-characters*_?_


### PR DESCRIPTION
I've been reviewing the formal grammar, and I noticed some duplication. I know this is a judgment call, and I also know that this doesn't keep the rules quite as isolated. However, the existing rule definition also doesn't fit well with the style guide anyways, so it seems like it was at least worth a discussion.

For context, the existing definition was:

```
> *decimal-digit* → Digit 0 through 9 \
```