### PR TITLE
Update some URLs to use the swiftlang GitHub organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ Discussions and contributions follow the [Swift Code of Conduct][conduct].
 For more information, see [Contributing to The Swift Programming Language][contributing].
 
 [asg]: https://help.apple.com/applestyleguide/
-[bugs]: https://github.com/apple/swift-book/issues
+[bugs]: https://github.com/swiftlang/swift-book/issues
 [conduct]: https://www.swift.org/code-of-conduct
 [contributing]: /CONTRIBUTING.md
 [forum]: https://forums.swift.org/c/swift-documentation/92
 [tspl-style]: /Style.md
 [published]: https://docs.swift.org/swift-book/documentation/the-swift-programming-language/
-[docc]: https://github.com/apple/swift-docc
+[docc]: https://github.com/swiftlang/swift-docc
 
 ## Building
 

--- a/Style.md
+++ b/Style.md
@@ -383,7 +383,7 @@ include a note as follows.
 > For information about enabling future language features,
 > see [Enabling future language features](FIXME).
 
-[SE-0362]: https://github.com/apple/swift-evolution/blob/main/proposals/0362-piecemeal-future-features.md
+[SE-0362]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0362-piecemeal-future-features.md
 
 # Tone
 


### PR DESCRIPTION
Some repository URLs are outdated. This change fixes them.