### PR TITLE
Remove argument label from inout parameter example

### DIFF
--- a/TSPL.docc/ReferenceManual/Declarations.md
+++ b/TSPL.docc/ReferenceManual/Declarations.md
@@ -875,7 +875,7 @@ To make an in-out parameter instead,
 you apply the `inout` parameter modifier.
 
 ```swift
-func someFunction(a: inout Int) {
+func someFunction(_ a: inout Int) {
     a += 1
 }
 ```


### PR DESCRIPTION
The call site doesn't specify a label, so this example does not compile as written.