### PR TITLE
Update the 'Main Actor' section to clarify isolation for non-isolated functions

### DIFF
--- a/TSPL.docc/LanguageGuide/Concurrency.md
+++ b/TSPL.docc/LanguageGuide/Concurrency.md
@@ -1065,8 +1065,8 @@ might suspend when you call them.
 This code also shows a common pattern:
 Perform long-running and CPU-intensive work in the background,
 and then switch to the main actor to update the UI.
-Because the `downloadAndShowPhoto(named:)` function isn't on the main actor,
-the work in `downloadPhoto(named:)` also doesn't run on the main actor.
+The `downloadPhoto(named:)` function is non-isolated,
+so it executes in a concurrency domain separate from the main actor.
 Only the work in `show(_:)` to update the UI runs on the main actor,
 because that function is marked with the `@MainActor` attribute.
 <!-- TODO


### PR DESCRIPTION
This PR updates the 'Main Actor' section to correct a phrasing that implies functions inherit actor isolation from their callers.

In the current text, the use of 'because' suggests downloadPhoto runs off the main actor only because its caller is also off the main actor. This contradicts the principle of [actor isolation and static isolation](https://www.swift.org/migration/documentation/swift-6-concurrency-migration-guide/dataracesafety/), where a function's isolation is determined by its own declaration.

I have updated the text to clarify that the execution context is determined by the callee's isolation domain and its isolation boundary, rather than being a side effect of the caller's state.
