### PR TITLE
Fix typo in the Memory Safety chapter. "it it" -> "if it"

### DIFF
--- a/TSPL.docc/LanguageGuide/MemorySafety.md
+++ b/TSPL.docc/LanguageGuide/MemorySafety.md
@@ -154,7 +154,7 @@ is either instantaneous or long-term.
 
 An access is *atomic* if
 it's a call to an atomic operation on [`Atomic`] or [`AtomicLazyReference`],
-or it it uses only C atomic operations;
+or if it uses only C atomic operations;
 otherwise it's nonatomic.
 For a list of C atomic functions, see the `stdatomic(3)` man page.
 


### PR DESCRIPTION
As noted by user `brainbarker` in [the forums](https://forums.swift.org/t/typo-in-online-documentation/83837).