### PR TITLE
Update the URL for Swift Atomics in a comment

### DIFF
--- a/TSPL.docc/LanguageGuide/MemorySafety.md
+++ b/TSPL.docc/LanguageGuide/MemorySafety.md
@@ -164,7 +164,7 @@ For a list of C atomic functions, see the `stdatomic(3)` man page.
 <!--
   Using the C atomic functions from Swift
   requires some shimming that's out of scope for TSPL - for example:
-  https://github.com/apple/swift-se-0282-experimental/tree/master/Sources/_AtomicsShims
+  https://github.com/apple/swift-atomics/tree/main/Sources/_AtomicsShims
 -->
 
 An access is *instantaneous*


### PR DESCRIPTION
https://github.com/apple/swift-se-0282-experimental no longer exists. Instead, this change replaces it with https://github.com/apple/swift-atomics.