### PR TITLE
Fix typo in line 545TheBasics.md in the Integer Bounds section

### DIFF
--- a/TSPL.docc/LanguageGuide/TheBasics.md
+++ b/TSPL.docc/LanguageGuide/TheBasics.md
@@ -542,7 +542,7 @@ The values of these properties are of the appropriate-sized number type
 and can therefore be used in expressions alongside other values of the same type.
 
 Calculations that produce out-of-bounds results,
-like a number larger that the `max` property,
+like a number larger than the `max` property,
 stop the program's execution instead of storing an invalid result.
 You can explicitly make the operation overflow instead,
 as described in <doc:AdvancedOperators#Overflow-Operators>.


### PR DESCRIPTION
Current version:
“Calculations that produce out-of-bounds results, like a number larger that the max property, stop the program’s execution instead of storing an invalid result. You can explicitly make the operation overflow instead, as described in Overflow Operators.”

Proposed version:
“Calculations that produce out-of-bounds results, like a number larger than the max property, stop the program’s execution instead of storing an invalid result. You can explicitly make the operation overflow instead, as described in Overflow Operators.”

<!-- If this pull request incorporates language changes from a Swift Evolution proposal, add the SE number in square brackets at the end of the PR title. -->

<!-- What's in this pull request? -->
Fixing a minor typo in the Swift Book's The Basics chapter.

<!-- Link to the issue that this pull request fixes, if applicable. -->
Fixes: https://github.com/apple/swift-book/issues/####
Fixes: rdar://####
