### PR TITLE
Improve Task cancellation sample code

### DIFF
--- a/TSPL.docc/LanguageGuide/Concurrency.md
+++ b/TSPL.docc/LanguageGuide/Concurrency.md
@@ -734,16 +734,18 @@ The code above makes several changes from the previous version:
 [`Task.isCancelled` instance]: https://developer.apple.com/documentation/swift/task/iscancelled-swift.property
 
 For work that needs immediate notification of cancellation,
-use the [`Task.withTaskCancellationHandler(operation:onCancel:isolation:)`][] method.
+use the [`withTaskCancellationHandler(operation:onCancel:isolation:)`][] function.
 For example:
 
-[`Task.withTaskCancellationHandler(operation:onCancel:isolation:)`]: https://developer.apple.com/documentation/swift/withtaskcancellationhandler(operation:oncancel:isolation:)
+[`withTaskCancellationHandler(operation:onCancel:isolation:)`]: https://developer.apple.com/documentation/swift/withtaskcancellationhandler(operation:oncancel:isolation:)
 
 ```swift
-let task = await Task.withTaskCancellationHandler {
-    // ...
-} onCancel: {
-    print("Canceled!")
+let task = Task {
+    await withTaskCancellationHandler {
+        // ...
+    } onCancel: {
+        print("Canceled!")
+    }
 }
 
 // ... some time later...


### PR DESCRIPTION
- Remove the use of deprecated Task cancellation API from the Task cancellation section.
- Improve the clarity of the Task cancellation sample code snippet.

Fixes: https://github.com/swiftlang/swift-book/issues/462
