### PR TITLE
Add print statement in control flow example

### DIFF
--- a/TSPL.docc/GuidedTour/GuidedTour.md
+++ b/TSPL.docc/GuidedTour/GuidedTour.md
@@ -423,6 +423,7 @@ var greeting = "Hello!"
 if let name = optionalName {
     greeting = "Hello, \(name)"
 }
+print(greeting)
 ```
 
 <!--


### PR DESCRIPTION
<!-- What's in this pull request? -->
The [guided tour](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/guidedtour/) example doesn't specify print after the greeting, so the experiment that follows won't be valid:

> Change optionalName to nil. What greeting do you get? Add an else clause that sets a different greeting if optionalName is nil.