### PR TITLE
extracts the grammar generation step into it's own script

### DIFF
--- a/bin/generate-grammar
+++ b/bin/generate-grammar
@@ -1,0 +1,37 @@
+#! /bin/bash
+
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2026 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+# Generates the "Summary of the Grammar" chapter from the formal grammar
+# blocks in the reference manual chapters.
+
+set -eux
+
+cd "$(git rev-parse --show-toplevel)"
+
+summary_chapter="TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md"
+if [[ -f "$summary_chapter" ]]
+then
+	echo "Summary of the grammar already exists"
+	exit 1
+fi
+{
+	echo "# Summary of the Grammar"
+	echo
+	echo "Read the whole formal grammar."
+	echo
+	awk -f bin/extract_grammar.awk TSPL.docc/ReferenceManual/LexicalStructure.md
+	awk -f bin/extract_grammar.awk TSPL.docc/ReferenceManual/Types.md
+	awk -f bin/extract_grammar.awk TSPL.docc/ReferenceManual/Expressions.md
+	awk -f bin/extract_grammar.awk TSPL.docc/ReferenceManual/Statements.md
+	awk -f bin/extract_grammar.awk TSPL.docc/ReferenceManual/Declarations.md
+	awk -f bin/extract_grammar.awk TSPL.docc/ReferenceManual/Attributes.md
+	awk -f bin/extract_grammar.awk TSPL.docc/ReferenceManual/Patterns.md
+	awk -f bin/extract_grammar.awk TSPL.docc/ReferenceManual/GenericParametersAndArguments.md
+} > "$summary_chapter"

--- a/bin/publish-book
+++ b/bin/publish-book
@@ -2,7 +2,7 @@
 
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2023 Apple Inc. and the Swift project authors
+# Copyright (c) 2023-2026 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information
@@ -24,25 +24,7 @@ cd "$(git rev-parse --show-toplevel)"
 
 # Summarize the formal grammar at the end of the reference.
 summary_chapter="TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md"
-if [[ -f "$summary_chapter" ]]
-then
-       echo "Summary of the grammar already exists"
-       exit 1
-fi
-{
-	echo "# Summary of the Grammar"
-	echo
-	echo "Read the whole formal grammar."
-	echo
-	awk -f bin/extract_grammar.awk TSPL.docc/ReferenceManual/LexicalStructure.md
-	awk -f bin/extract_grammar.awk TSPL.docc/ReferenceManual/Types.md
-	awk -f bin/extract_grammar.awk TSPL.docc/ReferenceManual/Expressions.md
-	awk -f bin/extract_grammar.awk TSPL.docc/ReferenceManual/Statements.md
-	awk -f bin/extract_grammar.awk TSPL.docc/ReferenceManual/Declarations.md
-	awk -f bin/extract_grammar.awk TSPL.docc/ReferenceManual/Attributes.md
-	awk -f bin/extract_grammar.awk TSPL.docc/ReferenceManual/Patterns.md
-	awk -f bin/extract_grammar.awk TSPL.docc/ReferenceManual/GenericParametersAndArguments.md
-} > "$summary_chapter"
+bin/generate-grammar
 
 # The published version of the book gets the swift.org header.
 cp -n TSPL.docc/header-publish.html TSPL.docc/header.html


### PR DESCRIPTION
This lets us run this setup script with an external repository's (swiftlang/docs) build script to do the expected prep work for the DocC catalog in order to combine it with other DocC catalogs for a combined archive of multiple doc sets together.

work needed to support https://github.com/swiftlang/docs/pull/72, ultimately to support https://github.com/swiftlang/docs/issues/24