### PR TITLE
Suppress the language version from the module name

### DIFF
--- a/TSPL.docc/The-Swift-Programming-Language.md
+++ b/TSPL.docc/The-Swift-Programming-Language.md
@@ -4,6 +4,7 @@ Write safe, fast, expressive code with a modern, general-purpose language.
 
 @Metadata {
   @TechnologyRoot
+  @DisplayName("The Swift Programming Language")
 }
 
 @Options(scope: global) {


### PR DESCRIPTION
This hides the (6.4 beta) extension on the module name from the name that's presented in the combined view of Swift documentation (a merged set of DocC catalogs).

The "easier" method may be to update the title itself, but that also removes it from interior content as well. 
