### PR TITLE
Typo in grammar for ~P

### DIFF
--- a/TSPL.docc/ReferenceManual/Types.md
+++ b/TSPL.docc/ReferenceManual/Types.md
@@ -1350,7 +1350,7 @@ to specify the type of its raw values, see <doc:Enumerations#Raw-Values>.
 > Grammar of a type inheritance clause:
 >
 > *type-inheritance-clause* → **`:`** *type-inheritance-list* \
-> *type-inheritance-list* → *attributes*_?_ **`~`**_?_ *type-identifier* | *attributes*_?_ *type-identifier* **`,`** *type-inheritance-list*
+> *type-inheritance-list* → *attributes*_?_ **`~`**_?_ *type-identifier* | *attributes*_?_ **`~`**_?_ *type-identifier* **`,`** *type-inheritance-list*
 
 ## Type Inference
 


### PR DESCRIPTION
The grammar here would only allow `~P` on the _final_ element of a list but it's allowed on any of the elements (eg, `struct S: ~Copyable, ~Escapable`).

Another way to see the bug: notice how the grammar only allows a comma after a type-identifier's that may not have a `~`.