### PR TITLE
Fix missing word in TheBasics.md: add 'to' after 'you'

### DIFF
--- a/TSPL.docc/LanguageGuide/TheBasics.md
+++ b/TSPL.docc/LanguageGuide/TheBasics.md
@@ -30,7 +30,7 @@ checks whether a value is missing before using the value,
 and non-optional values are guaranteed to never be missing.
 
 Swift is a safe language,
-which means it makes it easier for you find and fix several categories of bugs
+which means it makes it easier for you to find and fix several categories of bugs
 as early as possible during the development process,
 and lets you guarantee that certain kinds of bugs can't happen.
 Type safety enables you to be clear about


### PR DESCRIPTION
This PR fixes a missing word in the Swift documentation.

## Changes made:
- Fixed missing word in TheBasics.md: added 'to' after 'you'
- Original: 'easier for you find and fix'
- Fixed: 'easier for you to find and fix'

This ensures the sentence is grammatically correct in the official Swift documentation.

Fixes #457