### PR TITLE
Fix typo in OpaqueTypes Chapter

### DIFF
--- a/TSPL.docc/LanguageGuide/OpaqueTypes.md
+++ b/TSPL.docc/LanguageGuide/OpaqueTypes.md
@@ -485,7 +485,7 @@ func `repeat`<T: Shape>(shape: T, count: Int) -> some Collection {
 In this case,
 the underlying type of the return value
 varies depending on `T`:
-Whatever shape is passed it,
+Whatever shape is passed in,
 `repeat(shape:count:)` creates and returns an array of that shape.
 Nevertheless,
 the return value always has the same underlying type of `[T]`,


### PR DESCRIPTION
<!-- If this pull request incorporates language changes from a Swift Evolution proposal, add the SE number in square brackets at the end of the PR title. -->

<!-- What's in this pull request? -->
Fix typo: "Whatever shape is passed it" -> "Whatever shape is passed in"

<!-- Link to the issue that this pull request fixes, if applicable. -->

