### PR TITLE
Correct the Xcode version number

### DIFF
--- a/TSPL.docc/GuidedTour/Compatibility.md
+++ b/TSPL.docc/GuidedTour/Compatibility.md
@@ -3,7 +3,7 @@
 Learn what functionality is available in older language modes.
 
 This book describes Swift 6.4,
-the default version of Swift that's included in Xcode 26.4.
+the default version of Swift that's included in Xcode 27.
 You can use the Swift 6.4 compiler to build code
 that's written in Swift 6.4, Swift 5, Swift 4.2, or Swift 4.
 


### PR DESCRIPTION
Corrects a statement in Version Compatibility about which version of Xcode contains Swift 6.4.

Fixes: rdar://184937410 (TSPL: Version compatibility chapter incorrectly says Xcode 26.4 includes Swift 6.4.)