### PR TITLE
Add multi-version documentation support

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,72 @@
+name: Documentation
+
+on:
+  push:
+    branches: [main]
+    tags: ['swift-*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build DocC site
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Restore versioned documentation cache
+        uses: actions/cache@v6
+        with:
+          path: .docs/cache/versioned-docc
+          key: versioned-docc-${{ runner.os }}-${{ hashFiles('.vdc.json', 'Package.resolved') }}-${{ github.ref_type }}-${{ github.sha }}
+          restore-keys: |
+            versioned-docc-${{ runner.os }}-${{ hashFiles('.vdc.json', 'Package.resolved') }}-
+            versioned-docc-${{ runner.os }}-
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.3'
+
+      - name: Prepare Xcode
+        run: |
+          sudo xcode-select -s /Applications/Xcode_26.3.app/Contents/Developer
+          swift --version
+        shell: bash
+
+      - name: Build versioned DocC site
+        uses: DocCLab/VersionedDocC@0.0.13
+        with:
+          config: .vdc.json
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: .docs/build/versioned-site/swift-book
+
+  deploy:
+    name: Deploy DocC site
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /TSPL.docc/header.html
 /TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
 /swift-book
+/.docs/

--- a/.vdc.json
+++ b/.vdc.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DocCLab/VersionedDocC/0.0.13/Schema/VersionedDocC.schema.json",
+  "schemaVersion": 1,
+  "documentationOnly": true,
+  "projectName": "swift-book",
+  "modulePath": "the-swift-programming-language",
+  "catalogPath": "TSPL.docc",
+  "hostingBasePath": "/swift-book",
+  "defaultVersion": "main",
+  "articleChanges": {
+    "enabled": true
+  },
+  "versions": [
+    {
+      "name": "main",
+      "ref": "HEAD",
+      "sourceRef": "main"
+    },
+    {
+      "name": "6.3",
+      "ref": "swift-6.3-fcs",
+      "sourceRef": "swift-6.3-fcs"
+    },
+    {
+      "name": "6.2.3",
+      "ref": "swift-6.2.3-fcs",
+      "sourceRef": "swift-6.2.3-fcs"
+    },
+    {
+      "name": "6.2.1",
+      "ref": "swift-6.2.1-fcs",
+      "sourceRef": "swift-6.2.1-fcs"
+    },
+    {
+      "name": "6.2",
+      "ref": "swift-6.2-fcs",
+      "sourceRef": "swift-6.2-fcs"
+    },
+    {
+      "name": "6.1",
+      "ref": "swift-6.1-fcs",
+      "sourceRef": "swift-6.1-fcs"
+    },
+    {
+      "name": "6",
+      "ref": "swift-6-fcs",
+      "sourceRef": "swift-6-fcs"
+    },
+    {
+      "name": "5.10",
+      "ref": "swift-5.10-fcs",
+      "sourceRef": "swift-5.10-fcs"
+    },
+    {
+      "name": "5.9.2",
+      "ref": "swift-5.9.2-fcs",
+      "sourceRef": "swift-5.9.2-fcs"
+    },
+    {
+      "name": "5.9",
+      "ref": "swift-5.9-fcs",
+      "sourceRef": "swift-5.9-fcs"
+    },
+    {
+      "name": "5.8",
+      "ref": "swift-5.8-fcs",
+      "sourceRef": "swift-5.8-fcs"
+    },
+    {
+      "name": "5.7",
+      "ref": "swift-5.7-fcs",
+      "sourceRef": "swift-5.7-fcs",
+      "catalogPath": "Sources/TSPL/TSPL.docc"
+    }
+  ],
+  "sourceRepository": "https://github.com/swiftlang/swift-book"
+}


### PR DESCRIPTION
This adds version-aware DocC publishing for *The Swift Programming Language*.

The new publishing configuration and GitHub Pages workflow:

- Publish `main` and every FCS release with a DocC catalog, currently Swift 5.7 through Swift 6.3.
- Add a version picker to every documentation page.
- Provide stable, version-specific documentation URLs.
- Generate adjacent-version article change pages.
- Handle the older Swift 5.7 catalog location with a version-specific `catalogPath`.

Versions before Swift 5.7 are intentionally excluded because those tags contain the book in RST format rather than as a DocC catalog.

A working deployment of this change is available from the DocCLab fork:

- [Live versioned documentation](https://docclab.github.io/swift-book/main/documentation/the-swift-programming-language/)
- [Article changes](https://docclab.github.io/swift-book/main/changes/)
- [Successful Pages workflow](https://github.com/DocCLab/swift-book/actions/runs/31038086823)

The workflow uses [VersionedDocC 0.0.13](https://github.com/DocCLab/VersionedDocC/tree/0.0.13) to build and assemble the site.
<img width="1405" height="1106" alt="codex-clipboard-4d7a770b-6731-4a79-b3bb-1569d47b0fc9" src="https://github.com/user-attachments/assets/78fe3846-146e-4e4f-a937-de8b82445606" />
