### PR TITLE
Fix function type grammar for labeled parameters

### DIFF
--- a/TSPL.docc/ReferenceManual/Types.md
+++ b/TSPL.docc/ReferenceManual/Types.md
@@ -514,8 +514,9 @@ see <doc:MemorySafety>.
 > *function-type-argument-clause* → **`(`** *function-type-argument-list* **`...`**_?_ **`)`**
 >
 > *function-type-argument-list* → *function-type-argument* | *function-type-argument* **`,`** *function-type-argument-list* \
-> *function-type-argument* → *attributes*_?_ *parameter-modifier*_?_ *type* | *argument-label* *type-annotation* \
-> *argument-label* → *identifier*
+> *function-type-argument* → *attributes*_?_ *parameter-modifier*_?_ *type* | *external-argument-label*_?_ *local-argument-label* *type-annotation* \
+> *external-argument-label* → *identifier* | **`_`** \
+> *local-argument-label* → *identifier*
 >
 > *throws-clause* → **`throws`** | **`throws`** **`(`** *type* **`)`**
 


### PR DESCRIPTION
Fixes: https://github.com/apple/swift-book/issues/469

Update the function type grammar to support function parameters with external and local argument labels. This fixes the grammar so it correctly accepts function type syntax such as `(_ a: Int, _ b: Double) -> Bool`, bringing the TSPL grammar in line with the syntax accepted by the Swift compiler.