### PR TITLE
Revert "Suppress the language version from the module name (#474)"

### DIFF
--- a/TSPL.docc/The-Swift-Programming-Language.md
+++ b/TSPL.docc/The-Swift-Programming-Language.md
@@ -4,7 +4,6 @@ Write safe, fast, expressive code with a modern, general-purpose language.
 
 @Metadata {
   @TechnologyRoot
-  @DisplayName("The Swift Programming Language")
 }
 
 @Options(scope: global) {


### PR DESCRIPTION
This reverts commit e327e452ef7c1b8e677738e7798f2a9e9925bc81, reversing changes made to 29329996c4ec537de0b16e70609e2a6c4ecc2af7.

After getting it in place, I learned that @DisplayName() didn't have the follow-through impact I'd presumed it did - so this is effectively a no-op, and I didn't want to leave useless artifacts around. Turns out that DocC only uses `@DisplayName` directive when there's an explicit module from a surrounding package. When you're building from a "bare" DocC catalog with a central page identified by `@TechnologyRoot`, the H1 value of that page is overrides any values.